### PR TITLE
Install Perl modules for OpenSSL builds

### DIFF
--- a/scripts/bootstrap-ec2.sh
+++ b/scripts/bootstrap-ec2.sh
@@ -119,6 +119,7 @@ install_debian_deps() {
         build-essential
         pkg-config
         libssl-dev
+        perl
         postgresql-client
         golang-go
     )
@@ -145,6 +146,8 @@ install_rhel_deps() {
         make
         pkgconf-pkg-config
         openssl-devel
+        perl-FindBin
+        perl-core
         golang
     )
 


### PR DESCRIPTION
## Summary
- Install Perl dependencies needed by OpenSSL source builds during EC2 bootstrap.
- Add `perl-FindBin`/`perl-core` for Amazon Linux/RHEL and `perl` for Debian/Ubuntu.

## Test plan
- `bash -n scripts/bootstrap-ec2.sh`
- `git diff --check -- scripts/bootstrap-ec2.sh`


Made with [Cursor](https://cursor.com)