### PR TITLE
Avoid curl conflicts in EC2 bootstrap

### DIFF
--- a/scripts/bootstrap-ec2.sh
+++ b/scripts/bootstrap-ec2.sh
@@ -139,7 +139,6 @@ install_rhel_deps() {
 
     local packages=(
         ca-certificates
-        curl
         git
         gcc
         gcc-c++
@@ -150,6 +149,10 @@ install_rhel_deps() {
     )
 
     sudo_cmd "$package_manager" install -y "${packages[@]}"
+
+    if ! command -v curl >/dev/null 2>&1; then
+        install_first_available_package "$package_manager" curl-minimal curl
+    fi
 
     if ! command -v psql >/dev/null 2>&1; then
         install_first_available_package "$package_manager" postgresql16 postgresql15 postgresql14 postgresql


### PR DESCRIPTION
## Summary
- Do not install full `curl` during Amazon Linux/RHEL dependency setup when `curl-minimal` already provides the command.
- Install `curl-minimal` or `curl` only if the `curl` command is missing.

## Test plan
- `bash -n scripts/bootstrap-ec2.sh`
- `git diff --check -- scripts/bootstrap-ec2.sh`


Made with [Cursor](https://cursor.com)