### PR TITLE
Add dark mode and landscape link

### DIFF
--- a/ocg-server/static/css/styles.src.css
+++ b/ocg-server/static/css/styles.src.css
@@ -1065,3 +1065,106 @@ input:placeholder-shown {
 }
 
 /* End header nav loading */
+
+/* Dark mode */
+
+html.ocg-dark {
+  color-scheme: dark;
+  background-color: #020617;
+}
+
+html.ocg-dark body {
+  background-color: #020617;
+  color: #e5e7eb;
+}
+
+html.ocg-dark .bg-white,
+html.ocg-dark .bg-stone-50,
+html.ocg-dark .bg-stone-100 {
+  background-color: #0f172a !important;
+}
+
+html.ocg-dark .bg-stone-200 {
+  background-color: #1e293b !important;
+}
+
+html.ocg-dark .bg-transparent {
+  background-color: transparent !important;
+}
+
+html.ocg-dark .text-stone-950,
+html.ocg-dark .text-stone-900,
+html.ocg-dark .text-stone-800,
+html.ocg-dark .text-stone-700 {
+  color: #f8fafc !important;
+}
+
+html.ocg-dark .text-stone-600,
+html.ocg-dark .text-stone-500 {
+  color: #cbd5e1 !important;
+}
+
+html.ocg-dark .text-stone-400 {
+  color: #94a3b8 !important;
+}
+
+html.ocg-dark .border-stone-100,
+html.ocg-dark .border-stone-200,
+html.ocg-dark .border-stone-300,
+html.ocg-dark .divide-stone-100 > :not(:last-child),
+html.ocg-dark .divide-stone-200 > :not(:last-child) {
+  border-color: #334155 !important;
+}
+
+html.ocg-dark .shadow,
+html.ocg-dark .shadow-sm,
+html.ocg-dark .shadow-md,
+html.ocg-dark .shadow-lg,
+html.ocg-dark .drop-shadow-sm {
+  --tw-shadow-color: rgb(0 0 0 / 0.45) !important;
+  --tw-shadow: 0 10px 30px -12px rgb(0 0 0 / 0.65) !important;
+  box-shadow: var(--tw-shadow) !important;
+}
+
+html.ocg-dark :is(input, textarea, select, .input) {
+  background-color: #020617 !important;
+  border-color: #334155 !important;
+  color: #f8fafc !important;
+}
+
+html.ocg-dark :is(input, textarea, select, .input)::placeholder {
+  color: #94a3b8 !important;
+}
+
+html.ocg-dark .hover\:bg-stone-100:hover,
+html.ocg-dark .hover\:bg-stone-50:hover {
+  background-color: #1e293b !important;
+}
+
+html.ocg-dark .svg-icon.bg-stone-600,
+html.ocg-dark .bg-stone-600 {
+  background-color: #cbd5e1 !important;
+}
+
+html.ocg-dark .theme-toggle {
+  background-color: #0f172a !important;
+  color: #bae6fd !important;
+}
+
+html.ocg-dark .theme-toggle-icon {
+  color: #bae6fd !important;
+}
+
+html.ocg-dark .EasyMDEContainer .editor-toolbar,
+html.ocg-dark .EasyMDEContainer .CodeMirror,
+html.ocg-dark .EasyMDEContainer .editor-preview-active {
+  background-color: #020617 !important;
+  border-color: #334155 !important;
+  color: #f8fafc !important;
+}
+
+html.ocg-dark .EasyMDEContainer button {
+  color: #e5e7eb !important;
+}
+
+/* End dark mode */

--- a/ocg-server/static/js/common/header.js
+++ b/ocg-server/static/js/common/header.js
@@ -10,8 +10,98 @@ let pendingHeaderNavLink = null;
 let pendingHeaderNavLinkTimer = null;
 
 const headerNavLinkSelector = "[data-header-nav-link]";
+const themeStorageKey = "ocg-theme";
 /** Wait before showing nav loading so quick HTMX requests can finish without flicker. */
 const headerNavLinkPendingDelayMs = 120;
+
+/**
+ * Returns the stored theme preference, if any.
+ * @returns {"light"|"dark"|null}
+ */
+const getStoredTheme = () => {
+  try {
+    const theme = window.localStorage.getItem(themeStorageKey);
+    return theme === "light" || theme === "dark" ? theme : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Stores the theme preference.
+ * @param {"light"|"dark"} theme - Theme name.
+ */
+const setStoredTheme = (theme) => {
+  try {
+    window.localStorage.setItem(themeStorageKey, theme);
+  } catch {
+    // Ignore storage failures; the current page can still switch themes.
+  }
+};
+
+/**
+ * Returns the active theme.
+ * @returns {"light"|"dark"}
+ */
+const getActiveTheme = () => {
+  if (document.documentElement.classList.contains("ocg-dark")) {
+    return "dark";
+  }
+  return "light";
+};
+
+/**
+ * Updates all visible dark-mode toggle controls.
+ */
+const syncThemeToggleButtons = () => {
+  const isDark = getActiveTheme() === "dark";
+
+  document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
+    button.setAttribute("aria-pressed", String(isDark));
+    button.setAttribute("aria-label", isDark ? "Switch to light mode" : "Switch to dark mode");
+
+    const icon = button.querySelector(".theme-toggle-icon");
+    if (icon) {
+      icon.textContent = isDark ? "☀" : "☾";
+    }
+
+    const label = button.querySelector(".theme-toggle-label");
+    if (label) {
+      label.textContent = isDark ? "Light mode" : "Dark mode";
+    }
+  });
+};
+
+/**
+ * Applies the requested theme.
+ * @param {"light"|"dark"} theme - Theme name.
+ */
+const applyTheme = (theme) => {
+  document.documentElement.classList.toggle("ocg-dark", theme === "dark");
+  setStoredTheme(theme);
+  syncThemeToggleButtons();
+};
+
+/**
+ * Initializes dark mode from storage/system preference and binds controls.
+ */
+const initThemeToggle = () => {
+  const storedTheme = getStoredTheme();
+  if (storedTheme) {
+    document.documentElement.classList.toggle("ocg-dark", storedTheme === "dark");
+  }
+
+  document.querySelectorAll("[data-theme-toggle]").forEach((button) => {
+    if (!button.__ocgThemeToggleInitialized) {
+      button.addEventListener("click", () => {
+        applyTheme(getActiveTheme() === "dark" ? "light" : "dark");
+      });
+      button.__ocgThemeToggleInitialized = true;
+    }
+  });
+
+  syncThemeToggleButtons();
+};
 
 /**
  * Finds the header nav link that triggered an event.
@@ -73,6 +163,7 @@ const clearHeaderLoading = () => {
 const restoreHeaderState = () => {
   clearHeaderLoading();
   initUserDropdown();
+  initThemeToggle();
 };
 
 /**
@@ -259,6 +350,7 @@ const toggleDropdownVisibility = () => {
 export const initUserDropdown = () => {
   ensureDocumentHandlers();
   bindLifecycleListeners();
+  initThemeToggle();
 
   const button = getElementById(document, "user-dropdown-button");
   const dropdown = getElementById(document, "user-dropdown");

--- a/ocg-server/templates/common/base.html
+++ b/ocg-server/templates/common/base.html
@@ -6,6 +6,15 @@
 <!DOCTYPE html>
 <html lang="en" class="h-full min-h-screen">
   <head>
+    <script>
+      (() => {
+        const theme = localStorage.getItem("ocg-theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (theme === "dark" || (!theme && prefersDark)) {
+          document.documentElement.classList.add("ocg-dark");
+        }
+      })();
+    </script>
     {# Page title -#}
     {% block head_title -%}
       <title>Open Alliance Groups</title>

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -29,12 +29,20 @@
         {{ header::link(content = "Explore", href = explore_events, current_path = path, path = "/explore") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
         {{ header::link(content = "Jobs", href = "/jobs", current_path = path, path = "/jobs") -}}
+        {{ header::link(content = "Landscape", href = "https://landscape.cncf.io/", current_path = path, hx_boost = "false", hx_target = "", target = "_blank") -}}
       </div>
       {# End desktop links -#}
     </div>
 
     {# Desktop user menu -#}
-    <div class="flex flex-1 justify-end">
+    <div class="flex flex-1 justify-end items-center gap-3">
+      <button type="button"
+              class="theme-toggle inline-flex size-[38px] items-center justify-center rounded-full border border-primary-500 bg-white text-primary-700 transition-colors hover:border-primary-900 hover:text-primary-900"
+              data-theme-toggle
+              aria-label="Switch to dark mode"
+              aria-pressed="false">
+        <span class="theme-toggle-icon text-base leading-none" aria-hidden="true">☾</span>
+      </button>
       {% if page_id == PageId::SiteHome || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteStats || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
         <div hx-get="/section/user-menu"
              hx-trigger="load"
@@ -137,6 +145,35 @@
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="https://landscape.cncf.io/"
+               hx-boost="false"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-map bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Landscape</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <button type="button"
+                    class="theme-toggle inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+                    data-theme-toggle
+                    role="menuitem"
+                    aria-label="Switch to dark mode"
+                    aria-pressed="false">
+              <div class="flex items-center">
+                <div class="theme-toggle-icon w-4 text-center text-stone-600" aria-hidden="true">☾</div>
+                <div class="theme-toggle-label ms-2 text-xs/6">Dark mode</div>
+              </div>
+            </button>
           </li>
 
           <li class="hidden lg:block" role="none">
@@ -302,6 +339,36 @@
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="https://landscape.cncf.io/"
+               hx-boost="false"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-map bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Landscape</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden border-b border-stone-200 mb-2 pb-2"
+              role="none">
+            <button type="button"
+                    class="theme-toggle inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+                    data-theme-toggle
+                    role="menuitem"
+                    aria-label="Switch to dark mode"
+                    aria-pressed="false">
+              <div class="flex items-center">
+                <div class="theme-toggle-icon w-4 text-center text-stone-600" aria-hidden="true">☾</div>
+                <div class="theme-toggle-label ms-2 text-xs/6">Dark mode</div>
+              </div>
+            </button>
           </li>
 
           {# Sign up -#}

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -28,6 +28,12 @@ test.describe("site header", () => {
       navigation.getByRole("link", { name: "Jobs" }),
     ).toHaveAttribute("href", "/jobs");
     await expect(
+      navigation.getByRole("link", { name: "Landscape" }),
+    ).toHaveAttribute("href", "https://landscape.cncf.io/");
+    await expect(
+      navigation.getByRole("button", { name: "Switch to dark mode" }),
+    ).toBeVisible();
+    await expect(
       navigation.getByRole("link", { name: "Docs" }),
     ).toHaveCount(0);
   });
@@ -59,5 +65,11 @@ test.describe("site header", () => {
     await expect(
       userMenu.getByRole("menuitem", { name: "Jobs" }),
     ).toHaveAttribute("href", "/jobs");
+    await expect(
+      userMenu.getByRole("menuitem", { name: "Landscape" }),
+    ).toHaveAttribute("href", "https://landscape.cncf.io/");
+    await expect(
+      userMenu.getByRole("menuitem", { name: "Dark mode" }),
+    ).toBeVisible();
   });
 });

--- a/tests/unit/common/header.test.js
+++ b/tests/unit/common/header.test.js
@@ -24,6 +24,8 @@ describe("header", () => {
 
   afterEach(() => {
     resetDom();
+    window.localStorage.removeItem("ocg-theme");
+    document.documentElement.classList.remove("ocg-dark");
     scrollToMock.restore();
     setLocationPath(originalPath);
   });
@@ -177,6 +179,44 @@ describe("header", () => {
       false,
     );
     expect(link.hasAttribute("aria-busy")).to.equal(false);
+  });
+
+  it("toggles dark mode and persists the selected theme", () => {
+    // Build the DOM fixture with desktop and dropdown theme toggles.
+    document.body.innerHTML = `
+      <button id="user-dropdown-button" type="button">User</button>
+      <div id="user-dropdown" class="hidden"></div>
+      <button data-theme-toggle aria-label="Switch to dark mode">
+        <span class="theme-toggle-icon">☾</span>
+      </button>
+      <button data-theme-toggle aria-label="Switch to dark mode">
+        <span class="theme-toggle-icon">☾</span>
+        <span class="theme-toggle-label">Dark mode</span>
+      </button>
+    `;
+
+    // Wire header handlers before toggling the theme.
+    initUserDropdown();
+
+    // The first click enables dark mode on the whole document.
+    document.querySelector("[data-theme-toggle]").click();
+    expect(document.documentElement.classList.contains("ocg-dark")).to.equal(
+      true,
+    );
+    expect(window.localStorage.getItem("ocg-theme")).to.equal("dark");
+    expect(
+      document.querySelector(".theme-toggle-label").textContent,
+    ).to.equal("Light mode");
+
+    // The second click returns to light mode and updates all controls.
+    document.querySelector("[data-theme-toggle]").click();
+    expect(document.documentElement.classList.contains("ocg-dark")).to.equal(
+      false,
+    );
+    expect(window.localStorage.getItem("ocg-theme")).to.equal("light");
+    expect(
+      document.querySelector(".theme-toggle-label").textContent,
+    ).to.equal("Dark mode");
   });
 
   it("scrolls to the top after dashboard swaps", () => {


### PR DESCRIPTION
## Summary
- Add a persistent dark-mode toggle to the desktop header and mobile user menus.
- Add a Landscape link to the header and mobile menus, pointing to CNCF Landscape.
- Add CSS/JS coverage for dark theme styling and update header tests.

## Test plan
- `cargo check -p ocg-server`
- `npm --prefix tests/unit test -- --files common/header.test.js` (blocked locally: Playwright Chromium binary missing; run `npx playwright install`)


Made with [Cursor](https://cursor.com)