### PR TITLE
Add GOUP nginx configuration

### DIFF
--- a/scripts/nginx-goup.conf
+++ b/scripts/nginx-goup.conf
@@ -1,0 +1,95 @@
+# GOUP nginx configuration for goup.vc
+#
+# Install on EC2:
+#   sudo cp scripts/nginx-goup.conf /etc/nginx/conf.d/goup.conf
+#   sudo nginx -t
+#   sudo systemctl reload nginx
+#
+# The HTTPS server expects a Let's Encrypt certificate at:
+#   /etc/letsencrypt/live/goup.vc/fullchain.pem
+#   /etc/letsencrypt/live/goup.vc/privkey.pem
+#
+# If the certificate does not exist yet, temporarily comment out the HTTPS
+# server block below, reload nginx, then run:
+#   sudo certbot --nginx -d goup.vc -d www.goup.vc
+
+upstream goup_ocg_server {
+    server 127.0.0.1:9000;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    server_name goup.vc www.goup.vc;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://goup.vc$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name goup.vc www.goup.vc;
+
+    ssl_certificate /etc/letsencrypt/live/goup.vc/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/goup.vc/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    if ($host = www.goup.vc) {
+        return 301 https://goup.vc$request_uri;
+    }
+
+    client_max_body_size 2m;
+
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/javascript
+        application/json
+        application/xml
+        application/xml+rss;
+
+    location /static/ {
+        proxy_pass http://goup_ocg_server;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        proxy_pass http://goup_ocg_server;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_cache_bypass $http_upgrade;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}


### PR DESCRIPTION
## Summary
- Add nginx server blocks for `goup.vc` and `www.goup.vc`.
- Proxy GOUP traffic to the local OCG server on `127.0.0.1:9000`.
- Include Let's Encrypt certificate paths and certbot challenge handling.

## Test plan
- `git diff --check -- scripts/nginx-goup.conf`


Made with [Cursor](https://cursor.com)