### PR TITLE
Add Google Meet meeting provider

### DIFF
--- a/charts/ocg/templates/server_secret.yaml
+++ b/charts/ocg/templates/server_secret.yaml
@@ -46,6 +46,17 @@ stringData:
     log:
       format: {{ .Values.log.format }}
     meetings:
+{{- if .Values.meetings.googleMeet.enabled }}
+      google_meet:
+        calendar_id: {{ .Values.meetings.googleMeet.calendarId | quote }}
+        client_id: {{ .Values.meetings.googleMeet.clientId | quote }}
+        client_secret: {{ .Values.meetings.googleMeet.clientSecret | quote }}
+        enabled: {{ .Values.meetings.googleMeet.enabled }}
+        max_participants: {{ .Values.meetings.googleMeet.maxParticipants }}
+        refresh_token: {{ .Values.meetings.googleMeet.refreshToken | quote }}
+{{- else }}
+      google_meet: null
+{{- end }}
 {{- if .Values.meetings.zoom.enabled }}
       zoom:
         account_id: {{ .Values.meetings.zoom.accountId | quote }}

--- a/charts/ocg/values.yaml
+++ b/charts/ocg/values.yaml
@@ -74,6 +74,15 @@ log:
 
 # Meetings providers configuration (multiple providers can be enabled simultaneously)
 meetings:
+  # Google Meet provider configuration (set enabled to true to enable)
+  googleMeet:
+    enabled: false
+    calendarId: primary
+    clientId: ""
+    clientSecret: ""
+    maxParticipants: 100
+    refreshToken: ""
+
   # Zoom provider configuration (set enabled to true to enable)
   zoom:
     enabled: false

--- a/database/migrations/schema/0002_add_google_meet_provider.sql
+++ b/database/migrations/schema/0002_add_google_meet_provider.sql
@@ -1,0 +1,3 @@
+insert into meeting_provider (meeting_provider_id, display_name)
+values ('google_meet', 'Google Meet')
+on conflict do nothing;

--- a/database/tests/data/e2e.sql
+++ b/database/tests/data/e2e.sql
@@ -31,8 +31,8 @@ insert into alliance (
 ) values (
     '11111111-1111-1111-1111-111111111111',
     'e2e-test-alliance',
-    'Platform Engineering Alliance',
-    'Platform engineering alliance used for end-to-end coverage.',
+    'GOUP Alliance',
+    'GOUP Alliance used for end-to-end coverage.',
     '/static/images/e2e/alliance-primary-banner.svg',
     '/static/images/e2e/alliance-primary-banner-mobile.svg',
     '/static/images/e2e/alliance-primary-logo.svg'

--- a/database/tests/schema/06_constraints_and_reference_data.sql
+++ b/database/tests/schema/06_constraints_and_reference_data.sql
@@ -263,6 +263,7 @@ select has_check('meeting', 'meeting_recording_urls_not_empty_chk');
 select results_eq(
     'select * from meeting_provider order by meeting_provider_id',
     $$ values
+        ('google_meet', 'Google Meet'),
         ('zoom', 'Zoom')
     $$,
     'Meeting providers should exist'

--- a/ocg-server/src/config.rs
+++ b/ocg-server/src/config.rs
@@ -75,6 +75,12 @@ impl Config {
     /// Validate configuration consistency after loading from all sources.
     fn validate(&self) -> Result<()> {
         if let Some(meetings_cfg) = &self.meetings
+            && let Some(google_cfg) = &meetings_cfg.google_meet
+        {
+            google_cfg.validate()?;
+        }
+
+        if let Some(meetings_cfg) = &self.meetings
             && let Some(zoom_cfg) = &meetings_cfg.zoom
         {
             zoom_cfg.validate()?;
@@ -135,6 +141,8 @@ pub(crate) struct ImageStorageConfigS3 {
 /// Meetings configuration (multiple providers supported).
 #[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
 pub(crate) struct MeetingsConfig {
+    /// Google Meet provider configuration.
+    pub google_meet: Option<MeetingsGoogleMeetConfig>,
     /// Zoom provider configuration.
     pub zoom: Option<MeetingsZoomConfig>,
 }
@@ -143,6 +151,55 @@ impl MeetingsConfig {
     /// Check if at least one meetings provider is enabled.
     pub(crate) fn meetings_enabled(&self) -> bool {
         self.zoom.as_ref().is_some_and(|z| z.enabled)
+            || self.google_meet.as_ref().is_some_and(|g| g.enabled)
+    }
+}
+
+/// Google Meet configuration.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub(crate) struct MeetingsGoogleMeetConfig {
+    /// Google Calendar identifier where events with Meet links are created.
+    pub calendar_id: String,
+    /// OAuth client identifier.
+    pub client_id: String,
+    /// OAuth client secret.
+    pub client_secret: String,
+    /// Whether this provider is enabled.
+    pub enabled: bool,
+    /// Maximum number of participants allowed in a meeting.
+    pub max_participants: i32,
+    /// OAuth refresh token for the admin calendar account.
+    pub refresh_token: String,
+}
+
+impl MeetingsGoogleMeetConfig {
+    /// Validate Google Meet configuration.
+    fn validate(&self) -> Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if self.calendar_id.trim().is_empty() {
+            bail!("meetings.google_meet.calendar_id cannot be empty when google_meet is enabled");
+        }
+
+        if self.client_id.trim().is_empty() {
+            bail!("meetings.google_meet.client_id cannot be empty when google_meet is enabled");
+        }
+
+        if self.client_secret.trim().is_empty() {
+            bail!("meetings.google_meet.client_secret cannot be empty when google_meet is enabled");
+        }
+
+        if self.refresh_token.trim().is_empty() {
+            bail!("meetings.google_meet.refresh_token cannot be empty when google_meet is enabled");
+        }
+
+        if self.max_participants < 1 {
+            bail!("meetings.google_meet.max_participants must be >= 1");
+        }
+
+        Ok(())
     }
 }
 

--- a/ocg-server/src/handlers/dashboard/group/events.rs
+++ b/ocg-server/src/handlers/dashboard/group/events.rs
@@ -652,6 +652,11 @@ fn build_meetings_max_participants(
 ) -> HashMap<MeetingProvider, i32> {
     let mut map = HashMap::new();
     if let Some(cfg) = meetings_cfg
+        && let Some(google_meet) = &cfg.google_meet
+    {
+        map.insert(MeetingProvider::GoogleMeet, google_meet.max_participants);
+    }
+    if let Some(cfg) = meetings_cfg
         && let Some(zoom) = &cfg.zoom
     {
         map.insert(MeetingProvider::Zoom, zoom.max_participants);

--- a/ocg-server/src/handlers/dashboard/group/events/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/events/tests.rs
@@ -13,7 +13,7 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use crate::{
-    config::{PaymentsConfig, PaymentsStripeConfig},
+    config::{MeetingsConfig, MeetingsGoogleMeetConfig, PaymentsConfig, PaymentsStripeConfig},
     db::mock::MockDB,
     handlers::tests::*,
     services::{
@@ -33,6 +33,28 @@ use crate::{
         permissions::GroupPermission,
     },
 };
+
+#[test]
+fn test_build_meetings_max_participants_includes_google_meet() {
+    let cfg = MeetingsConfig {
+        google_meet: Some(MeetingsGoogleMeetConfig {
+            calendar_id: "primary".to_string(),
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            enabled: true,
+            max_participants: 250,
+            refresh_token: "refresh-token".to_string(),
+        }),
+        zoom: None,
+    };
+
+    let max_participants = super::build_meetings_max_participants(Some(&cfg));
+
+    assert_eq!(
+        max_participants.get(&MeetingProvider::GoogleMeet),
+        Some(&250)
+    );
+}
 
 #[tokio::test]
 #[allow(clippy::too_many_lines)]

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -35,16 +35,16 @@ use crate::{
     },
     templates::{
         dashboard::{
-            audit::{AuditLogRecord, AuditLogsOutput},
             alliance::{
                 analytics::{
-                    AttendeesStats, AllianceDashboardStats, AlliancePageViewsStats, EventsStats,
+                    AllianceDashboardStats, AlliancePageViewsStats, AttendeesStats, EventsStats,
                     GroupsStats, MembersStats, PageViewsStats as AlliancePageViewsEntry,
                 },
                 groups::Group,
                 settings::AllianceUpdate,
                 team::AllianceTeamMember,
             },
+            audit::{AuditLogRecord, AuditLogsOutput},
             group::{
                 analytics::{
                     GroupAttendeesStats, GroupDashboardStats, GroupEventsStats, GroupMembersStats,
@@ -1373,6 +1373,7 @@ pub(crate) fn sample_invitation_request() -> InvitationRequest {
 /// Sample Zoom meetings configuration used in handler tests.
 pub(crate) fn sample_zoom_meetings_cfg(secret: &str) -> MeetingsConfig {
     MeetingsConfig {
+        google_meet: None,
         zoom: Some(MeetingsZoomConfig {
             account_id: "account-id".to_string(),
             client_id: "client-id".to_string(),

--- a/ocg-server/src/main.rs
+++ b/ocg-server/src/main.rs
@@ -27,7 +27,8 @@ use crate::{
     services::{
         images::{DbImageStorage, DynImageStorage, S3ImageStorage},
         meetings::{
-            DynMeetingsProvider, MeetingProvider, MeetingsManager, zoom::ZoomMeetingsProvider,
+            DynMeetingsProvider, MeetingProvider, MeetingsManager,
+            google::GoogleMeetMeetingsProvider, zoom::ZoomMeetingsProvider,
         },
         notifications::{DynEmailSender, LettreEmailSender, PgNotificationsManager},
         payments::{
@@ -184,6 +185,16 @@ fn setup_image_storage(cfg: &Config, db: Arc<PgDB>) -> DynImageStorage {
 fn start_meetings_workers(cfg: &Config, db: Arc<PgDB>, background_tasks: &BackgroundTasks) {
     // Collect the meetings providers enabled in the configuration
     let mut meetings_providers = HashMap::new();
+
+    if let Some(ref meetings_cfg) = cfg.meetings
+        && let Some(ref google_cfg) = meetings_cfg.google_meet
+        && google_cfg.enabled
+    {
+        meetings_providers.insert(
+            MeetingProvider::GoogleMeet,
+            Arc::new(GoogleMeetMeetingsProvider::new(google_cfg)) as DynMeetingsProvider,
+        );
+    }
 
     if let Some(ref meetings_cfg) = cfg.meetings
         && let Some(ref zoom_cfg) = meetings_cfg.zoom

--- a/ocg-server/src/services/meetings.rs
+++ b/ocg-server/src/services/meetings.rs
@@ -20,6 +20,7 @@ use crate::{config::MeetingsZoomConfig, db::DynDB};
 #[cfg(test)]
 mod tests;
 
+pub(crate) mod google;
 pub(crate) mod zoom;
 
 /// Time after which claimed meeting processing requires manual review.
@@ -536,6 +537,7 @@ impl MeetingsSyncWorker {
     async fn assign_provider_host_user(&self, meeting: &Meeting) -> Result<Meeting, SyncError> {
         match meeting.provider {
             MeetingProvider::Zoom => self.assign_zoom_host_user(meeting).await,
+            MeetingProvider::GoogleMeet => Ok(meeting.clone()),
         }
     }
 
@@ -660,6 +662,9 @@ impl Meeting {
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub(crate) enum MeetingProvider {
+    #[serde(rename = "google_meet")]
+    #[strum(serialize = "google_meet")]
+    GoogleMeet,
     #[default]
     Zoom,
 }

--- a/ocg-server/src/services/meetings/google.rs
+++ b/ocg-server/src/services/meetings/google.rs
@@ -1,0 +1,115 @@
+//! Google Meet-backed meetings provider implementation.
+
+use async_trait::async_trait;
+
+use crate::{
+    config::MeetingsGoogleMeetConfig,
+    services::meetings::google::client::{
+        CalendarEventRequest, GOOGLE_CALENDAR_EVENT_NOT_FOUND, GoogleCalendarClient,
+        GoogleCalendarClientError,
+    },
+};
+
+use super::{
+    Meeting, MeetingEndResult, MeetingProviderError, MeetingProviderMeeting, MeetingsProvider,
+};
+
+pub(crate) mod client;
+
+/// Google Meet-backed meetings provider implementation.
+pub(crate) struct GoogleMeetMeetingsProvider {
+    client: GoogleCalendarClient,
+}
+
+impl GoogleMeetMeetingsProvider {
+    /// Create a new `GoogleMeetMeetingsProvider`.
+    pub(crate) fn new(cfg: &MeetingsGoogleMeetConfig) -> Self {
+        Self {
+            client: GoogleCalendarClient::new(cfg.clone()),
+        }
+    }
+}
+
+#[async_trait]
+impl MeetingsProvider for GoogleMeetMeetingsProvider {
+    /// Create a Google Calendar event with a Google Meet conference.
+    async fn create_meeting(
+        &self,
+        meeting: &Meeting,
+    ) -> Result<MeetingProviderMeeting, MeetingProviderError> {
+        let req = CalendarEventRequest::try_from(meeting).map_err(MeetingProviderError::from)?;
+        let event = self
+            .client
+            .create_event(&req)
+            .await
+            .map_err(MeetingProviderError::from)?;
+
+        Ok(MeetingProviderMeeting {
+            id: event.id,
+            join_url: event.meet_url.ok_or_else(|| {
+                MeetingProviderError::Client(
+                    "google calendar event did not include a meet join url".to_string(),
+                )
+            })?,
+            password: None,
+        })
+    }
+
+    /// Delete the backing Google Calendar event.
+    async fn delete_meeting(&self, provider_meeting_id: &str) -> Result<(), MeetingProviderError> {
+        match self.client.delete_event(provider_meeting_id).await {
+            Ok(()) => Ok(()),
+            Err(GoogleCalendarClientError::Client { code, .. })
+                if code == GOOGLE_CALENDAR_EVENT_NOT_FOUND =>
+            {
+                Err(MeetingProviderError::NotFound)
+            }
+            Err(e) => Err(MeetingProviderError::from(e)),
+        }
+    }
+
+    /// Google Meet does not support the same explicit host-side end call as Zoom.
+    async fn end_meeting(
+        &self,
+        _provider_meeting_id: &str,
+    ) -> Result<MeetingEndResult, MeetingProviderError> {
+        Ok(MeetingEndResult::AlreadyNotRunning)
+    }
+
+    /// Get the backing Google Calendar event details.
+    async fn get_meeting(
+        &self,
+        provider_meeting_id: &str,
+    ) -> Result<MeetingProviderMeeting, MeetingProviderError> {
+        let event = self
+            .client
+            .get_event(provider_meeting_id)
+            .await
+            .map_err(MeetingProviderError::from)?;
+
+        Ok(MeetingProviderMeeting {
+            id: event.id,
+            join_url: event.meet_url.ok_or_else(|| {
+                MeetingProviderError::Client(
+                    "google calendar event did not include a meet join url".to_string(),
+                )
+            })?,
+            password: None,
+        })
+    }
+
+    /// Update the backing Google Calendar event.
+    async fn update_meeting(
+        &self,
+        provider_meeting_id: &str,
+        meeting: &Meeting,
+    ) -> Result<(), MeetingProviderError> {
+        let req = CalendarEventRequest::try_from(meeting).map_err(MeetingProviderError::from)?;
+        self.client
+            .update_event(provider_meeting_id, &req)
+            .await
+            .map_err(MeetingProviderError::from)?;
+
+        Ok(())
+    }
+}

--- a/ocg-server/src/services/meetings/google/client.rs
+++ b/ocg-server/src/services/meetings/google/client.rs
@@ -1,0 +1,591 @@
+//! Lightweight Google Calendar client for Google Meet operations.
+
+use std::time::{Duration, Instant};
+
+use anyhow::{Result, anyhow};
+use chrono::{DateTime, Utc};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use reqwest::Client as HttpClient;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use tokio::sync::Mutex;
+use tracing::{instrument, trace};
+use uuid::Uuid;
+
+use crate::{config::MeetingsGoogleMeetConfig, services::meetings::Meeting};
+
+use super::MeetingProviderError;
+
+/// Google Calendar client error code for "event does not exist".
+pub(crate) const GOOGLE_CALENDAR_EVENT_NOT_FOUND: i32 = 404;
+
+/// Base URL for Google Calendar API v3.
+const BASE_URL: &str = "https://www.googleapis.com/calendar/v3";
+
+/// Timeout for HTTP requests to Google Calendar API.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Maximum meeting duration in minutes.
+const MAX_DURATION_MINUTES: i64 = 720;
+
+/// Minimum meeting duration in minutes.
+const MIN_DURATION_MINUTES: i64 = 5;
+
+/// Margin before token expiry to trigger refresh.
+const TOKEN_EXPIRY_MARGIN: Duration = Duration::from_mins(5);
+
+/// Google OAuth token endpoint.
+const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+/// Google Calendar client for event and Meet operations.
+pub(crate) struct GoogleCalendarClient {
+    cfg: MeetingsGoogleMeetConfig,
+    http_client: HttpClient,
+    token: Mutex<Option<CachedToken>>,
+}
+
+impl GoogleCalendarClient {
+    /// Create a new Google Calendar client.
+    pub(crate) fn new(cfg: MeetingsGoogleMeetConfig) -> Self {
+        let http_client = HttpClient::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .expect("failed to build http client");
+
+        Self {
+            cfg,
+            http_client,
+            token: Mutex::new(None),
+        }
+    }
+
+    /// Create a Calendar event with Google Meet conference data.
+    #[instrument(skip(self, req), err)]
+    pub(crate) async fn create_event(
+        &self,
+        req: &CalendarEventRequest,
+    ) -> Result<GoogleCalendarEvent, GoogleCalendarClientError> {
+        trace!("google calendar client: create event");
+
+        let token = self
+            .get_token()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Token(e.to_string()))?;
+        let url = self.calendar_events_url("conferenceDataVersion=1");
+        let request = req.clone().with_meet_conference();
+        let response = self
+            .http_client
+            .post(&url)
+            .bearer_auth(token)
+            .json(&request)
+            .send()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Network(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(GoogleCalendarClientError::from_response(response).await);
+        }
+
+        let response = response
+            .json::<CalendarEventResponse>()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Network(e.to_string()))?;
+        GoogleCalendarEvent::try_from(response)
+    }
+
+    /// Delete a Calendar event by ID.
+    #[instrument(skip(self), err)]
+    pub(crate) async fn delete_event(
+        &self,
+        event_id: &str,
+    ) -> Result<(), GoogleCalendarClientError> {
+        trace!("google calendar client: delete event");
+
+        let token = self
+            .get_token()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Token(e.to_string()))?;
+        let url = self.calendar_event_url(event_id, "");
+        let response = self
+            .http_client
+            .delete(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Network(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(GoogleCalendarClientError::from_response(response).await);
+        }
+
+        Ok(())
+    }
+
+    /// Get a Calendar event by ID.
+    #[instrument(skip(self), err)]
+    pub(crate) async fn get_event(
+        &self,
+        event_id: &str,
+    ) -> Result<GoogleCalendarEvent, GoogleCalendarClientError> {
+        trace!("google calendar client: get event");
+
+        let token = self
+            .get_token()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Token(e.to_string()))?;
+        let url = self.calendar_event_url(event_id, "conferenceDataVersion=1");
+        let response = self
+            .http_client
+            .get(&url)
+            .bearer_auth(token)
+            .send()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Network(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(GoogleCalendarClientError::from_response(response).await);
+        }
+
+        let response = response
+            .json::<CalendarEventResponse>()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Network(e.to_string()))?;
+        GoogleCalendarEvent::try_from(response)
+    }
+
+    /// Update an existing Calendar event.
+    #[instrument(skip(self, req), err)]
+    pub(crate) async fn update_event(
+        &self,
+        event_id: &str,
+        req: &CalendarEventRequest,
+    ) -> Result<(), GoogleCalendarClientError> {
+        trace!("google calendar client: update event");
+
+        let token = self
+            .get_token()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Token(e.to_string()))?;
+        let url = self.calendar_event_url(event_id, "conferenceDataVersion=1");
+        let response = self
+            .http_client
+            .patch(&url)
+            .bearer_auth(token)
+            .json(req)
+            .send()
+            .await
+            .map_err(|e| GoogleCalendarClientError::Network(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(GoogleCalendarClientError::from_response(response).await);
+        }
+
+        Ok(())
+    }
+
+    /// Fetch a new access token from Google using the configured refresh token.
+    #[instrument(skip(self), err)]
+    async fn fetch_token(&self) -> Result<CachedToken> {
+        trace!("google calendar client: fetch token");
+
+        let params = [
+            ("client_id", self.cfg.client_id.as_str()),
+            ("client_secret", self.cfg.client_secret.as_str()),
+            ("refresh_token", self.cfg.refresh_token.as_str()),
+            ("grant_type", "refresh_token"),
+        ];
+        let body = serde_urlencoded::to_string(params)?;
+        let response = self
+            .http_client
+            .post(GOOGLE_TOKEN_URL)
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(body)
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            let error: GoogleTokenErrorResponse = response.json().await.unwrap_or_default();
+            return Err(anyhow!(
+                "google token error: {} - {}",
+                error.error,
+                error.error_description
+            ));
+        }
+
+        let token_response: TokenResponse = response.json().await?;
+        let expires_at = Instant::now() + Duration::from_secs(token_response.expires_in);
+
+        Ok(CachedToken {
+            access_token: token_response.access_token,
+            expires_at,
+        })
+    }
+
+    /// Get a valid access token, fetching a new one if needed.
+    async fn get_token(&self) -> Result<String> {
+        let mut token_guard = self.token.lock().await;
+        if let Some(ref cached) = *token_guard
+            && Instant::now() + TOKEN_EXPIRY_MARGIN < cached.expires_at
+        {
+            return Ok(cached.access_token.clone());
+        }
+
+        let new_token = self.fetch_token().await?;
+        let access_token = new_token.access_token.clone();
+        *token_guard = Some(new_token);
+
+        Ok(access_token)
+    }
+
+    /// Returns the events collection URL for the configured calendar.
+    fn calendar_events_url(&self, query: &str) -> String {
+        let calendar_id = utf8_percent_encode(&self.cfg.calendar_id, NON_ALPHANUMERIC);
+        if query.is_empty() {
+            format!("{BASE_URL}/calendars/{calendar_id}/events")
+        } else {
+            format!("{BASE_URL}/calendars/{calendar_id}/events?{query}")
+        }
+    }
+
+    /// Returns a single event URL for the configured calendar.
+    fn calendar_event_url(&self, event_id: &str, query: &str) -> String {
+        let calendar_id = utf8_percent_encode(&self.cfg.calendar_id, NON_ALPHANUMERIC);
+        let event_id = utf8_percent_encode(event_id, NON_ALPHANUMERIC);
+        if query.is_empty() {
+            format!("{BASE_URL}/calendars/{calendar_id}/events/{event_id}")
+        } else {
+            format!("{BASE_URL}/calendars/{calendar_id}/events/{event_id}?{query}")
+        }
+    }
+}
+
+/// Cached OAuth access token with expiry tracking.
+struct CachedToken {
+    access_token: String,
+    expires_at: Instant,
+}
+
+/// Calendar event request used for create and update.
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CalendarEventRequest {
+    pub conference_data: Option<ConferenceData>,
+    pub description: Option<String>,
+    pub end: EventDateTime,
+    pub start: EventDateTime,
+    pub summary: String,
+}
+
+impl CalendarEventRequest {
+    /// Adds a Google Meet conference creation request.
+    fn with_meet_conference(mut self) -> Self {
+        self.conference_data = Some(ConferenceData {
+            create_request: ConferenceCreateRequest {
+                conference_solution_key: ConferenceSolutionKey {
+                    conference_type: "hangoutsMeet",
+                },
+                request_id: Uuid::new_v4().to_string(),
+            },
+        });
+        self
+    }
+}
+
+impl TryFrom<&Meeting> for CalendarEventRequest {
+    type Error = GoogleCalendarClientError;
+
+    fn try_from(m: &Meeting) -> Result<Self, Self::Error> {
+        let starts_at = m.starts_at.ok_or_else(|| GoogleCalendarClientError::Client {
+            code: 400,
+            message: "missing meeting starts_at".to_string(),
+        })?;
+        let duration = m.duration.ok_or_else(|| GoogleCalendarClientError::Client {
+            code: 400,
+            message: "missing meeting duration".to_string(),
+        })?;
+        duration_minutes(duration)?;
+        let duration = chrono::Duration::from_std(duration).map_err(|err| {
+            GoogleCalendarClientError::Client {
+                code: 400,
+                message: err.to_string(),
+            }
+        })?;
+        let ends_at = starts_at.checked_add_signed(duration).ok_or_else(|| {
+            GoogleCalendarClientError::Client {
+                code: 400,
+                message: "meeting end time overflow".to_string(),
+            }
+        })?;
+        let timezone = m.timezone.clone();
+
+        Ok(Self {
+            conference_data: None,
+            description: m.hosts.as_ref().and_then(|hosts| {
+                (!hosts.is_empty()).then(|| format!("Additional host emails: {}", hosts.join(", ")))
+            }),
+            end: EventDateTime {
+                date_time: ends_at,
+                time_zone: timezone.clone(),
+            },
+            start: EventDateTime {
+                date_time: starts_at,
+                time_zone: timezone,
+            },
+            summary: m.topic.clone().unwrap_or_else(|| "GOUP meeting".to_string()),
+        })
+    }
+}
+
+/// Date-time shape expected by Google Calendar API.
+#[skip_serializing_none]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct EventDateTime {
+    pub date_time: DateTime<Utc>,
+    pub time_zone: Option<String>,
+}
+
+/// Conference creation data.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConferenceData {
+    pub create_request: ConferenceCreateRequest,
+}
+
+/// Conference creation request.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConferenceCreateRequest {
+    pub conference_solution_key: ConferenceSolutionKey,
+    pub request_id: String,
+}
+
+/// Conference solution key.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ConferenceSolutionKey {
+    #[serde(rename = "type")]
+    pub conference_type: &'static str,
+}
+
+/// Response from Google's OAuth token endpoint.
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: u64,
+}
+
+/// Google Calendar event details returned by the client.
+#[derive(Debug)]
+pub(crate) struct GoogleCalendarEvent {
+    pub id: String,
+    pub meet_url: Option<String>,
+}
+
+impl TryFrom<CalendarEventResponse> for GoogleCalendarEvent {
+    type Error = GoogleCalendarClientError;
+
+    fn try_from(response: CalendarEventResponse) -> Result<Self, Self::Error> {
+        let meet_url = response.hangout_link.or_else(|| {
+            response.conference_data.and_then(|conference_data| {
+                conference_data.entry_points.into_iter().find_map(|entry_point| {
+                    (entry_point.entry_point_type == "video").then_some(entry_point.uri)
+                })
+            })
+        });
+
+        Ok(Self {
+            id: response.id.ok_or_else(|| GoogleCalendarClientError::Client {
+                code: 400,
+                message: "google calendar event response missing id".to_string(),
+            })?,
+            meet_url,
+        })
+    }
+}
+
+/// Calendar event response.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CalendarEventResponse {
+    conference_data: Option<ConferenceDataResponse>,
+    hangout_link: Option<String>,
+    id: Option<String>,
+}
+
+/// Conference data response.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConferenceDataResponse {
+    #[serde(default)]
+    entry_points: Vec<ConferenceEntryPoint>,
+}
+
+/// Conference entry point response.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ConferenceEntryPoint {
+    entry_point_type: String,
+    uri: String,
+}
+
+/// Error types from Google Calendar client calls.
+#[derive(Debug)]
+pub(crate) enum GoogleCalendarClientError {
+    /// Non-retryable client errors.
+    Client { code: i32, message: String },
+    /// Network or connection errors.
+    Network(String),
+    /// Rate limit exceeded.
+    RateLimit { retry_after: Duration },
+    /// Server errors.
+    Server { code: i32, message: String },
+    /// Token fetch error.
+    Token(String),
+}
+
+impl std::fmt::Display for GoogleCalendarClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Client { code, message } => {
+                write!(f, "google calendar client error: {code} - {message}")
+            }
+            Self::Network(msg) => write!(f, "google calendar network error: {msg}"),
+            Self::RateLimit { retry_after } => {
+                write!(
+                    f,
+                    "google calendar rate limit exceeded (retry after {}s)",
+                    retry_after.as_secs()
+                )
+            }
+            Self::Server { code, message } => {
+                write!(f, "google calendar server error: {code} - {message}")
+            }
+            Self::Token(msg) => write!(f, "google calendar token error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for GoogleCalendarClientError {}
+
+impl From<GoogleCalendarClientError> for MeetingProviderError {
+    fn from(e: GoogleCalendarClientError) -> Self {
+        match e {
+            GoogleCalendarClientError::Client { code, message } => {
+                if code == GOOGLE_CALENDAR_EVENT_NOT_FOUND {
+                    Self::NotFound
+                } else {
+                    Self::Client(format!("{code}: {message}"))
+                }
+            }
+            GoogleCalendarClientError::Network(msg) => Self::Network(msg),
+            GoogleCalendarClientError::RateLimit { retry_after } => Self::RateLimit { retry_after },
+            GoogleCalendarClientError::Server { code, message } => {
+                Self::Server(format!("{code}: {message}"))
+            }
+            GoogleCalendarClientError::Token(msg) => Self::Token(msg),
+        }
+    }
+}
+
+impl GoogleCalendarClientError {
+    /// Create error from HTTP response status and body.
+    async fn from_response(response: reqwest::Response) -> Self {
+        let retry_after = response
+            .headers()
+            .get(reqwest::header::RETRY_AFTER)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+            .map_or(Duration::from_mins(1), Duration::from_secs);
+        let status = response.status();
+        let error: GoogleCalendarErrorEnvelope = response.json().await.unwrap_or_default();
+        let code = if error.error.code == 0 {
+            i32::from(status.as_u16())
+        } else {
+            error.error.code
+        };
+        let message = error.error.message;
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            Self::RateLimit { retry_after }
+        } else if status == reqwest::StatusCode::UNAUTHORIZED
+            || status == reqwest::StatusCode::FORBIDDEN
+        {
+            Self::Token(format!("{code} - {message}"))
+        } else if status.is_client_error() {
+            Self::Client { code, message }
+        } else {
+            Self::Server { code, message }
+        }
+    }
+}
+
+/// Google Calendar error envelope.
+#[derive(Debug, Default, Deserialize)]
+struct GoogleCalendarErrorEnvelope {
+    #[serde(default)]
+    error: GoogleCalendarError,
+}
+
+/// Google Calendar error body.
+#[derive(Debug, Default, Deserialize)]
+struct GoogleCalendarError {
+    #[serde(default)]
+    code: i32,
+    #[serde(default)]
+    message: String,
+}
+
+/// Google OAuth token error response.
+#[derive(Debug, Default, Deserialize)]
+struct GoogleTokenErrorResponse {
+    #[serde(default)]
+    error: String,
+    #[serde(default)]
+    error_description: String,
+}
+
+/// Validate and convert a duration to minutes.
+fn duration_minutes(d: std::time::Duration) -> Result<i64, GoogleCalendarClientError> {
+    let minutes = i64::try_from(d.as_secs() / 60).unwrap_or(i64::MAX);
+    if !(MIN_DURATION_MINUTES..=MAX_DURATION_MINUTES).contains(&minutes) {
+        return Err(GoogleCalendarClientError::Client {
+            code: 400,
+            message: format!("invalid meeting duration: {minutes} minutes"),
+        });
+    }
+    Ok(minutes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use chrono::Utc;
+    use serde_json::json;
+
+    use crate::services::meetings::Meeting;
+
+    use super::CalendarEventRequest;
+
+    #[test]
+    fn create_event_request_can_include_meet_conference_data() {
+        let request = CalendarEventRequest::try_from(&Meeting {
+            duration: Some(Duration::from_secs(30 * 60)),
+            starts_at: Some(Utc::now()),
+            topic: Some("Demo".to_string()),
+            timezone: Some("America/New_York".to_string()),
+            ..Default::default()
+        })
+        .unwrap()
+        .with_meet_conference();
+        let value = serde_json::to_value(request).unwrap();
+
+        assert_eq!(value["summary"], json!("Demo"));
+        assert_eq!(
+            value["conferenceData"]["createRequest"]["conferenceSolutionKey"]["type"],
+            json!("hangoutsMeet")
+        );
+        assert!(
+            value["conferenceData"]["createRequest"]["requestId"]
+                .as_str()
+                .is_some_and(|request_id| !request_id.is_empty())
+        );
+    }
+}

--- a/ocg-server/static/images/e2e/alliance-primary-banner-mobile.svg
+++ b/ocg-server/static/images/e2e/alliance-primary-banner-mobile.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1220 192" role="img" aria-label="Platform Engineering Alliance mobile banner">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1220 192" role="img" aria-label="GOUP Alliance mobile banner">
   <defs>
     <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
       <stop offset="0%" stop-color="#115e59"/>

--- a/ocg-server/static/images/e2e/alliance-primary-banner.svg
+++ b/ocg-server/static/images/e2e/alliance-primary-banner.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2428 192" role="img" aria-label="Platform Engineering Alliance banner">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2428 192" role="img" aria-label="GOUP Alliance banner">
   <defs>
     <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
       <stop offset="0%" stop-color="#0f766e"/>

--- a/ocg-server/static/images/e2e/alliance-primary-logo.svg
+++ b/ocg-server/static/images/e2e/alliance-primary-logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360" role="img" aria-label="Platform Engineering Alliance logo">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 360" role="img" aria-label="GOUP Alliance logo">
   <rect width="360" height="360" rx="72" fill="#0f766e"/>
   <circle cx="180" cy="180" r="118" fill="#f0fdfa" fill-opacity="0.12"/>
   <path d="M110 128 h140 v34 h-102 v36 h84 v34 h-84 v52 h-38 z" fill="#f0fdfa"/>

--- a/ocg-server/static/js/common/online-event-details.js
+++ b/ocg-server/static/js/common/online-event-details.js
@@ -108,7 +108,7 @@ export class OnlineEventDetails extends LitWrapper {
     this.meetingPassword = "";
     this.meetingError = "";
     this.fieldNamePrefix = "";
-    this.meetingProviderId = DEFAULT_MEETING_PROVIDER;
+    this.meetingProviderId = "";
     this.meetingRecordingRawUrls = [];
     this.meetingRecordingPublished = false;
     this.meetingMaxParticipants = {};
@@ -121,7 +121,7 @@ export class OnlineEventDetails extends LitWrapper {
     this._rawRecordingUrls = [];
     this._recordingRequested = true;
     this._createMeeting = false;
-    this._providerId = DEFAULT_MEETING_PROVIDER;
+    this._providerId = "";
     this._hosts = [];
     this._capacityWarning = "";
     this.disabled = false;
@@ -166,7 +166,7 @@ export class OnlineEventDetails extends LitWrapper {
       : [];
     this._recordingRequested = this.meetingRecordingRequested !== false;
     this._createMeeting = this.meetingRequested;
-    this._providerId = this.meetingProviderId || DEFAULT_MEETING_PROVIDER;
+    this._providerId = this._normalizeProviderId(this.meetingProviderId);
     this._hosts = Array.isArray(this.meetingHosts) ? [...this.meetingHosts] : [];
     this._mode = startsInAutomaticMode ? "automatic" : "manual";
     this._checkMeetingCapacity();
@@ -772,7 +772,7 @@ export class OnlineEventDetails extends LitWrapper {
       meeting_recording_requested: this._recordingRequested !== false,
       meeting_recording_url: (this._recordingUrl || "").trim(),
       meeting_requested: isAutomatic,
-      meeting_provider_id: isAutomatic ? (this._providerId || DEFAULT_MEETING_PROVIDER).trim() : "",
+      meeting_provider_id: isAutomatic ? this._normalizeProviderId(this._providerId).trim() : "",
     };
 
     if (this._supportsJoinInstructions()) {
@@ -794,7 +794,7 @@ export class OnlineEventDetails extends LitWrapper {
     this._rawRecordingUrls = [];
     this._recordingRequested = true;
     this._createMeeting = false;
-    this._providerId = DEFAULT_MEETING_PROVIDER;
+    this._providerId = this._getDefaultProviderId();
     this._hosts = [];
     this.requestUpdate();
   }
@@ -884,6 +884,51 @@ export class OnlineEventDetails extends LitWrapper {
     }
 
     return null;
+  }
+
+  _getProviderOptions() {
+    const configuredProviders =
+      this.meetingMaxParticipants && typeof this.meetingMaxParticipants === "object"
+        ? Object.keys(this.meetingMaxParticipants).filter((providerId) => providerId.trim() !== "")
+        : [];
+    const providerIds = configuredProviders.length > 0 ? configuredProviders : [DEFAULT_MEETING_PROVIDER];
+
+    if (this._providerId && !providerIds.includes(this._providerId)) {
+      providerIds.push(this._providerId);
+    }
+
+    return providerIds.map((providerId) => ({
+      id: providerId,
+      label: this._getProviderLabel(providerId),
+    }));
+  }
+
+  _getProviderLabel(providerId) {
+    switch (providerId) {
+      case "google_meet":
+        return "Google Meet";
+      case "zoom":
+        return "Zoom";
+      default:
+        return providerId
+          .split("_")
+          .filter(Boolean)
+          .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+          .join(" ");
+    }
+  }
+
+  _getDefaultProviderId() {
+    return this._getProviderOptions()[0]?.id || DEFAULT_MEETING_PROVIDER;
+  }
+
+  _normalizeProviderId(providerId) {
+    const requestedProviderId = (providerId || "").trim();
+    const providerOptions = this._getProviderOptions();
+    if (requestedProviderId && providerOptions.some((option) => option.id === requestedProviderId)) {
+      return requestedProviderId;
+    }
+    return providerOptions[0]?.id || DEFAULT_MEETING_PROVIDER;
   }
 
   _checkMeetingCapacity() {
@@ -1179,14 +1224,18 @@ export class OnlineEventDetails extends LitWrapper {
                       ? "bg-stone-100 text-stone-500 cursor-not-allowed"
                       : ""}"
                     @change="${(event) => {
-                      this._providerId = event.target.value || DEFAULT_MEETING_PROVIDER;
+                      this._providerId = this._normalizeProviderId(event.target.value);
                       this._checkMeetingCapacity();
                     }}"
                     ?disabled=${this.disabled}
                   >
-                    <option value="zoom" .selected="${this._providerId === DEFAULT_MEETING_PROVIDER}">
-                      Zoom
-                    </option>
+                    ${this._getProviderOptions().map(
+                      (provider) => html`
+                        <option value="${provider.id}" .selected="${this._providerId === provider.id}">
+                          ${provider.label}
+                        </option>
+                      `,
+                    )}
                   </select>
                 </div>
                 <div class="space-y-2 lg:w-1/2">

--- a/ocg-server/static/js/dashboard/event/sessions/item.js
+++ b/ocg-server/static/js/dashboard/event/sessions/item.js
@@ -546,6 +546,7 @@ class SessionItem extends LitWrapper {
                         ?meeting-requested=${this.data.meeting_requested}
                         ?meeting-in-sync=${this.data.meeting_in_sync}
                         meeting-password=${this.data.meeting_password || ""}
+                        meeting-provider-id=${this.data.meeting_provider_id || this.data.meeting_provider || ""}
                         meeting-error=${this.data.meeting_error || ""}
                         starts-at=${this.data.starts_at || ""}
                         ends-at=${this.data.ends_at || ""}

--- a/ocg-server/templates/dashboard/group/events_update.html
+++ b/ocg-server/templates/dashboard/group/events_update.html
@@ -723,6 +723,7 @@
                 {% if let Some(meeting_error) = &event.meeting_error %}meeting-error="{{ meeting_error }}"{% endif %}
 
                 {% if let Some(meeting_hosts) = &event.meeting_hosts %}meeting-hosts="{{ meeting_hosts|json }}"{% endif %}
+                {% if let Some(meeting_provider) = event.meeting_provider %}meeting-provider-id="{{ meeting_provider }}"{% endif %}
                 meeting-max-participants="{{ meetings_max_participants|json }}" starts-at="{{ event.starts_at|display_some_datetime_tz(DATE_FORMAT, event.timezone.clone() ) }}" ends-at="{{ event.ends_at|display_some_datetime_tz(DATE_FORMAT, event.timezone.clone() ) }}"></online-event-details>
               {% else %}
                 <div class="space-y-6">

--- a/scripts/bootstrap-ec2.sh
+++ b/scripts/bootstrap-ec2.sh
@@ -46,6 +46,12 @@ SMTP_PASSWORD="${OCG_SMTP_PASSWORD:-}"
 EMAIL_FROM_ADDRESS="${OCG_EMAIL_FROM_ADDRESS:-no-reply@goup.vc}"
 EMAIL_FROM_NAME="${OCG_EMAIL_FROM_NAME:-GOUP Alliance}"
 ADMIN_EMAIL="${OCG_ADMIN_EMAIL:-}"
+GOOGLE_MEET_ENABLED="${OCG_GOOGLE_MEET_ENABLED:-false}"
+GOOGLE_MEET_CALENDAR_ID="${OCG_GOOGLE_MEET_CALENDAR_ID:-primary}"
+GOOGLE_MEET_CLIENT_ID="${OCG_GOOGLE_MEET_CLIENT_ID:-}"
+GOOGLE_MEET_CLIENT_SECRET="${OCG_GOOGLE_MEET_CLIENT_SECRET:-}"
+GOOGLE_MEET_REFRESH_TOKEN="${OCG_GOOGLE_MEET_REFRESH_TOKEN:-}"
+GOOGLE_MEET_MAX_PARTICIPANTS="${OCG_GOOGLE_MEET_MAX_PARTICIPANTS:-100}"
 
 usage() {
     cat <<'EOF'
@@ -63,6 +69,15 @@ Common optional environment:
   OCG_DB_NAME                  DB name. Default: ocg
   OCG_DB_USER                  DB user. Default: ocg
   OCG_ADMIN_EMAIL              Existing user email to grant alliance admin.
+  OCG_GOOGLE_MEET_ENABLED      Enable automatic Google Meet creation. Default: false
+  OCG_GOOGLE_MEET_CALENDAR_ID  Google Calendar ID. Default: primary
+  OCG_GOOGLE_MEET_CLIENT_ID    Google OAuth client ID.
+  OCG_GOOGLE_MEET_CLIENT_SECRET
+                               Google OAuth client secret.
+  OCG_GOOGLE_MEET_REFRESH_TOKEN
+                               Google OAuth refresh token.
+  OCG_GOOGLE_MEET_MAX_PARTICIPANTS
+                               Google Meet participant limit. Default: 100
   BOOTSTRAP_INSTALL_DEPS       Install missing EC2 dependencies. Default: true
   BOOTSTRAP_INSTALL_POSTGRES_SERVER
                                Also install local PostgreSQL/PostGIS packages when available.
@@ -339,6 +354,12 @@ require_cmd psql
 require_cmd tern
 
 log "Writing configuration"
+if [[ "$GOOGLE_MEET_ENABLED" == "true" ]]; then
+    [[ -n "$GOOGLE_MEET_CLIENT_ID" ]] || die "set OCG_GOOGLE_MEET_CLIENT_ID when OCG_GOOGLE_MEET_ENABLED=true"
+    [[ -n "$GOOGLE_MEET_CLIENT_SECRET" ]] || die "set OCG_GOOGLE_MEET_CLIENT_SECRET when OCG_GOOGLE_MEET_ENABLED=true"
+    [[ -n "$GOOGLE_MEET_REFRESH_TOKEN" ]] || die "set OCG_GOOGLE_MEET_REFRESH_TOKEN when OCG_GOOGLE_MEET_ENABLED=true"
+fi
+
 write_file_once "$TERN_CONFIG" 600 <<EOF
 [database]
 host = $DB_HOST
@@ -376,6 +397,16 @@ images:
 
 log:
   format: json
+
+meetings:
+  google_meet:
+    calendar_id: "$GOOGLE_MEET_CALENDAR_ID"
+    client_id: "$GOOGLE_MEET_CLIENT_ID"
+    client_secret: "$GOOGLE_MEET_CLIENT_SECRET"
+    enabled: $GOOGLE_MEET_ENABLED
+    max_participants: $GOOGLE_MEET_MAX_PARTICIPANTS
+    refresh_token: "$GOOGLE_MEET_REFRESH_TOKEN"
+  zoom: null
 
 server:
   addr: $SERVER_ADDR

--- a/tests/e2e/dashboard/alliance/logs/logs.spec.js
+++ b/tests/e2e/dashboard/alliance/logs/logs.spec.js
@@ -28,7 +28,7 @@ test.describe("alliance dashboard logs view", () => {
     const auditLogRow = dashboardContent.locator("tr.audit-log-row").first();
     await expect(auditLogRow).toContainText("Alliance updated");
     await expect(auditLogRow).toContainText("e2e-admin-1");
-    await expect(auditLogRow).toContainText("Platform Engineering Alliance");
+    await expect(auditLogRow).toContainText("GOUP Alliance");
 
     // Open the filters modal and verify the active filters.
     await adminAlliancePage.getByRole("button", { name: "Filters" }).click();
@@ -90,9 +90,7 @@ test.describe("alliance dashboard logs view", () => {
     await expect(
       dashboardContent.locator("tr.audit-log-row").first(),
     ).toBeVisible();
-    await expect(dashboardContent).toContainText(
-      "Platform Engineering Alliance",
-    );
+    await expect(dashboardContent).toContainText("GOUP Alliance");
     await expect(
       dashboardContent
         .locator("tr.audit-log-row", {

--- a/tests/e2e/dashboard/alliance/settings/settings.spec.js
+++ b/tests/e2e/dashboard/alliance/settings/settings.spec.js
@@ -118,9 +118,8 @@ test.describe("alliance dashboard settings view", () => {
       bannerMobileUrl:
         "/static/images/e2e/alliance-secondary-banner-mobile.svg",
       bannerUrl: "/static/images/e2e/alliance-secondary-banner.svg",
-      description:
-        "Updated platform engineering alliance details for settings coverage.",
-      displayName: `Platform Engineering Alliance ${Date.now()}`,
+      description: "Updated GOUP Alliance details for settings coverage.",
+      displayName: `GOUP Alliance ${Date.now()}`,
       logoUrl: "/static/images/e2e/alliance-secondary-logo.svg",
     };
 

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -27,12 +27,12 @@ export const TEST_REGISTRATION_QUESTIONS_EVENT = {
 };
 export const TEST_SEARCH_QUERY = "Test";
 export const TEST_SITE_TITLE = "E2E Test Site";
-export const TEST_ALLIANCE_TITLE = "Platform Engineering Alliance";
+export const TEST_ALLIANCE_TITLE = "GOUP Alliance";
 export const TEST_ALLIANCE_TITLE_2 = "Developer Experience Alliance";
 
 /** Alliance details for assertions. */
 export const TEST_ALLIANCE_DESCRIPTION =
-  "Platform engineering alliance used for end-to-end coverage.";
+  "GOUP Alliance used for end-to-end coverage.";
 export const TEST_ALLIANCE_BANNER_URL =
   "/static/images/e2e/alliance-primary-banner.svg";
 export const TEST_ALLIANCE_BANNER_MOBILE_URL =


### PR DESCRIPTION
## Summary
- Add Google Meet as an automatic meeting provider using Google Calendar API and admin OAuth refresh tokens.
- Add google_meet provider reference data, Helm/EC2 config, and dynamic meeting provider UI.
- Update E2E alliance naming from Platform Engineering Alliance to GOUP Alliance.

## Test plan
- cargo check -p ocg-server
- cargo test -p ocg-server create_event_request_can_include_meet_conference_data -- --quiet
- cargo test -p ocg-server test_build_meetings_max_participants_includes_google_meet -- --quiet
- git diff --check

Note: focused frontend tests were attempted but local Playwright Chromium is missing; run npx playwright install before frontend test execution.

Made with [Cursor](https://cursor.com)