### PR TITLE
Integrate jobs into GOUP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /tests/e2e/test-results
 /tests/unit/node_modules
 /tmp
+gitjobs/
 Chart.lock
 chart/charts
 ocg-server/dist

--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -48,6 +48,16 @@
 {{ template "common/search_events.sql" }}
 {{ template "common/search_groups.sql" }}
 
+{{ template "jobs/job_summary_json.sql" }}
+{{ template "jobs/add_job.sql" }}
+{{ template "jobs/add_job_application.sql" }}
+{{ template "jobs/delete_job.sql" }}
+{{ template "jobs/get_job_by_slug.sql" }}
+{{ template "jobs/list_user_jobs.sql" }}
+{{ template "jobs/search_jobs.sql" }}
+{{ template "jobs/update_job.sql" }}
+{{ template "jobs/update_job_published.sql" }}
+
 {{ template "alliance/get_alliance_id_by_name.sql" }}
 {{ template "alliance/get_alliance_name_by_id.sql" }}
 {{ template "alliance/get_alliance_recently_added_groups.sql" }}

--- a/database/migrations/functions/jobs/add_job.sql
+++ b/database/migrations/functions/jobs/add_job.sql
@@ -1,0 +1,43 @@
+create or replace function add_job(p_user_id uuid, p_input jsonb, p_tags text[])
+returns uuid language plpgsql as $$
+declare
+    v_job_id uuid;
+    v_slug_base text;
+    v_slug text;
+begin
+    v_slug_base := regexp_replace(lower(trim(p_input->>'title')), '[^a-z0-9]+', '-', 'g');
+    v_slug_base := trim(both '-' from v_slug_base);
+    if v_slug_base = '' then
+        v_slug_base := 'job';
+    end if;
+    v_slug := left(v_slug_base, 60) || '-' || generate_slug(6);
+
+    insert into jobs_job (
+        posted_by_user_id,
+        title,
+        slug,
+        company_name,
+        summary,
+        description,
+        apply_url,
+        location,
+        remote,
+        tags
+    )
+    values (
+        p_user_id,
+        trim(p_input->>'title'),
+        v_slug,
+        trim(p_input->>'company_name'),
+        trim(p_input->>'summary'),
+        trim(p_input->>'description'),
+        trim(p_input->>'apply_url'),
+        nullif(trim(p_input->>'location'), ''),
+        coalesce((p_input->>'remote')::boolean, false),
+        coalesce(p_tags, '{}'::text[])
+    )
+    returning job_id into v_job_id;
+
+    return v_job_id;
+end;
+$$;

--- a/database/migrations/functions/jobs/add_job_application.sql
+++ b/database/migrations/functions/jobs/add_job_application.sql
@@ -1,0 +1,18 @@
+create or replace function add_job_application(p_user_id uuid, p_job_id uuid, p_input jsonb)
+returns void language plpgsql as $$
+begin
+    insert into jobs_application (job_id, applicant_user_id, note)
+    select p_job_id, p_user_id, nullif(trim(p_input->>'note'), '')
+    from jobs_job j
+    where j.job_id = p_job_id
+    and j.published = true
+    and j.posted_by_user_id <> p_user_id
+    on conflict (job_id, applicant_user_id) do update
+    set note = excluded.note,
+        created_at = current_timestamp;
+
+    if not found then
+        raise exception 'job not found';
+    end if;
+end;
+$$;

--- a/database/migrations/functions/jobs/delete_job.sql
+++ b/database/migrations/functions/jobs/delete_job.sql
@@ -1,0 +1,12 @@
+create or replace function delete_job(p_user_id uuid, p_job_id uuid)
+returns void language plpgsql as $$
+begin
+    delete from jobs_job
+    where job_id = p_job_id
+    and posted_by_user_id = p_user_id;
+
+    if not found then
+        raise exception 'job not found';
+    end if;
+end;
+$$;

--- a/database/migrations/functions/jobs/get_job_by_slug.sql
+++ b/database/migrations/functions/jobs/get_job_by_slug.sql
@@ -1,0 +1,25 @@
+create or replace function get_job_by_slug(p_slug text, p_viewer_user_id uuid default null)
+returns jsonb language plpgsql stable as $$
+declare
+    v_job jobs_job;
+begin
+    select *
+    into v_job
+    from jobs_job
+    where slug = p_slug
+    and published = true;
+
+    if v_job.job_id is null then
+        raise exception 'job not found';
+    end if;
+
+    return job_summary_json(v_job) || jsonb_build_object(
+        'viewer_has_applied', exists (
+            select 1
+            from jobs_application ja
+            where ja.job_id = v_job.job_id
+            and ja.applicant_user_id = p_viewer_user_id
+        )
+    );
+end;
+$$;

--- a/database/migrations/functions/jobs/job_summary_json.sql
+++ b/database/migrations/functions/jobs/job_summary_json.sql
@@ -1,0 +1,27 @@
+create or replace function job_summary_json(p_job jobs_job)
+returns jsonb language sql stable as $$
+    select jsonb_build_object(
+        'job_id', p_job.job_id,
+        'title', p_job.title,
+        'slug', p_job.slug,
+        'company_name', p_job.company_name,
+        'summary', p_job.summary,
+        'description', p_job.description,
+        'location', p_job.location,
+        'remote', p_job.remote,
+        'apply_url', p_job.apply_url,
+        'tags', p_job.tags,
+        'published', p_job.published,
+        'application_count', (
+            select count(*)::int
+            from jobs_application ja
+            where ja.job_id = p_job.job_id
+        ),
+        'posted_by_user_id', p_job.posted_by_user_id,
+        'created_at', extract(epoch from p_job.created_at)::bigint,
+        'updated_at', case
+            when p_job.updated_at is null then null
+            else extract(epoch from p_job.updated_at)::bigint
+        end
+    );
+$$;

--- a/database/migrations/functions/jobs/list_user_jobs.sql
+++ b/database/migrations/functions/jobs/list_user_jobs.sql
@@ -1,0 +1,37 @@
+create or replace function list_user_jobs(p_user_id uuid, p_filters jsonb)
+returns jsonb language plpgsql stable as $$
+declare
+    v_limit int := coalesce((p_filters->>'limit')::int, 20);
+    v_offset int := coalesce((p_filters->>'offset')::int, 0);
+    v_total int;
+    v_jobs jsonb;
+begin
+    with matches as (
+        select *
+        from jobs_job
+        where posted_by_user_id = p_user_id
+    ),
+    counted as (
+        select count(*)::int as total from matches
+    ),
+    paged as (
+        select *
+        from matches
+        order by created_at desc, job_id desc
+        limit v_limit
+        offset v_offset
+    )
+    select
+        counted.total,
+        coalesce(jsonb_agg(job_summary_json(paged) order by paged.created_at desc, paged.job_id desc), '[]'::jsonb)
+    into v_total, v_jobs
+    from counted
+    left join paged on true
+    group by counted.total;
+
+    return jsonb_build_object(
+        'jobs', coalesce(v_jobs, '[]'::jsonb),
+        'total', coalesce(v_total, 0)
+    );
+end;
+$$;

--- a/database/migrations/functions/jobs/search_jobs.sql
+++ b/database/migrations/functions/jobs/search_jobs.sql
@@ -1,0 +1,57 @@
+create or replace function search_jobs(p_filters jsonb)
+returns jsonb language plpgsql stable as $$
+declare
+    v_limit int := coalesce((p_filters->>'limit')::int, 20);
+    v_offset int := coalesce((p_filters->>'offset')::int, 0);
+    v_query text := nullif(trim(p_filters->>'query'), '');
+    v_location text := nullif(trim(p_filters->>'location'), '');
+    v_remote boolean := (p_filters->>'remote')::boolean;
+    v_total int;
+    v_jobs jsonb;
+begin
+    with matches as (
+        select j.*
+        from jobs_job j
+        where j.published = true
+        and (
+            v_query is null
+            or j.title ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or j.company_name ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or j.summary ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or j.description ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or exists (
+                select 1
+                from unnest(j.tags) tag
+                where tag ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+        )
+        and (
+            v_location is null
+            or j.location ilike '%' || escape_ilike_pattern(v_location) || '%' escape '\'
+        )
+        and (v_remote is null or j.remote = v_remote)
+    ),
+    counted as (
+        select count(*)::int as total from matches
+    ),
+    paged as (
+        select *
+        from matches
+        order by created_at desc, job_id desc
+        limit v_limit
+        offset v_offset
+    )
+    select
+        counted.total,
+        coalesce(jsonb_agg(job_summary_json(paged) order by paged.created_at desc, paged.job_id desc), '[]'::jsonb)
+    into v_total, v_jobs
+    from counted
+    left join paged on true
+    group by counted.total;
+
+    return jsonb_build_object(
+        'jobs', coalesce(v_jobs, '[]'::jsonb),
+        'total', coalesce(v_total, 0)
+    );
+end;
+$$;

--- a/database/migrations/functions/jobs/update_job.sql
+++ b/database/migrations/functions/jobs/update_job.sql
@@ -1,0 +1,21 @@
+create or replace function update_job(p_user_id uuid, p_job_id uuid, p_input jsonb, p_tags text[])
+returns void language plpgsql as $$
+begin
+    update jobs_job
+    set title = trim(p_input->>'title'),
+        company_name = trim(p_input->>'company_name'),
+        summary = trim(p_input->>'summary'),
+        description = trim(p_input->>'description'),
+        apply_url = trim(p_input->>'apply_url'),
+        location = nullif(trim(p_input->>'location'), ''),
+        remote = coalesce((p_input->>'remote')::boolean, false),
+        tags = coalesce(p_tags, '{}'::text[]),
+        updated_at = current_timestamp
+    where job_id = p_job_id
+    and posted_by_user_id = p_user_id;
+
+    if not found then
+        raise exception 'job not found';
+    end if;
+end;
+$$;

--- a/database/migrations/functions/jobs/update_job_published.sql
+++ b/database/migrations/functions/jobs/update_job_published.sql
@@ -1,0 +1,14 @@
+create or replace function update_job_published(p_user_id uuid, p_job_id uuid, p_published boolean)
+returns void language plpgsql as $$
+begin
+    update jobs_job
+    set published = p_published,
+        updated_at = current_timestamp
+    where job_id = p_job_id
+    and posted_by_user_id = p_user_id;
+
+    if not found then
+        raise exception 'job not found';
+    end if;
+end;
+$$;

--- a/database/migrations/schema/0003_jobs.sql
+++ b/database/migrations/schema/0003_jobs.sql
@@ -1,0 +1,37 @@
+create table jobs_job (
+    job_id uuid default gen_random_uuid() primary key,
+    posted_by_user_id uuid not null references "user" (user_id) on delete cascade,
+    title text not null,
+    slug text not null unique,
+    company_name text not null,
+    summary text not null,
+    description text not null,
+    apply_url text not null,
+    location text,
+    remote boolean default false not null,
+    tags text[] default '{}'::text[] not null,
+    published boolean default true not null,
+    created_at timestamp with time zone default current_timestamp not null,
+    updated_at timestamp with time zone
+);
+
+create index jobs_job_published_created_at_idx
+on jobs_job (published, created_at desc);
+
+create index jobs_job_posted_by_user_id_created_at_idx
+on jobs_job (posted_by_user_id, created_at desc);
+
+create index jobs_job_tags_idx
+on jobs_job using gin (tags);
+
+create table jobs_application (
+    job_application_id uuid default gen_random_uuid() primary key,
+    job_id uuid not null references jobs_job (job_id) on delete cascade,
+    applicant_user_id uuid not null references "user" (user_id) on delete cascade,
+    note text,
+    created_at timestamp with time zone default current_timestamp not null,
+    unique (job_id, applicant_user_id)
+);
+
+create index jobs_application_applicant_user_id_created_at_idx
+on jobs_application (applicant_user_id, created_at desc);

--- a/ocg-server/src/db.rs
+++ b/ocg-server/src/db.rs
@@ -9,9 +9,9 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio_postgres::types::{FromSql, Json, ToSql};
 
 use crate::db::{
-    activity_tracker::DBActivityTracker, auth::DBAuth, common::DBCommon, alliance::DBAlliance,
-    dashboard::DBDashboard, event::DBEvent, group::DBGroup, images::DBImages, meetings::DBMeetings,
-    notifications::DBNotifications, payments::DBPayments, site::DBSite,
+    activity_tracker::DBActivityTracker, alliance::DBAlliance, auth::DBAuth, common::DBCommon,
+    dashboard::DBDashboard, event::DBEvent, group::DBGroup, images::DBImages, jobs::DBJobs,
+    meetings::DBMeetings, notifications::DBNotifications, payments::DBPayments, site::DBSite,
 };
 
 /// Module containing authentication database operations.
@@ -42,6 +42,9 @@ pub(crate) mod group;
 /// Module containing database functionality for storing images.
 pub(crate) mod images;
 
+/// Module containing database functionality for jobs.
+pub(crate) mod jobs;
+
 /// Module containing database functionality for managing meetings.
 pub(crate) mod meetings;
 
@@ -71,6 +74,7 @@ pub(crate) trait DBOperations:
     + DBEvent
     + DBGroup
     + DBImages
+    + DBJobs
     + DBMeetings
     + DBNotifications
     + DBPayments
@@ -89,6 +93,7 @@ impl<T> DBOperations for T where
         + DBEvent
         + DBGroup
         + DBImages
+        + DBJobs
         + DBMeetings
         + DBNotifications
         + DBPayments

--- a/ocg-server/src/db/jobs.rs
+++ b/ocg-server/src/db/jobs.rs
@@ -1,0 +1,152 @@
+//! Database operations for jobs.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_postgres::types::Json;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::PgExecutor,
+    types::jobs::{
+        DashboardJobsFilters, DashboardJobsOutput, JobApplicationInput, JobFull, JobInput,
+        JobsFilters, JobsOutput, parse_tags,
+    },
+};
+
+/// Database operations for the jobs product area.
+#[async_trait]
+pub(crate) trait DBJobs {
+    /// Search published jobs.
+    async fn search_jobs(&self, filters: &JobsFilters) -> Result<JobsOutput>;
+
+    /// Get a public job by slug.
+    async fn get_job_by_slug(&self, slug: &str, viewer_user_id: Option<Uuid>) -> Result<JobFull>;
+
+    /// List jobs owned by a user.
+    async fn list_user_jobs(
+        &self,
+        user_id: Uuid,
+        filters: &DashboardJobsFilters,
+    ) -> Result<DashboardJobsOutput>;
+
+    /// Add a job owned by a user.
+    async fn add_job(&self, user_id: Uuid, input: &JobInput) -> Result<Uuid>;
+
+    /// Update a job owned by a user.
+    async fn update_job(&self, user_id: Uuid, job_id: Uuid, input: &JobInput) -> Result<()>;
+
+    /// Delete a job owned by a user.
+    async fn delete_job(&self, user_id: Uuid, job_id: Uuid) -> Result<()>;
+
+    /// Toggle job publishing status.
+    async fn update_job_published(
+        &self,
+        user_id: Uuid,
+        job_id: Uuid,
+        published: bool,
+    ) -> Result<()>;
+
+    /// Add an application for a job.
+    async fn add_job_application(
+        &self,
+        user_id: Uuid,
+        job_id: Uuid,
+        input: &JobApplicationInput,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+impl<T> DBJobs for T
+where
+    T: PgExecutor + Send + Sync,
+{
+    #[instrument(skip(self, filters), err)]
+    async fn search_jobs(&self, filters: &JobsFilters) -> Result<JobsOutput> {
+        self.fetch_json_one("select search_jobs($1::jsonb)", &[&Json(filters)])
+            .await
+    }
+
+    #[instrument(skip(self), err)]
+    async fn get_job_by_slug(&self, slug: &str, viewer_user_id: Option<Uuid>) -> Result<JobFull> {
+        self.fetch_json_one(
+            "select get_job_by_slug($1::text, $2::uuid)",
+            &[&slug, &viewer_user_id],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, filters), err)]
+    async fn list_user_jobs(
+        &self,
+        user_id: Uuid,
+        filters: &DashboardJobsFilters,
+    ) -> Result<DashboardJobsOutput> {
+        self.fetch_json_one(
+            "select list_user_jobs($1::uuid, $2::jsonb)",
+            &[&user_id, &Json(filters)],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_job(&self, user_id: Uuid, input: &JobInput) -> Result<Uuid> {
+        let tags = parse_tags(input.tags.as_deref());
+        self.fetch_scalar_one(
+            "select add_job($1::uuid, $2::jsonb, $3::text[])",
+            &[&user_id, &Json(input), &tags],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn update_job(&self, user_id: Uuid, job_id: Uuid, input: &JobInput) -> Result<()> {
+        let tags = parse_tags(input.tags.as_deref());
+        self.execute(
+            "select update_job($1::uuid, $2::uuid, $3::jsonb, $4::text[])",
+            &[&user_id, &job_id, &Json(input), &tags],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), err)]
+    async fn delete_job(&self, user_id: Uuid, job_id: Uuid) -> Result<()> {
+        self.execute(
+            "select delete_job($1::uuid, $2::uuid)",
+            &[&user_id, &job_id],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), err)]
+    async fn update_job_published(
+        &self,
+        user_id: Uuid,
+        job_id: Uuid,
+        published: bool,
+    ) -> Result<()> {
+        self.execute(
+            "select update_job_published($1::uuid, $2::uuid, $3::boolean)",
+            &[&user_id, &job_id, &published],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_job_application(
+        &self,
+        user_id: Uuid,
+        job_id: Uuid,
+        input: &JobApplicationInput,
+    ) -> Result<()> {
+        self.execute(
+            "select add_job_application($1::uuid, $2::uuid, $3::jsonb)",
+            &[&user_id, &job_id, &Json(input)],
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -849,6 +849,52 @@ mock! {
     }
 
     #[async_trait]
+    impl crate::db::jobs::DBJobs for DB {
+        async fn search_jobs(
+            &self,
+            filters: &crate::types::jobs::JobsFilters,
+        ) -> Result<crate::types::jobs::JobsOutput>;
+        async fn get_job_by_slug(
+            &self,
+            slug: &str,
+            viewer_user_id: Option<Uuid>,
+        ) -> Result<crate::types::jobs::JobFull>;
+        async fn list_user_jobs(
+            &self,
+            user_id: Uuid,
+            filters: &crate::types::jobs::DashboardJobsFilters,
+        ) -> Result<crate::types::jobs::DashboardJobsOutput>;
+        async fn add_job(
+            &self,
+            user_id: Uuid,
+            input: &crate::types::jobs::JobInput,
+        ) -> Result<Uuid>;
+        async fn update_job(
+            &self,
+            user_id: Uuid,
+            job_id: Uuid,
+            input: &crate::types::jobs::JobInput,
+        ) -> Result<()>;
+        async fn delete_job(
+            &self,
+            user_id: Uuid,
+            job_id: Uuid,
+        ) -> Result<()>;
+        async fn update_job_published(
+            &self,
+            user_id: Uuid,
+            job_id: Uuid,
+            published: bool,
+        ) -> Result<()>;
+        async fn add_job_application(
+            &self,
+            user_id: Uuid,
+            job_id: Uuid,
+            input: &crate::types::jobs::JobApplicationInput,
+        ) -> Result<()>;
+    }
+
+    #[async_trait]
     impl crate::db::meetings::DBMeetings for DB {
         async fn add_meeting(
             &self,

--- a/ocg-server/src/handlers/dashboard.rs
+++ b/ocg-server/src/handlers/dashboard.rs
@@ -1,10 +1,12 @@
 //! HTTP handlers for dashboards functionality.
 
-/// Common dashboard handlers.
-pub(crate) mod common;
 /// Alliance dashboard handlers.
 pub(crate) mod alliance;
+/// Common dashboard handlers.
+pub(crate) mod common;
 /// Group dashboard handlers.
 pub(crate) mod group;
+/// Jobs dashboard handlers.
+pub(crate) mod jobs;
 /// User dashboard handlers.
 pub(crate) mod user;

--- a/ocg-server/src/handlers/dashboard/jobs.rs
+++ b/ocg-server/src/handlers/dashboard/jobs.rs
@@ -1,0 +1,138 @@
+//! HTTP handlers for the jobs dashboard.
+
+use askama::Template;
+use axum::{
+    extract::{Path, RawQuery, State},
+    http::StatusCode,
+    response::{Html, IntoResponse},
+};
+use axum_messages::Messages;
+use garde::Validate;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, ValidatedForm},
+    },
+    router::serde_qs_config,
+    templates::{PageId, auth::User, dashboard::jobs::Page},
+    types::{
+        jobs::{DashboardJobsFilters, JobInput},
+        pagination::NavigationLinks,
+    },
+};
+
+const DASHBOARD_JOBS_URL: &str = "/dashboard/jobs";
+
+/// Render the jobs dashboard.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    auth_session: crate::auth::AuthSession,
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, HandlerError> {
+    let filters = parse_filters(raw_query.as_deref().unwrap_or_default())?;
+    let output = db.list_user_jobs(user.user_id, &filters).await?;
+    let site_settings = db.get_site_settings().await?;
+    let navigation_links = NavigationLinks::from_filters(
+        &filters,
+        output.total,
+        DASHBOARD_JOBS_URL,
+        DASHBOARD_JOBS_URL,
+    )?;
+
+    let template = Page {
+        messages: messages.into_iter().collect(),
+        page_id: PageId::JobsDashboard,
+        path: DASHBOARD_JOBS_URL.to_string(),
+        site_settings,
+        user: User::from_session(auth_session).await?,
+        filters,
+        jobs: output.jobs,
+        total: output.total,
+        navigation_links,
+    };
+
+    Ok(Html(template.render()?))
+}
+
+/// Add a job.
+#[instrument(skip_all, err)]
+pub(crate) async fn add(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<JobInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_job(user.user_id, &input).await?;
+    messages.success("Job posted.");
+    Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+}
+
+/// Update a job.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(job_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<JobInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_job(user.user_id, job_id, &input).await?;
+    messages.success("Job updated.");
+    Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+}
+
+/// Delete a job.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(job_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_job(user.user_id, job_id).await?;
+    messages.success("Job deleted.");
+    Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+}
+
+/// Publish a job.
+#[instrument(skip_all, err)]
+pub(crate) async fn publish(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(job_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_job_published(user.user_id, job_id, true).await?;
+    messages.success("Job published.");
+    Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+}
+
+/// Unpublish a job.
+#[instrument(skip_all, err)]
+pub(crate) async fn unpublish(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(job_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_job_published(user.user_id, job_id, false).await?;
+    messages.success("Job unpublished.");
+    Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+}
+
+fn parse_filters(raw_query: &str) -> Result<DashboardJobsFilters, HandlerError> {
+    let filters: DashboardJobsFilters = if raw_query.is_empty() {
+        DashboardJobsFilters::default()
+    } else {
+        serde_qs_config().deserialize_str(raw_query)?
+    };
+    filters.validate()?;
+    Ok(filters)
+}

--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -2,5 +2,6 @@
 
 pub(crate) mod explore;
 pub(crate) mod home;
+pub(crate) mod jobs;
 pub(crate) mod not_found;
 pub(crate) mod stats;

--- a/ocg-server/src/handlers/site/jobs.rs
+++ b/ocg-server/src/handlers/site/jobs.rs
@@ -1,0 +1,113 @@
+//! HTTP handlers for the public jobs pages.
+
+use askama::Template;
+use axum::{
+    extract::{Path, RawQuery, State},
+    http::StatusCode,
+    response::{Html, IntoResponse},
+};
+use axum_messages::Messages;
+use garde::Validate;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    auth::AuthSession,
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extend_public_shared_cache_headers,
+        extractors::{CurrentUser, ValidatedForm},
+    },
+    router::serde_qs_config,
+    templates::{PageId, auth::User, site::jobs},
+    types::{
+        jobs::{JobApplicationInput, JobsFilters},
+        pagination::NavigationLinks,
+    },
+};
+
+const JOBS_URL: &str = "/jobs";
+
+/// Render the public jobs listing page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, HandlerError> {
+    let filters = parse_filters(raw_query.as_deref().unwrap_or_default())?;
+    let output = db.search_jobs(&filters).await?;
+    let site_settings = db.get_site_settings().await?;
+    let navigation_links =
+        NavigationLinks::from_filters(&filters, output.total, JOBS_URL, JOBS_URL)?;
+
+    let template = jobs::Page {
+        page_id: PageId::SiteJobs,
+        path: JOBS_URL.to_string(),
+        site_settings,
+        user: User::from_session(auth_session).await?,
+        filters,
+        jobs: output.jobs,
+        total: output.total,
+        navigation_links,
+    };
+
+    Ok((
+        extend_public_shared_cache_headers(&[])?,
+        Html(template.render()?),
+    ))
+}
+
+/// Render a public job details page.
+#[instrument(skip_all, err)]
+pub(crate) async fn details(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+    Path(slug): Path<String>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let viewer_user_id = auth_session.user.as_ref().map(|user| user.user_id);
+    let job = db.get_job_by_slug(&slug, viewer_user_id).await?;
+    let site_settings = db.get_site_settings().await?;
+
+    let template = jobs::DetailsPage {
+        page_id: PageId::SiteJobs,
+        path: format!("{JOBS_URL}/{slug}"),
+        site_settings,
+        user: User::from_session(auth_session).await?,
+        job,
+    };
+
+    Ok((
+        extend_public_shared_cache_headers(&[])?,
+        Html(template.render()?),
+    ))
+}
+
+/// Apply to a job as the current user.
+#[instrument(skip_all, err)]
+pub(crate) async fn apply(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(job_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<JobApplicationInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_job_application(user.user_id, job_id, &input).await?;
+    messages.success("Application saved.");
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-job-details")],
+    ))
+}
+
+fn parse_filters(raw_query: &str) -> Result<JobsFilters, HandlerError> {
+    let filters: JobsFilters = if raw_query.is_empty() {
+        JobsFilters::default()
+    } else {
+        serde_qs_config().deserialize_str(raw_query)?
+    };
+    filters.validate()?;
+    Ok(filters)
+}

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -33,8 +33,9 @@ use crate::{
     config::{HttpServerConfig, MeetingsConfig, PaymentsConfig},
     db::DynDB,
     handlers::{
+        alliance,
         auth::{self, LOG_IN_URL},
-        alliance, event, group, images, meetings, payments, site,
+        event, group, images, meetings, payments, site,
     },
     services::{
         images::DynImageStorage, notifications::DynNotificationsManager,
@@ -203,10 +204,7 @@ pub(crate) async fn setup(
             "/{alliance}/event/{event_id}/cfs-submissions",
             post(event::submit_cfs_submission),
         )
-        .route(
-            "/{alliance}/group/{group_id}/join",
-            post(group::join_group),
-        )
+        .route("/{alliance}/group/{group_id}/join", post(group::join_group))
         .route(
             "/{alliance}/group/{group_id}/leave",
             delete(group::leave_group),
@@ -215,6 +213,7 @@ pub(crate) async fn setup(
             "/{alliance}/group/{group_id}/membership",
             get(group::membership_status),
         )
+        .route("/jobs/{job_id}/apply", post(site::jobs::apply))
         // Protected dashboard routes
         .route(
             "/dashboard/account/update/details",
@@ -223,6 +222,23 @@ pub(crate) async fn setup(
         .route(
             "/dashboard/account/update/password",
             put(auth::update_user_password),
+        )
+        .route(
+            "/dashboard/jobs",
+            get(crate::handlers::dashboard::jobs::page).post(crate::handlers::dashboard::jobs::add),
+        )
+        .route(
+            "/dashboard/jobs/{job_id}",
+            put(crate::handlers::dashboard::jobs::update)
+                .delete(crate::handlers::dashboard::jobs::delete),
+        )
+        .route(
+            "/dashboard/jobs/{job_id}/publish",
+            put(crate::handlers::dashboard::jobs::publish),
+        )
+        .route(
+            "/dashboard/jobs/{job_id}/unpublish",
+            put(crate::handlers::dashboard::jobs::unpublish),
         )
         .nest("/dashboard/alliance", alliance_dashboard_router)
         .nest("/dashboard/group", group_dashboard_router)
@@ -268,6 +284,8 @@ pub(crate) async fn setup(
         .route("/images/og/{file_name}", get(images::serve_open_graph))
         .route("/images/{file_name}", get(images::serve))
         .route("/log-in", get(auth::log_in_page))
+        .route("/jobs", get(site::jobs::page))
+        .route("/jobs/{slug}", get(site::jobs::details))
         .route("/stats", get(site::stats::page))
         // Alliance-prefixed public routes
         .route("/{alliance}", get(alliance::page))
@@ -285,10 +303,7 @@ pub(crate) async fn setup(
             get(event::page),
         )
         // Page view tracking routes
-        .route(
-            "/alliances/{alliance_id}/views",
-            post(alliance::track_view),
-        )
+        .route("/alliances/{alliance_id}/views", post(alliance::track_view))
         .route("/events/{event_id}/views", post(event::track_view))
         .route("/groups/{group_id}/views", post(group::track_view))
         .fallback(site::not_found::page);

--- a/ocg-server/src/templates.rs
+++ b/ocg-server/src/templates.rs
@@ -6,10 +6,10 @@
 
 use serde::{Deserialize, Serialize};
 
-/// Authentication pages templates.
-pub(crate) mod auth;
 /// Alliance site templates.
 pub(crate) mod alliance;
+/// Authentication pages templates.
+pub(crate) mod auth;
 /// Dashboard templates.
 pub(crate) mod dashboard;
 /// Event page templates.
@@ -35,10 +35,12 @@ pub(crate) enum PageId {
     Event,
     Group,
     GroupDashboard,
+    JobsDashboard,
     LogIn,
     SignUp,
     SiteExplore,
     SiteHome,
+    SiteJobs,
     SiteNotFound,
     SiteStats,
     UserDashboard,

--- a/ocg-server/src/templates/dashboard.rs
+++ b/ocg-server/src/templates/dashboard.rs
@@ -1,11 +1,13 @@
 //! Templates for dashboard pages.
 
-/// Shared dashboard audit log templates.
-pub(crate) mod audit;
 /// Alliance dashboard templates.
 pub(crate) mod alliance;
+/// Shared dashboard audit log templates.
+pub(crate) mod audit;
 /// Group dashboard templates.
 pub(crate) mod group;
+/// Jobs dashboard templates.
+pub(crate) mod jobs;
 /// User dashboard templates.
 pub(crate) mod user;
 

--- a/ocg-server/src/templates/dashboard/jobs.rs
+++ b/ocg-server/src/templates/dashboard/jobs.rs
@@ -1,0 +1,38 @@
+//! Templates and types for the jobs dashboard.
+
+use askama::Template;
+use axum_messages::{Level, Message};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{PageId, auth::User, filters, helpers::user_initials},
+    types::{
+        jobs::{DashboardJobsFilters, JobSummary},
+        pagination::NavigationLinks,
+        site::SiteSettings,
+    },
+};
+
+/// Jobs dashboard page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/jobs.html")]
+pub(crate) struct Page {
+    /// Flash messages.
+    pub messages: Vec<Message>,
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// Pagination filters.
+    pub filters: DashboardJobsFilters,
+    /// User-owned jobs.
+    pub jobs: Vec<JobSummary>,
+    /// Total jobs.
+    pub total: usize,
+    /// Pagination links.
+    pub navigation_links: NavigationLinks,
+}

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -4,6 +4,8 @@
 pub(crate) mod explore;
 /// Templates for the home page.
 pub(crate) mod home;
+/// Templates for the jobs pages.
+pub(crate) mod jobs;
 /// Templates for the not found page.
 pub(crate) mod not_found;
 /// Templates for the stats page.

--- a/ocg-server/src/templates/site/jobs.rs
+++ b/ocg-server/src/templates/site/jobs.rs
@@ -1,0 +1,51 @@
+//! Templates and types for the public jobs pages.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{PageId, auth::User, filters, helpers::user_initials},
+    types::{
+        jobs::{JobFull, JobSummary, JobsFilters},
+        pagination::NavigationLinks,
+        site::SiteSettings,
+    },
+};
+
+/// Public jobs listing page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/jobs/page.html")]
+pub(crate) struct Page {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// Search filters.
+    pub filters: JobsFilters,
+    /// Matching jobs.
+    pub jobs: Vec<JobSummary>,
+    /// Total matching jobs.
+    pub total: usize,
+    /// Pagination links.
+    pub navigation_links: NavigationLinks,
+}
+
+/// Public job details page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/jobs/details.html")]
+pub(crate) struct DetailsPage {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// Job details.
+    pub job: JobFull,
+}

--- a/ocg-server/src/types.rs
+++ b/ocg-server/src/types.rs
@@ -3,6 +3,7 @@
 pub mod alliance;
 pub mod event;
 pub mod group;
+pub(crate) mod jobs;
 pub mod location;
 pub mod pagination;
 pub mod payments;

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -1,0 +1,178 @@
+//! Jobs domain types.
+
+use chrono::{DateTime, Utc};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use uuid::Uuid;
+
+use crate::{
+    templates::dashboard,
+    types::pagination::{Pagination, ToRawQuery},
+    validation::{
+        MAX_LEN_DESCRIPTION, MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_ENTITY_NAME, MAX_LEN_M,
+        MAX_LEN_TAG, MAX_PAGINATION_LIMIT, trimmed_non_empty, trimmed_non_empty_opt,
+    },
+};
+
+/// Public jobs search filters.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Validate)]
+pub(crate) struct JobsFilters {
+    /// Free-text search query.
+    #[garde(length(max = MAX_LEN_M))]
+    pub query: Option<String>,
+    /// Location filter.
+    #[garde(length(max = MAX_LEN_M))]
+    pub location: Option<String>,
+    /// Remote-only filter.
+    #[garde(skip)]
+    pub remote: Option<bool>,
+    /// Number of results per page.
+    #[serde(default = "dashboard::default_limit")]
+    #[garde(range(max = MAX_PAGINATION_LIMIT))]
+    pub limit: Option<usize>,
+    /// Pagination offset.
+    #[serde(default = "dashboard::default_offset")]
+    #[garde(skip)]
+    pub offset: Option<usize>,
+}
+
+crate::impl_pagination_and_raw_query!(JobsFilters, limit, offset);
+
+/// User jobs dashboard filters.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Validate)]
+pub(crate) struct DashboardJobsFilters {
+    /// Number of results per page.
+    #[serde(default = "dashboard::default_limit")]
+    #[garde(range(max = MAX_PAGINATION_LIMIT))]
+    pub limit: Option<usize>,
+    /// Pagination offset.
+    #[serde(default = "dashboard::default_offset")]
+    #[garde(skip)]
+    pub offset: Option<usize>,
+}
+
+crate::impl_pagination_and_raw_query!(DashboardJobsFilters, limit, offset);
+
+/// Job form input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct JobInput {
+    /// Job title.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub title: String,
+    /// Employer/company name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub company_name: String,
+    /// Short summary.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub summary: String,
+    /// Full job description.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION))]
+    pub description: String,
+    /// Apply URL.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub apply_url: String,
+    /// Location label.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub location: Option<String>,
+    /// Remote-friendly role.
+    #[garde(skip)]
+    pub remote: Option<bool>,
+    /// Job tags, comma-separated.
+    #[garde(length(max = MAX_LEN_M))]
+    pub tags: Option<String>,
+}
+
+/// Application form input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct JobApplicationInput {
+    /// Optional note to the job poster.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub note: Option<String>,
+}
+
+/// Job search output.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct JobsOutput {
+    /// Matching jobs.
+    pub jobs: Vec<JobSummary>,
+    /// Total number of matching jobs.
+    pub total: usize,
+}
+
+/// User dashboard jobs output.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct DashboardJobsOutput {
+    /// Jobs owned by the current user.
+    pub jobs: Vec<JobSummary>,
+    /// Total number of matching jobs.
+    pub total: usize,
+}
+
+/// Public job summary.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JobSummary {
+    /// Job identifier.
+    pub job_id: Uuid,
+    /// Job title.
+    pub title: String,
+    /// URL slug.
+    pub slug: String,
+    /// Employer/company name.
+    pub company_name: String,
+    /// Short summary.
+    pub summary: String,
+    /// Full job description.
+    pub description: String,
+    /// Location label.
+    pub location: Option<String>,
+    /// Remote-friendly role.
+    pub remote: bool,
+    /// Apply URL.
+    pub apply_url: String,
+    /// Tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Whether the job is published.
+    pub published: bool,
+    /// Number of applications.
+    #[serde(default)]
+    pub application_count: i32,
+    /// Poster user identifier.
+    pub posted_by_user_id: Uuid,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    /// Last update time.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Full public job details.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JobFull {
+    /// Summary fields.
+    #[serde(flatten)]
+    pub summary: JobSummary,
+    /// Whether the viewer already applied.
+    #[serde(default)]
+    pub viewer_has_applied: bool,
+}
+
+/// Tags parsed from comma-separated form input.
+pub(crate) fn parse_tags(input: Option<&str>) -> Vec<String> {
+    input
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty())
+        .take(12)
+        .map(|tag| tag.chars().take(MAX_LEN_TAG).collect())
+        .collect()
+}

--- a/ocg-server/static/js/site/jobs/details.js
+++ b/ocg-server/static/js/site/jobs/details.js
@@ -1,0 +1,3 @@
+document.body.addEventListener("refresh-job-details", () => {
+  window.location.reload();
+});

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -28,14 +28,14 @@
         {{ header::link(content = "Home", href = "/", current_path = path) -}}
         {{ header::link(content = "Explore", href = explore_events, current_path = path, path = "/explore") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
-        {{ header::link(content = "Jobs", href = "https://github.com/sakomws/gitjobs", current_path = path, hx_boost = "false", hx_target = "", target = "_blank") -}}
+        {{ header::link(content = "Jobs", href = "/jobs", current_path = path, path = "/jobs") -}}
       </div>
       {# End desktop links -#}
     </div>
 
     {# Desktop user menu -#}
     <div class="flex flex-1 justify-end">
-      {% if page_id == PageId::SiteHome || page_id == PageId::SiteExplore || page_id == PageId::SiteStats || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
+      {% if page_id == PageId::SiteHome || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteStats || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
         <div hx-get="/section/user-menu"
              hx-trigger="load"
              hx-target="this"
@@ -126,14 +126,13 @@
           </li>
 
           <li class="lg:hidden" role="none">
-            <a href="https://github.com/sakomws/gitjobs"
-               hx-boost="false"
-               target="_blank"
-               rel="noopener noreferrer"
+            <a href="/jobs"
+               hx-boost="true"
+               hx-target="body"
                class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
                role="menuitem">
               <div class="flex items-center">
-                <div class="svg-icon size-4 icon-external-link bg-stone-600"></div>
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Jobs</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
@@ -200,6 +199,19 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-user-small bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">User Dashboard</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+          <li class="hidden lg:block" role="none">
+            <a href="/dashboard/jobs"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Jobs Dashboard</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -279,14 +291,13 @@
 
           <li class="lg:hidden border-b border-stone-200 mb-2 pb-2"
               role="none">
-            <a href="https://github.com/sakomws/gitjobs"
-               hx-boost="false"
-               target="_blank"
-               rel="noopener noreferrer"
+            <a href="/jobs"
+               hx-boost="true"
+               hx-target="body"
                class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
                role="menuitem">
               <div class="flex items-center">
-                <div class="svg-icon size-4 icon-external-link bg-stone-600"></div>
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Jobs</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -1,0 +1,205 @@
+{% extends "dashboard/dashboard_base.html" -%}
+{% import "macros/dashboard.html" as dashboard -%}
+{% import "macros/feedback.html" as feedback -%}
+{% import "macros/pagination.html" as pagination -%}
+{% import "macros/ui.html" as ui -%}
+
+{% block menu -%}
+  <div class="flex justify-between items-center mt-3 mb-6 px-3 lg:px-5">
+    <div class="font-semibold text-stone-900 text-sm lg:text-lg">Jobs Dashboard</div>
+  </div>
+
+  <div class="max-h-full w-full flex flex-col flex-1 space-y-5 mb-5 overflow-y-auto px-3 lg:px-5">
+    <div class="leading-10 grid gap-y-0.5">
+      {{ dashboard::menu_title(text = "Jobs", extra_styles = "py-1.5") -}}
+      {{ dashboard::menu_item(name = "My Jobs", icon = "search", is_active = true, href = "/dashboard/jobs") -}}
+      {{ dashboard::menu_item(name = "Public Jobs", icon = "external-link", is_active = false, href = "/jobs") -}}
+    </div>
+    <div class="leading-10 pt-6 border-t border-stone-200 grid gap-y-0.5">
+      {{ dashboard::menu_title(text = "GOUP", extra_styles = "py-1.5") -}}
+      {{ dashboard::menu_item(name = "User Dashboard", icon = "user-small", is_active = false, href = "/dashboard/user") -}}
+    </div>
+  </div>
+{% endblock menu -%}
+
+{% block dashboard_main -%}
+  <div class="p-4 sm:p-6 lg:p-12">
+    {{ dashboard::page_title(title = "Jobs", description = "Post and manage roles shown on the GOUP jobs board.") -}}
+
+    {% if !messages.is_empty() -%}
+      <div class="mt-6">{{ feedback::alerts(messages) -}}</div>
+    {% endif -%}
+
+    <section class="mt-8 rounded-2xl border border-stone-200 bg-stone-50 p-5">
+      <h2 class="text-lg font-semibold text-stone-950">Post a job</h2>
+      <form class="mt-4 grid gap-4"
+            action="/dashboard/jobs"
+            method="post"
+            hx-post="/dashboard/jobs"
+            hx-target="body">
+        <div class="grid gap-4 lg:grid-cols-2">
+          <div>
+            <label class="label" for="new-job-title">Title</label>
+            <input id="new-job-title" name="title" class="input" required />
+          </div>
+          <div>
+            <label class="label" for="new-job-company">Company</label>
+            <input id="new-job-company" name="company_name" class="input" required />
+          </div>
+        </div>
+        <div>
+          <label class="label" for="new-job-summary">Summary</label>
+          <input id="new-job-summary" name="summary" class="input" required maxlength="500" />
+        </div>
+        <div>
+          <label class="label" for="new-job-description">Description</label>
+          <textarea id="new-job-description" name="description" rows="6" class="input" required></textarea>
+        </div>
+        <div class="grid gap-4 lg:grid-cols-3">
+          <div>
+            <label class="label" for="new-job-apply-url">Apply URL</label>
+            <input id="new-job-apply-url" name="apply_url" class="input" required />
+          </div>
+          <div>
+            <label class="label" for="new-job-location">Location</label>
+            <input id="new-job-location" name="location" class="input" />
+          </div>
+          <div>
+            <label class="label" for="new-job-tags">Tags</label>
+            <input id="new-job-tags" name="tags" class="input" placeholder="Rust, Platform, DevOps" />
+          </div>
+        </div>
+        <label class="inline-flex items-center gap-2 text-sm text-stone-700">
+          <input type="checkbox"
+                 name="remote"
+                 value="true"
+                 class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
+          Remote-friendly role
+        </label>
+        <div>
+          <button class="btn-primary" type="submit">Post job</button>
+        </div>
+      </form>
+    </section>
+
+    <div class="my-8 flex items-center justify-between">
+      <div class="text-sm text-stone-600">
+        {{ pagination::range_display(offset = filters.offset.unwrap_or(0), count = jobs.len(), total = total, label = "job") }}
+      </div>
+    </div>
+
+    {% if jobs.is_empty() -%}
+      <div class="rounded-2xl border border-dashed border-stone-300 bg-white px-6 py-16 text-center">
+        <h2 class="text-lg font-semibold text-stone-900">No jobs posted yet</h2>
+        <p class="mt-2 text-sm text-stone-600">Use the form above to add your first role.</p>
+      </div>
+    {% else -%}
+      <div class="grid gap-5">
+        {% for job in jobs -%}
+          <article class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+            <div class="mb-4 flex items-start justify-between gap-4">
+              <div>
+                <div class="flex flex-wrap items-center gap-2">
+                  <h2 class="text-lg font-semibold text-stone-950">{{ job.title }}</h2>
+                  {% if job.published -%}
+                    <span class="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">Published</span>
+                  {% else -%}
+                    <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">Draft</span>
+                  {% endif -%}
+                </div>
+                <p class="mt-1 text-sm text-stone-600">{{ job.company_name }} · {{ job.application_count }} application{% if job.application_count != 1 %}s{% endif %}</p>
+              </div>
+              <a class="text-sm font-semibold text-primary-700 hover:text-primary-900"
+                 href="/jobs/{{ job.slug }}">View</a>
+            </div>
+
+            <form class="grid gap-4"
+                  hx-put="/dashboard/jobs/{{ job.job_id }}"
+                  hx-target="body">
+              <div class="grid gap-4 lg:grid-cols-2">
+                <div>
+                  <label class="label" for="job-title-{{ job.job_id }}">Title</label>
+                  <input id="job-title-{{ job.job_id }}" name="title" class="input" value="{{ job.title }}" required />
+                </div>
+                <div>
+                  <label class="label" for="job-company-{{ job.job_id }}">Company</label>
+                  <input id="job-company-{{ job.job_id }}"
+                         name="company_name"
+                         class="input"
+                         value="{{ job.company_name }}"
+                         required />
+                </div>
+              </div>
+              <div>
+                <label class="label" for="job-summary-{{ job.job_id }}">Summary</label>
+                <input id="job-summary-{{ job.job_id }}"
+                       name="summary"
+                       class="input"
+                       value="{{ job.summary }}"
+                       required
+                       maxlength="500" />
+              </div>
+              <div>
+                <label class="label" for="job-description-{{ job.job_id }}">Description</label>
+                <textarea id="job-description-{{ job.job_id }}" name="description" rows="5" class="input" required>{{ job.description }}</textarea>
+              </div>
+              <div class="grid gap-4 lg:grid-cols-3">
+                <div>
+                  <label class="label" for="job-apply-url-{{ job.job_id }}">Apply URL</label>
+                  <input id="job-apply-url-{{ job.job_id }}"
+                         name="apply_url"
+                         class="input"
+                         value="{{ job.apply_url }}"
+                         required />
+                </div>
+                <div>
+                  <label class="label" for="job-location-{{ job.job_id }}">Location</label>
+                  <input id="job-location-{{ job.job_id }}"
+                         name="location"
+                         class="input"
+                         value="{{ job.location.as_deref().unwrap_or("") }}" />
+                </div>
+                <div>
+                  <label class="label" for="job-tags-{{ job.job_id }}">Tags</label>
+                  <input id="job-tags-{{ job.job_id }}"
+                         name="tags"
+                         class="input"
+                         value="{{ job.tags.join(", ") }}" />
+                </div>
+              </div>
+              <label class="inline-flex items-center gap-2 text-sm text-stone-700">
+                <input type="checkbox"
+                       name="remote"
+                       value="true"
+                       {% if job.remote %}checked{% endif %}
+                       class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
+                Remote-friendly role
+              </label>
+              <div class="flex flex-wrap gap-2">
+                <button class="btn-primary" type="submit">Save changes</button>
+                {% if job.published -%}
+                  <button class="btn-secondary"
+                          type="button"
+                          hx-put="/dashboard/jobs/{{ job.job_id }}/unpublish"
+                          hx-target="body">Unpublish</button>
+                {% else -%}
+                  <button class="btn-secondary"
+                          type="button"
+                          hx-put="/dashboard/jobs/{{ job.job_id }}/publish"
+                          hx-target="body">Publish</button>
+                {% endif -%}
+                <button class="btn-tertiary"
+                        type="button"
+                        hx-delete="/dashboard/jobs/{{ job.job_id }}"
+                        hx-confirm="Delete this job?"
+                        hx-target="body">Delete</button>
+              </div>
+            </form>
+          </article>
+        {% endfor -%}
+      </div>
+
+      {{ pagination::navigation_links(links = navigation_links, hx_target = "body") }}
+    {% endif -%}
+  </div>
+{% endblock dashboard_main -%}

--- a/ocg-server/templates/site/jobs/details.html
+++ b/ocg-server/templates/site/jobs/details.html
@@ -1,0 +1,87 @@
+{% extends "common/base.html" -%}
+
+{% block scripts -%}
+  <script type="module" src="/static/js/site/jobs/details.js"></script>
+{% endblock scripts -%}
+
+{% block jumbotron -%}
+  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
+    <a class="mb-5 inline-flex text-sm font-medium text-primary-700 hover:text-primary-900"
+       href="/jobs">Back to jobs</a>
+    <div class="relative max-w-4xl">
+      <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">{{ job.summary.company_name }}</p>
+      <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
+        {{ job.summary.title }}
+      </h1>
+      <div class="flex flex-wrap gap-2">
+        {% if job.summary.remote -%}
+          <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">Remote</span>
+        {% endif -%}
+        {% if let Some(location) = &job.summary.location -%}
+          <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">{{ location }}</span>
+        {% endif -%}
+        <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">Posted {{ job.summary.created_at.format("%b %d, %Y") }}</span>
+      </div>
+    </div>
+  </div>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto grid max-w-7xl gap-8 p-4 pb-12 sm:p-6 lg:grid-cols-[1fr_340px] lg:p-8 lg:pb-16">
+    <article class="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm">
+      <p class="mb-8 text-lg/8 text-stone-700">{{ job.summary.summary }}</p>
+
+      {% if !job.summary.tags.is_empty() -%}
+        <div class="mb-8 flex flex-wrap gap-2">
+          {% for tag in job.summary.tags -%}
+            <span class="rounded-full bg-stone-50 px-2.5 py-1 text-xs font-medium text-stone-700 ring-1 ring-inset ring-stone-200">{{ tag }}</span>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+
+      <h2 class="mb-3 text-xl font-semibold text-stone-950">About the role</h2>
+      <div class="whitespace-pre-line text-sm/7 text-stone-700">{{ job.summary.description }}</div>
+    </article>
+
+    <aside class="h-fit rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+      <h2 class="text-lg font-semibold text-stone-950">Apply</h2>
+      <p class="mt-2 text-sm/6 text-stone-600">
+        Use the employer application link or save your interest with GOUP.
+      </p>
+
+      <a class="btn-primary mt-5 w-full justify-center"
+         href="{{ job.summary.apply_url }}"
+         target="_blank"
+         rel="noopener noreferrer"
+         hx-boost="false">Apply on company site</a>
+
+      {% if user.logged_in -%}
+        {% if job.viewer_has_applied -%}
+          <div class="mt-5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
+            Your interest has been saved.
+          </div>
+        {% else -%}
+          <form class="mt-5"
+                hx-post="/jobs/{{ job.summary.job_id }}/apply"
+                hx-swap="none"
+                hx-disabled-elt="button">
+            <label class="mb-2 block text-sm font-medium text-stone-700" for="job-application-note">
+              Optional note
+            </label>
+            <textarea id="job-application-note"
+                      name="note"
+                      rows="4"
+                      class="input"
+                      placeholder="Share a short note for the poster"></textarea>
+            <button class="btn-secondary mt-3 w-full justify-center" type="submit">
+              Save interest
+            </button>
+          </form>
+        {% endif -%}
+      {% else -%}
+        <a class="btn-secondary mt-3 w-full justify-center"
+           href="/log-in?next_url=/jobs/{{ job.summary.slug }}">Log in to save interest</a>
+      {% endif -%}
+    </aside>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/jobs/page.html
+++ b/ocg-server/templates/site/jobs/page.html
@@ -1,0 +1,105 @@
+{% extends "common/base.html" -%}
+{% import "macros/pagination.html" as pagination -%}
+
+{% block jumbotron -%}
+  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
+    <div class="relative max-w-3xl">
+      <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Jobs</p>
+      <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
+        Open roles for builders in the GOUP Alliance
+      </h1>
+      <p class="max-w-2xl text-base/7 text-stone-600">
+        Discover jobs from alliance members, partners, and open source teams.
+      </p>
+    </div>
+  </div>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
+    <form method="get"
+          action="/jobs"
+          class="mb-8 grid gap-3 rounded-2xl border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_240px_auto_auto]">
+      <label class="sr-only" for="jobs-query">Search jobs</label>
+      <input id="jobs-query"
+             name="query"
+             value="{{ filters.query.as_deref().unwrap_or("") }}"
+             class="input"
+             placeholder="Search title, company, summary, or tags" />
+
+      <label class="sr-only" for="jobs-location">Location</label>
+      <input id="jobs-location"
+             name="location"
+             value="{{ filters.location.as_deref().unwrap_or("") }}"
+             class="input"
+             placeholder="Location" />
+
+      <label class="inline-flex items-center gap-2 rounded-lg border border-stone-200 px-3 text-sm text-stone-700">
+        <input type="checkbox"
+               name="remote"
+               value="true"
+               {% if filters.remote == Some(true) %}checked{% endif %}
+               class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
+        Remote
+      </label>
+
+      <button class="btn-primary" type="submit">Search</button>
+    </form>
+
+    <div class="mb-5 flex items-center justify-between gap-3">
+      <div class="text-sm text-stone-600">
+        {{ pagination::range_display(offset = filters.offset.unwrap_or(0), count = jobs.len(), total = total, label = "job") }}
+      </div>
+      {% if user.logged_in -%}
+        <a class="btn-secondary" href="/dashboard/jobs">Post a job</a>
+      {% else -%}
+        <a class="btn-secondary" href="/log-in?next_url=/dashboard/jobs">Post a job</a>
+      {% endif -%}
+    </div>
+
+    {% if jobs.is_empty() -%}
+      <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-6 py-16 text-center">
+        <h2 class="text-lg font-semibold text-stone-900">No jobs found</h2>
+        <p class="mt-2 text-sm text-stone-600">Try a broader search or clear the filters.</p>
+      </div>
+    {% else -%}
+      <div class="grid gap-4">
+        {% for job in jobs -%}
+          <article class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm transition hover:border-primary-200 hover:shadow-md">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <div class="mb-2 flex flex-wrap items-center gap-2">
+                  <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">{{ job.company_name }}</span>
+                  {% if job.remote -%}
+                    <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">Remote</span>
+                  {% endif -%}
+                  {% if let Some(location) = &job.location -%}
+                    <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">{{ location }}</span>
+                  {% endif -%}
+                </div>
+                <h2 class="text-xl font-semibold text-stone-950">
+                  <a class="hover:text-primary-700" href="/jobs/{{ job.slug }}">{{ job.title }}</a>
+                </h2>
+                <p class="mt-2 max-w-3xl text-sm/6 text-stone-600">{{ job.summary }}</p>
+                {% if !job.tags.is_empty() -%}
+                  <div class="mt-4 flex flex-wrap gap-2">
+                    {% for tag in job.tags -%}
+                      <span class="rounded-full bg-stone-50 px-2.5 py-1 text-xs font-medium text-stone-700 ring-1 ring-inset ring-stone-200">{{ tag }}</span>
+                    {% endfor -%}
+                  </div>
+                {% endif -%}
+              </div>
+              <div class="shrink-0 text-sm text-stone-500 lg:text-right">
+                <div>Posted {{ job.created_at.format("%b %d, %Y") }}</div>
+                <a class="mt-3 inline-flex font-semibold text-primary-700 hover:text-primary-900"
+                   href="/jobs/{{ job.slug }}">View role</a>
+              </div>
+            </div>
+          </article>
+        {% endfor -%}
+      </div>
+
+      {{ pagination::navigation_links(links = navigation_links, hx_target = "body") }}
+    {% endif -%}
+  </div>
+{% endblock content -%}

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -26,7 +26,7 @@ test.describe("site header", () => {
     ).toHaveAttribute("href", "/stats");
     await expect(
       navigation.getByRole("link", { name: "Jobs" }),
-    ).toHaveAttribute("href", "https://github.com/sakomws/gitjobs");
+    ).toHaveAttribute("href", "/jobs");
     await expect(
       navigation.getByRole("link", { name: "Docs" }),
     ).toHaveCount(0);
@@ -58,6 +58,6 @@ test.describe("site header", () => {
     ).toHaveAttribute("href", "/log-in");
     await expect(
       userMenu.getByRole("menuitem", { name: "Jobs" }),
-    ).toHaveAttribute("href", "https://github.com/sakomws/gitjobs");
+    ).toHaveAttribute("href", "/jobs");
   });
 });


### PR DESCRIPTION
## Summary
- Add a first-class GOUP jobs board at `/jobs` with search, detail pages, and local header navigation.
- Add jobs database schema/functions plus GOUP-authenticated job posting, editing, publishing, deletion, and application interest capture.
- Keep the cloned `gitjobs/` checkout ignored so only GOUP-native integration files are committed.

## Test plan
- `TERN_CONF="$HOME/.config/ocg/tern.conf" ./migrate.sh` from `database/migrations`
- `cargo check -p ocg-server`
- `cargo test -p ocg-server`


Made with [Cursor](https://cursor.com)