### PR TITLE
Add jobs link to header

### DIFF
--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -28,6 +28,7 @@
         {{ header::link(content = "Home", href = "/", current_path = path) -}}
         {{ header::link(content = "Explore", href = explore_events, current_path = path, path = "/explore") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
+        {{ header::link(content = "Jobs", href = "https://github.com/sakomws/gitjobs", current_path = path, hx_boost = "false", hx_target = "", target = "_blank") -}}
       </div>
       {# End desktop links -#}
     </div>
@@ -119,6 +120,21 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-charts bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Stats</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="https://github.com/sakomws/gitjobs"
+               hx-boost="false"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-external-link bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Jobs</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -256,6 +272,22 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-charts bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Stats</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden border-b border-stone-200 mb-2 pb-2"
+              role="none">
+            <a href="https://github.com/sakomws/gitjobs"
+               hx-boost="false"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-external-link bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Jobs</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/ocg-server/templates/macros/header.html
+++ b/ocg-server/templates/macros/header.html
@@ -7,6 +7,7 @@
      hx-target="{{ hx_target }}"
      {% if !target.is_empty() -%}
        target="{{ target }}"
+       rel="noopener noreferrer"
      {% endif -%}
      data-header-nav-link
      class="header-nav-link mx-3 pb-1 border-0 border-primary-500 text-base font-semibold tracking-widest text-primary-500 uppercase border-b-2 transition-colors

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -25,6 +25,9 @@ test.describe("site header", () => {
       navigation.getByRole("link", { name: "Stats" }),
     ).toHaveAttribute("href", "/stats");
     await expect(
+      navigation.getByRole("link", { name: "Jobs" }),
+    ).toHaveAttribute("href", "https://github.com/sakomws/gitjobs");
+    await expect(
       navigation.getByRole("link", { name: "Docs" }),
     ).toHaveCount(0);
   });
@@ -53,5 +56,8 @@ test.describe("site header", () => {
     await expect(
       userMenu.getByRole("menuitem", { name: "Log in" }),
     ).toHaveAttribute("href", "/log-in");
+    await expect(
+      userMenu.getByRole("menuitem", { name: "Jobs" }),
+    ).toHaveAttribute("href", "https://github.com/sakomws/gitjobs");
   });
 });


### PR DESCRIPTION
## Summary
- Add a Jobs link to the desktop header and mobile user menus.
- Point the link to the GitJobs project at https://github.com/sakomws/gitjobs.
- Add noopener/noreferrer to new-tab header links and update header e2e expectations.

## Test plan
- cargo check -p ocg-server
- git diff --check

Note: focused Playwright e2e execution was attempted but local tests/e2e dependencies are not installed (`@playwright/test` missing).

Made with [Cursor](https://cursor.com)