### PR TITLE
Pin tern version in EC2 bootstrap

### DIFF
--- a/scripts/bootstrap-ec2.sh
+++ b/scripts/bootstrap-ec2.sh
@@ -197,7 +197,7 @@ install_tern() {
     require_cmd go
     log "Installing tern"
     install -d "${GOBIN:-$HOME/go/bin}"
-    GOBIN="${GOBIN:-$HOME/go/bin}" go install github.com/jackc/tern/v2@latest
+    GOBIN="${GOBIN:-$HOME/go/bin}" go install github.com/jackc/tern/v2@v2.3.2
     export PATH="$HOME/go/bin:$PATH"
 }
 


### PR DESCRIPTION
## Summary
- Pin tern installation to v2.3.2 so Amazon Linux Go 1.24 can install it.
- Avoid `@latest` selecting tern releases requiring Go 1.25+.

## Test plan
- `bash -n scripts/bootstrap-ec2.sh`
- `git diff --check -- scripts/bootstrap-ec2.sh`


Made with [Cursor](https://cursor.com)