### PR TITLE
Add GOUP landscape, wiki, and sharing polish

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -58,6 +58,14 @@
 {{ template "jobs/update_job.sql" }}
 {{ template "jobs/update_job_published.sql" }}
 
+{{ template "landscape/landscape_entry_json.sql" }}
+{{ template "landscape/add_landscape_entry.sql" }}
+{{ template "landscape/delete_landscape_entry.sql" }}
+{{ template "landscape/list_alliance_landscape_entries.sql" }}
+{{ template "landscape/search_landscape_entries.sql" }}
+{{ template "landscape/update_landscape_entry.sql" }}
+{{ template "landscape/update_landscape_entry_published.sql" }}
+
 {{ template "alliance/get_alliance_id_by_name.sql" }}
 {{ template "alliance/get_alliance_name_by_id.sql" }}
 {{ template "alliance/get_alliance_recently_added_groups.sql" }}

--- a/database/migrations/functions/jobs/get_job_by_slug.sql
+++ b/database/migrations/functions/jobs/get_job_by_slug.sql
@@ -7,7 +7,8 @@ begin
     into v_job
     from jobs_job
     where slug = p_slug
-    and published = true;
+    and published = true
+    and expires_at > current_timestamp;
 
     if v_job.job_id is null then
         raise exception 'job not found';

--- a/database/migrations/functions/jobs/job_summary_json.sql
+++ b/database/migrations/functions/jobs/job_summary_json.sql
@@ -18,10 +18,18 @@ returns jsonb language sql stable as $$
             where ja.job_id = p_job.job_id
         ),
         'posted_by_user_id', p_job.posted_by_user_id,
+        'poster_username', u.username,
+        'poster_name', u.name,
+        'poster_photo_url', u.photo_url,
+        'poster_title', u.title,
+        'poster_company', u.company,
+        'expires_at', extract(epoch from p_job.expires_at)::bigint,
         'created_at', extract(epoch from p_job.created_at)::bigint,
         'updated_at', case
             when p_job.updated_at is null then null
             else extract(epoch from p_job.updated_at)::bigint
         end
-    );
+    )
+    from "user" u
+    where u.user_id = p_job.posted_by_user_id;
 $$;

--- a/database/migrations/functions/jobs/search_jobs.sql
+++ b/database/migrations/functions/jobs/search_jobs.sql
@@ -13,6 +13,7 @@ begin
         select j.*
         from jobs_job j
         where j.published = true
+        and j.expires_at > current_timestamp
         and (
             v_query is null
             or j.title ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'

--- a/database/migrations/functions/jobs/update_job_published.sql
+++ b/database/migrations/functions/jobs/update_job_published.sql
@@ -3,6 +3,11 @@ returns void language plpgsql as $$
 begin
     update jobs_job
     set published = p_published,
+        expires_at = case
+            when p_published and expires_at <= current_timestamp
+                then current_timestamp + interval '30 days'
+            else expires_at
+        end,
         updated_at = current_timestamp
     where job_id = p_job_id
     and posted_by_user_id = p_user_id;

--- a/database/migrations/functions/landscape/add_landscape_entry.sql
+++ b/database/migrations/functions/landscape/add_landscape_entry.sql
@@ -1,0 +1,60 @@
+create or replace function add_landscape_entry(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_input jsonb,
+    p_tags text[]
+) returns uuid language plpgsql as $$
+declare
+    v_entry_id uuid;
+    v_slug_base text;
+    v_slug text;
+begin
+    v_slug_base := regexp_replace(lower(trim(p_input->>'name')), '[^a-z0-9]+', '-', 'g');
+    v_slug_base := trim(both '-' from v_slug_base);
+    if v_slug_base = '' then
+        v_slug_base := 'landscape';
+    end if;
+    v_slug := left(v_slug_base, 60) || '-' || generate_slug(6);
+
+    insert into landscape_entry (
+        alliance_id,
+        added_by_user_id,
+        name,
+        slug,
+        kind,
+        summary,
+        description,
+        website_url,
+        github_url,
+        logo_url,
+        category,
+        tags
+    )
+    values (
+        p_alliance_id,
+        p_actor_user_id,
+        trim(p_input->>'name'),
+        v_slug,
+        trim(p_input->>'kind'),
+        trim(p_input->>'summary'),
+        nullif(trim(p_input->>'description'), ''),
+        nullif(trim(p_input->>'website_url'), ''),
+        nullif(trim(p_input->>'github_url'), ''),
+        nullif(trim(p_input->>'logo_url'), ''),
+        nullif(trim(p_input->>'category'), ''),
+        coalesce(p_tags, '{}'::text[])
+    )
+    returning landscape_entry_id into v_entry_id;
+
+    perform insert_audit_log(
+        'landscape_entry_added',
+        p_actor_user_id,
+        'landscape_entry',
+        v_entry_id,
+        p_alliance_id,
+        null
+    );
+
+    return v_entry_id;
+end;
+$$;

--- a/database/migrations/functions/landscape/delete_landscape_entry.sql
+++ b/database/migrations/functions/landscape/delete_landscape_entry.sql
@@ -1,0 +1,24 @@
+create or replace function delete_landscape_entry(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_entry_id uuid
+) returns void language plpgsql as $$
+begin
+    delete from landscape_entry
+    where landscape_entry_id = p_entry_id
+      and alliance_id = p_alliance_id;
+
+    if not found then
+        raise exception 'landscape entry not found';
+    end if;
+
+    perform insert_audit_log(
+        'landscape_entry_deleted',
+        p_actor_user_id,
+        'landscape_entry',
+        p_entry_id,
+        p_alliance_id,
+        null
+    );
+end;
+$$;

--- a/database/migrations/functions/landscape/landscape_entry_json.sql
+++ b/database/migrations/functions/landscape/landscape_entry_json.sql
@@ -1,0 +1,21 @@
+create or replace function landscape_entry_json(p_entry landscape_entry)
+returns jsonb language sql stable as $$
+    select jsonb_build_object(
+        'landscape_entry_id', p_entry.landscape_entry_id,
+        'alliance_id', p_entry.alliance_id,
+        'added_by_user_id', p_entry.added_by_user_id,
+        'name', p_entry.name,
+        'slug', p_entry.slug,
+        'kind', p_entry.kind,
+        'summary', p_entry.summary,
+        'description', p_entry.description,
+        'website_url', p_entry.website_url,
+        'github_url', p_entry.github_url,
+        'logo_url', p_entry.logo_url,
+        'category', p_entry.category,
+        'tags', p_entry.tags,
+        'published', p_entry.published,
+        'created_at', extract(epoch from p_entry.created_at)::bigint,
+        'updated_at', extract(epoch from p_entry.updated_at)::bigint
+    );
+$$;

--- a/database/migrations/functions/landscape/list_alliance_landscape_entries.sql
+++ b/database/migrations/functions/landscape/list_alliance_landscape_entries.sql
@@ -1,0 +1,56 @@
+create or replace function list_alliance_landscape_entries(
+    p_alliance_id uuid,
+    p_filters jsonb
+) returns jsonb language plpgsql stable as $$
+declare
+    v_limit int := coalesce((p_filters->>'limit')::int, 50);
+    v_offset int := coalesce((p_filters->>'offset')::int, 0);
+    v_query text := nullif(trim(p_filters->>'query'), '');
+    v_total int;
+    v_entries jsonb;
+begin
+    with matches as (
+        select le.*
+        from landscape_entry le
+        where le.alliance_id = p_alliance_id
+        and (
+            v_query is null
+            or le.name ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.summary ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.description ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.category ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or exists (
+                select 1
+                from unnest(le.tags) tag
+                where tag ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+        )
+    ),
+    counted as (
+        select count(*)::int as total from matches
+    ),
+    paged as (
+        select *
+        from matches
+        order by created_at desc, landscape_entry_id desc
+        limit v_limit
+        offset v_offset
+    )
+    select
+        counted.total,
+        coalesce(
+            jsonb_agg(landscape_entry_json(paged) order by paged.created_at desc, paged.landscape_entry_id desc)
+                filter (where paged.landscape_entry_id is not null),
+            '[]'::jsonb
+        )
+    into v_total, v_entries
+    from counted
+    left join paged on true
+    group by counted.total;
+
+    return jsonb_build_object(
+        'entries', coalesce(v_entries, '[]'::jsonb),
+        'total', coalesce(v_total, 0)
+    );
+end;
+$$;

--- a/database/migrations/functions/landscape/search_landscape_entries.sql
+++ b/database/migrations/functions/landscape/search_landscape_entries.sql
@@ -1,0 +1,64 @@
+create or replace function search_landscape_entries(p_filters jsonb)
+returns jsonb language plpgsql stable as $$
+declare
+    v_limit int := coalesce((p_filters->>'limit')::int, 20);
+    v_offset int := coalesce((p_filters->>'offset')::int, 0);
+    v_query text := nullif(trim(p_filters->>'query'), '');
+    v_kind text := nullif(trim(p_filters->>'kind'), '');
+    v_category text := nullif(trim(p_filters->>'category'), '');
+    v_alliance text := nullif(trim(p_filters->>'alliance'), '');
+    v_total int;
+    v_entries jsonb;
+begin
+    with matches as (
+        select le.*
+        from landscape_entry le
+        join alliance a on a.alliance_id = le.alliance_id
+        where le.published = true
+        and (v_alliance is null or a.name = v_alliance)
+        and (v_kind is null or le.kind = v_kind)
+        and (
+            v_category is null
+            or le.category ilike '%' || escape_ilike_pattern(v_category) || '%' escape '\'
+        )
+        and (
+            v_query is null
+            or le.name ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.summary ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.description ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.category ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or exists (
+                select 1
+                from unnest(le.tags) tag
+                where tag ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+        )
+    ),
+    counted as (
+        select count(*)::int as total from matches
+    ),
+    paged as (
+        select *
+        from matches
+        order by created_at desc, landscape_entry_id desc
+        limit v_limit
+        offset v_offset
+    )
+    select
+        counted.total,
+        coalesce(
+            jsonb_agg(landscape_entry_json(paged) order by paged.created_at desc, paged.landscape_entry_id desc)
+                filter (where paged.landscape_entry_id is not null),
+            '[]'::jsonb
+        )
+    into v_total, v_entries
+    from counted
+    left join paged on true
+    group by counted.total;
+
+    return jsonb_build_object(
+        'entries', coalesce(v_entries, '[]'::jsonb),
+        'total', coalesce(v_total, 0)
+    );
+end;
+$$;

--- a/database/migrations/functions/landscape/update_landscape_entry.sql
+++ b/database/migrations/functions/landscape/update_landscape_entry.sql
@@ -1,0 +1,36 @@
+create or replace function update_landscape_entry(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_entry_id uuid,
+    p_input jsonb,
+    p_tags text[]
+) returns void language plpgsql as $$
+begin
+    update landscape_entry
+    set name = trim(p_input->>'name'),
+        kind = trim(p_input->>'kind'),
+        summary = trim(p_input->>'summary'),
+        description = nullif(trim(p_input->>'description'), ''),
+        website_url = nullif(trim(p_input->>'website_url'), ''),
+        github_url = nullif(trim(p_input->>'github_url'), ''),
+        logo_url = nullif(trim(p_input->>'logo_url'), ''),
+        category = nullif(trim(p_input->>'category'), ''),
+        tags = coalesce(p_tags, '{}'::text[]),
+        updated_at = current_timestamp
+    where landscape_entry_id = p_entry_id
+      and alliance_id = p_alliance_id;
+
+    if not found then
+        raise exception 'landscape entry not found';
+    end if;
+
+    perform insert_audit_log(
+        'landscape_entry_updated',
+        p_actor_user_id,
+        'landscape_entry',
+        p_entry_id,
+        p_alliance_id,
+        null
+    );
+end;
+$$;

--- a/database/migrations/functions/landscape/update_landscape_entry_published.sql
+++ b/database/migrations/functions/landscape/update_landscape_entry_published.sql
@@ -1,0 +1,27 @@
+create or replace function update_landscape_entry_published(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_entry_id uuid,
+    p_published boolean
+) returns void language plpgsql as $$
+begin
+    update landscape_entry
+    set published = p_published,
+        updated_at = current_timestamp
+    where landscape_entry_id = p_entry_id
+      and alliance_id = p_alliance_id;
+
+    if not found then
+        raise exception 'landscape entry not found';
+    end if;
+
+    perform insert_audit_log(
+        case when p_published then 'landscape_entry_published' else 'landscape_entry_unpublished' end,
+        p_actor_user_id,
+        'landscape_entry',
+        p_entry_id,
+        p_alliance_id,
+        null
+    );
+end;
+$$;

--- a/database/migrations/functions/site/get_site_stats.sql
+++ b/database/migrations/functions/site/get_site_stats.sql
@@ -1,7 +1,7 @@
 -- Returns site statistics as a JSON object.
 --
--- The function computes statistics for 4 domains: groups, members, events,
--- and attendees. Each domain includes the following stat types:
+-- The function computes statistics for alliance activity, jobs, and landscape
+-- entries. Each domain includes the following stat types:
 --
 --   - total: Total count of entities (all-time)
 --   - running_total: Cumulative total over time (last 10 years)
@@ -86,6 +86,42 @@ attendees as (
     join events e on e.event_id = ea.event_id
     where ea.status = 'confirmed'
 ),
+jobs as (
+    select
+        jj.created_at,
+        timezone(
+            'UTC',
+            date_trunc('month', jj.created_at at time zone 'UTC')
+        ) as created_month
+    from jobs_job jj
+    where jj.published = true
+),
+landscape_startups as (
+    select
+        le.created_at,
+        timezone(
+            'UTC',
+            date_trunc('month', le.created_at at time zone 'UTC')
+        ) as created_month
+    from landscape_entry le
+    join alliance a on a.alliance_id = le.alliance_id
+    where a.active = true
+      and le.published = true
+      and le.kind = 'startup'
+),
+landscape_open_source as (
+    select
+        le.created_at,
+        timezone(
+            'UTC',
+            date_trunc('month', le.created_at at time zone 'UTC')
+        ) as created_month
+    from landscape_entry le
+    join alliance a on a.alliance_id = le.alliance_id
+    where a.active = true
+      and le.published = true
+      and le.kind = 'github_project'
+),
 domain_running_total_counts as (
     select
         'groups' as domain,
@@ -124,6 +160,36 @@ domain_running_total_counts as (
     from attendees a
     join params p on a.created_at >= p.period_start
     group by a.created_month
+
+    union all
+
+    select
+        'jobs' as domain,
+        j.created_month as bucket_start,
+        count(*)::int as count
+    from jobs j
+    join params p on j.created_at >= p.period_start
+    group by j.created_month
+
+    union all
+
+    select
+        'landscape_startups' as domain,
+        ls.created_month as bucket_start,
+        count(*)::int as count
+    from landscape_startups ls
+    join params p on ls.created_at >= p.period_start
+    group by ls.created_month
+
+    union all
+
+    select
+        'landscape_open_source' as domain,
+        los.created_month as bucket_start,
+        count(*)::int as count
+    from landscape_open_source los
+    join params p on los.created_at >= p.period_start
+    group by los.created_month
 ),
 domain_monthly_counts as (
     select
@@ -184,6 +250,45 @@ select json_strip_nulls(json_build_object(
             where domain = 'attendees'
         )),
         'total', (select count(*)::int from attendees)
+    ),
+    'jobs', json_build_object(
+        'per_month', stats_label_count_series((
+            select jsonb_agg(to_jsonb(counts))
+            from domain_monthly_counts counts
+            where domain = 'jobs'
+        )),
+        'running_total', stats_running_total_series((
+            select jsonb_agg(to_jsonb(counts))
+            from domain_running_total_counts counts
+            where domain = 'jobs'
+        )),
+        'total', (select count(*)::int from jobs)
+    ),
+    'landscape_startups', json_build_object(
+        'per_month', stats_label_count_series((
+            select jsonb_agg(to_jsonb(counts))
+            from domain_monthly_counts counts
+            where domain = 'landscape_startups'
+        )),
+        'running_total', stats_running_total_series((
+            select jsonb_agg(to_jsonb(counts))
+            from domain_running_total_counts counts
+            where domain = 'landscape_startups'
+        )),
+        'total', (select count(*)::int from landscape_startups)
+    ),
+    'landscape_open_source', json_build_object(
+        'per_month', stats_label_count_series((
+            select jsonb_agg(to_jsonb(counts))
+            from domain_monthly_counts counts
+            where domain = 'landscape_open_source'
+        )),
+        'running_total', stats_running_total_series((
+            select jsonb_agg(to_jsonb(counts))
+            from domain_running_total_counts counts
+            where domain = 'landscape_open_source'
+        )),
+        'total', (select count(*)::int from landscape_open_source)
     )
 ));
 $$ language sql;

--- a/database/migrations/schema/0003_jobs.sql
+++ b/database/migrations/schema/0003_jobs.sql
@@ -11,12 +11,16 @@ create table jobs_job (
     remote boolean default false not null,
     tags text[] default '{}'::text[] not null,
     published boolean default true not null,
+    expires_at timestamp with time zone default current_timestamp + interval '30 days' not null,
     created_at timestamp with time zone default current_timestamp not null,
     updated_at timestamp with time zone
 );
 
 create index jobs_job_published_created_at_idx
 on jobs_job (published, created_at desc);
+
+create index jobs_job_published_expires_at_created_at_idx
+on jobs_job (published, expires_at, created_at desc);
 
 create index jobs_job_posted_by_user_id_created_at_idx
 on jobs_job (posted_by_user_id, created_at desc);

--- a/database/migrations/schema/0004_set_goup_favicon.sql
+++ b/database/migrations/schema/0004_set_goup_favicon.sql
@@ -1,4 +1,3 @@
 update site
 set favicon_url = '/static/images/favicon.png'
-where title = 'GOUP Alliance'
-and favicon_url is null;
+where title = 'GOUP Alliance';

--- a/database/migrations/schema/0005_landscape.sql
+++ b/database/migrations/schema/0005_landscape.sql
@@ -1,0 +1,31 @@
+create table landscape_entry (
+    landscape_entry_id uuid default gen_random_uuid() primary key,
+    alliance_id uuid not null references alliance (alliance_id) on delete cascade,
+    added_by_user_id uuid not null references "user" (user_id) on delete cascade,
+    name text not null,
+    slug text not null,
+    kind text not null check (kind in ('startup', 'github_project')),
+    summary text not null,
+    description text,
+    website_url text,
+    github_url text,
+    logo_url text,
+    category text,
+    tags text[] default '{}'::text[] not null,
+    published boolean default true not null,
+    created_at timestamp with time zone default current_timestamp not null,
+    updated_at timestamp with time zone,
+    unique (alliance_id, slug)
+);
+
+create index landscape_entry_alliance_published_created_at_idx
+on landscape_entry (alliance_id, published, created_at desc);
+
+create index landscape_entry_published_created_at_idx
+on landscape_entry (published, created_at desc);
+
+create index landscape_entry_kind_idx
+on landscape_entry (kind);
+
+create index landscape_entry_tags_idx
+on landscape_entry using gin (tags);

--- a/database/migrations/schema/0006_jobs_expiry_and_favicon.sql
+++ b/database/migrations/schema/0006_jobs_expiry_and_favicon.sql
@@ -1,0 +1,17 @@
+alter table jobs_job
+add column if not exists expires_at timestamp with time zone;
+
+update jobs_job
+set expires_at = created_at + interval '30 days'
+where expires_at is null;
+
+alter table jobs_job
+alter column expires_at set default current_timestamp + interval '30 days',
+alter column expires_at set not null;
+
+create index if not exists jobs_job_published_expires_at_created_at_idx
+on jobs_job (published, expires_at, created_at desc);
+
+update site
+set favicon_url = '/static/images/favicon.png'
+where title = 'GOUP Alliance';

--- a/ocg-server/src/db.rs
+++ b/ocg-server/src/db.rs
@@ -11,7 +11,8 @@ use tokio_postgres::types::{FromSql, Json, ToSql};
 use crate::db::{
     activity_tracker::DBActivityTracker, alliance::DBAlliance, auth::DBAuth, common::DBCommon,
     dashboard::DBDashboard, event::DBEvent, group::DBGroup, images::DBImages, jobs::DBJobs,
-    meetings::DBMeetings, notifications::DBNotifications, payments::DBPayments, site::DBSite,
+    landscape::DBLandscape, meetings::DBMeetings, notifications::DBNotifications,
+    payments::DBPayments, site::DBSite,
 };
 
 /// Module containing authentication database operations.
@@ -45,6 +46,9 @@ pub(crate) mod images;
 /// Module containing database functionality for jobs.
 pub(crate) mod jobs;
 
+/// Module containing database functionality for landscape entries.
+pub(crate) mod landscape;
+
 /// Module containing database functionality for managing meetings.
 pub(crate) mod meetings;
 
@@ -75,6 +79,7 @@ pub(crate) trait DBOperations:
     + DBGroup
     + DBImages
     + DBJobs
+    + DBLandscape
     + DBMeetings
     + DBNotifications
     + DBPayments
@@ -94,6 +99,7 @@ impl<T> DBOperations for T where
         + DBGroup
         + DBImages
         + DBJobs
+        + DBLandscape
         + DBMeetings
         + DBNotifications
         + DBPayments

--- a/ocg-server/src/db/landscape.rs
+++ b/ocg-server/src/db/landscape.rs
@@ -1,0 +1,155 @@
+//! Database operations for landscape entries.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_postgres::types::Json;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::PgExecutor,
+    types::landscape::{
+        DashboardLandscapeFilters, LandscapeEntryInput, LandscapeOutput, LandscapeFilters,
+        parse_tags,
+    },
+};
+
+/// Database operations for the landscape product area.
+#[async_trait]
+pub(crate) trait DBLandscape {
+    /// Search published landscape entries.
+    async fn search_landscape_entries(&self, filters: &LandscapeFilters)
+    -> Result<LandscapeOutput>;
+
+    /// List entries for one alliance dashboard.
+    async fn list_alliance_landscape_entries(
+        &self,
+        alliance_id: Uuid,
+        filters: &DashboardLandscapeFilters,
+    ) -> Result<LandscapeOutput>;
+
+    /// Add a landscape entry to an alliance.
+    async fn add_landscape_entry(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        input: &LandscapeEntryInput,
+    ) -> Result<Uuid>;
+
+    /// Update a landscape entry.
+    async fn update_landscape_entry(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        entry_id: Uuid,
+        input: &LandscapeEntryInput,
+    ) -> Result<()>;
+
+    /// Delete a landscape entry.
+    async fn delete_landscape_entry(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        entry_id: Uuid,
+    ) -> Result<()>;
+
+    /// Toggle landscape entry publishing status.
+    async fn update_landscape_entry_published(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        entry_id: Uuid,
+        published: bool,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+impl<T> DBLandscape for T
+where
+    T: PgExecutor + Send + Sync,
+{
+    #[instrument(skip(self, filters), err)]
+    async fn search_landscape_entries(
+        &self,
+        filters: &LandscapeFilters,
+    ) -> Result<LandscapeOutput> {
+        self.fetch_json_one("select search_landscape_entries($1::jsonb)", &[&Json(filters)])
+            .await
+    }
+
+    #[instrument(skip(self, filters), err)]
+    async fn list_alliance_landscape_entries(
+        &self,
+        alliance_id: Uuid,
+        filters: &DashboardLandscapeFilters,
+    ) -> Result<LandscapeOutput> {
+        self.fetch_json_one(
+            "select list_alliance_landscape_entries($1::uuid, $2::jsonb)",
+            &[&alliance_id, &Json(filters)],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_landscape_entry(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        input: &LandscapeEntryInput,
+    ) -> Result<Uuid> {
+        let tags = parse_tags(input.tags.as_deref());
+        self.fetch_scalar_one(
+            "select add_landscape_entry($1::uuid, $2::uuid, $3::jsonb, $4::text[])",
+            &[&actor_user_id, &alliance_id, &Json(input), &tags],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn update_landscape_entry(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        entry_id: Uuid,
+        input: &LandscapeEntryInput,
+    ) -> Result<()> {
+        let tags = parse_tags(input.tags.as_deref());
+        self.execute(
+            "select update_landscape_entry($1::uuid, $2::uuid, $3::uuid, $4::jsonb, $5::text[])",
+            &[&actor_user_id, &alliance_id, &entry_id, &Json(input), &tags],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), err)]
+    async fn delete_landscape_entry(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        entry_id: Uuid,
+    ) -> Result<()> {
+        self.execute(
+            "select delete_landscape_entry($1::uuid, $2::uuid, $3::uuid)",
+            &[&actor_user_id, &alliance_id, &entry_id],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self), err)]
+    async fn update_landscape_entry_published(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        entry_id: Uuid,
+        published: bool,
+    ) -> Result<()> {
+        self.execute(
+            "select update_landscape_entry_published($1::uuid, $2::uuid, $3::uuid, $4::boolean)",
+            &[&actor_user_id, &alliance_id, &entry_id, &published],
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -895,6 +895,45 @@ mock! {
     }
 
     #[async_trait]
+    impl crate::db::landscape::DBLandscape for DB {
+        async fn search_landscape_entries(
+            &self,
+            filters: &crate::types::landscape::LandscapeFilters,
+        ) -> Result<crate::types::landscape::LandscapeOutput>;
+        async fn list_alliance_landscape_entries(
+            &self,
+            alliance_id: Uuid,
+            filters: &crate::types::landscape::DashboardLandscapeFilters,
+        ) -> Result<crate::types::landscape::LandscapeOutput>;
+        async fn add_landscape_entry(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            input: &crate::types::landscape::LandscapeEntryInput,
+        ) -> Result<Uuid>;
+        async fn update_landscape_entry(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            entry_id: Uuid,
+            input: &crate::types::landscape::LandscapeEntryInput,
+        ) -> Result<()>;
+        async fn delete_landscape_entry(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            entry_id: Uuid,
+        ) -> Result<()>;
+        async fn update_landscape_entry_published(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            entry_id: Uuid,
+            published: bool,
+        ) -> Result<()>;
+    }
+
+    #[async_trait]
     impl crate::db::meetings::DBMeetings for DB {
         async fn add_meeting(
             &self,

--- a/ocg-server/src/handlers/dashboard/alliance.rs
+++ b/ocg-server/src/handlers/dashboard/alliance.rs
@@ -26,6 +26,7 @@ pub(crate) mod event_categories;
 pub(crate) mod group_categories;
 pub(crate) mod groups;
 pub(crate) mod home;
+pub(crate) mod landscape;
 pub(crate) mod logs;
 pub(crate) mod regions;
 pub(crate) mod settings;

--- a/ocg-server/src/handlers/dashboard/alliance/home.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/home.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_messages::Messages;
 use tracing::instrument;
 
-use super::{groups, logs, team};
+use super::{groups, landscape, logs, team};
 
 use crate::{
     auth::AuthSession,
@@ -105,6 +105,16 @@ pub(crate) async fn page(
             )
             .await?;
             Content::Groups(template)
+        }
+        Tab::Landscape => {
+            let (_, template) = landscape::prepare_list_page(
+                &db,
+                alliance_id,
+                user_id,
+                raw_query.as_deref().unwrap_or_default(),
+            )
+            .await?;
+            Content::Landscape(template)
         }
         Tab::Logs => {
             let (_, template) = logs::prepare_list_page(

--- a/ocg-server/src/handlers/dashboard/alliance/landscape.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/landscape.rs
@@ -1,0 +1,170 @@
+//! HTTP handlers for managing alliance landscape entries.
+
+use anyhow::Result;
+use askama::Template;
+use axum::{
+    extract::{Path, RawQuery, State},
+    http::{HeaderName, StatusCode},
+    response::{Html, IntoResponse},
+};
+use garde::Validate;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, ValidatedFormQs},
+    },
+    router::serde_qs_config,
+    templates::dashboard::alliance::landscape,
+    types::{
+        landscape::{DashboardLandscapeFilters, LandscapeEntryInput},
+        pagination::{self, NavigationLinks},
+        permissions::AlliancePermission,
+    },
+};
+
+const DASHBOARD_URL: &str = "/dashboard/alliance?tab=landscape";
+const PARTIAL_URL: &str = "/dashboard/alliance/landscape";
+
+/// Displays the list of landscape entries for the alliance dashboard.
+#[instrument(skip_all, err)]
+pub(crate) async fn list_page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (filters, template) = prepare_list_page(
+        &db,
+        alliance_id,
+        user.user_id,
+        raw_query.as_deref().unwrap_or_default(),
+    )
+    .await?;
+
+    let url = pagination::build_url(DASHBOARD_URL, &filters)?;
+    let headers = [(HeaderName::from_static("hx-push-url"), url)];
+
+    Ok((headers, Html(template.render()?)))
+}
+
+/// Adds a new landscape entry.
+#[instrument(skip_all, err)]
+pub(crate) async fn add(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    ValidatedFormQs(input): ValidatedFormQs<LandscapeEntryInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_landscape_entry(user.user_id, alliance_id, &input).await?;
+
+    Ok((
+        StatusCode::CREATED,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Updates an existing landscape entry.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    Path(entry_id): Path<Uuid>,
+    ValidatedFormQs(input): ValidatedFormQs<LandscapeEntryInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_landscape_entry(user.user_id, alliance_id, entry_id, &input)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Deletes a landscape entry.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    Path(entry_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_landscape_entry(user.user_id, alliance_id, entry_id)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Publishes a landscape entry.
+#[instrument(skip_all, err)]
+pub(crate) async fn publish(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    Path(entry_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_landscape_entry_published(user.user_id, alliance_id, entry_id, true)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Unpublishes a landscape entry.
+#[instrument(skip_all, err)]
+pub(crate) async fn unpublish(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    Path(entry_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_landscape_entry_published(user.user_id, alliance_id, entry_id, false)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Prepares the landscape list page and filters for the alliance dashboard.
+pub(crate) async fn prepare_list_page(
+    db: &DynDB,
+    alliance_id: Uuid,
+    user_id: Uuid,
+    raw_query: &str,
+) -> Result<(DashboardLandscapeFilters, landscape::ListPage), HandlerError> {
+    let filters: DashboardLandscapeFilters = if raw_query.is_empty() {
+        DashboardLandscapeFilters::default()
+    } else {
+        serde_qs_config().deserialize_str(raw_query)?
+    };
+    filters.validate()?;
+
+    let (can_manage_landscape, output) = tokio::try_join!(
+        db.user_has_alliance_permission(&alliance_id, &user_id, AlliancePermission::GroupsWrite),
+        db.list_alliance_landscape_entries(alliance_id, &filters)
+    )?;
+    let navigation_links =
+        NavigationLinks::from_filters(&filters, output.total, DASHBOARD_URL, PARTIAL_URL)?;
+
+    Ok((
+        filters.clone(),
+        landscape::ListPage {
+            can_manage_landscape,
+            filters,
+            entries: output.entries,
+            total: output.total,
+            navigation_links,
+        },
+    ))
+}

--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -3,5 +3,7 @@
 pub(crate) mod explore;
 pub(crate) mod home;
 pub(crate) mod jobs;
+pub(crate) mod landscape;
 pub(crate) mod not_found;
 pub(crate) mod stats;
+pub(crate) mod wiki;

--- a/ocg-server/src/handlers/site/landscape.rs
+++ b/ocg-server/src/handlers/site/landscape.rs
@@ -1,0 +1,60 @@
+//! HTTP handlers for the public landscape page.
+
+use askama::Template;
+use axum::{
+    extract::{RawQuery, State},
+    response::{Html, IntoResponse},
+};
+use garde::Validate;
+use tracing::instrument;
+
+use crate::{
+    auth::AuthSession,
+    db::DynDB,
+    handlers::{error::HandlerError, extend_public_shared_cache_headers},
+    router::serde_qs_config,
+    templates::{PageId, auth::User, site::landscape},
+    types::{landscape::LandscapeFilters, pagination::NavigationLinks},
+};
+
+const LANDSCAPE_URL: &str = "/landscape";
+
+/// Render the public landscape listing page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, HandlerError> {
+    let filters = parse_filters(raw_query.as_deref().unwrap_or_default())?;
+    let output = db.search_landscape_entries(&filters).await?;
+    let site_settings = db.get_site_settings().await?;
+    let navigation_links =
+        NavigationLinks::from_filters(&filters, output.total, LANDSCAPE_URL, LANDSCAPE_URL)?;
+
+    let template = landscape::Page {
+        page_id: PageId::SiteLandscape,
+        path: LANDSCAPE_URL.to_string(),
+        site_settings,
+        user: User::from_session(auth_session).await?,
+        filters,
+        entries: output.entries,
+        total: output.total,
+        navigation_links,
+    };
+
+    Ok((
+        extend_public_shared_cache_headers(&[])?,
+        Html(template.render()?),
+    ))
+}
+
+fn parse_filters(raw_query: &str) -> Result<LandscapeFilters, HandlerError> {
+    let filters: LandscapeFilters = if raw_query.is_empty() {
+        LandscapeFilters::default()
+    } else {
+        serde_qs_config().deserialize_str(raw_query)?
+    };
+    filters.validate()?;
+    Ok(filters)
+}

--- a/ocg-server/src/handlers/site/wiki.rs
+++ b/ocg-server/src/handlers/site/wiki.rs
@@ -1,0 +1,287 @@
+//! HTTP handlers for the public wiki page.
+
+use std::time::Duration;
+
+use askama::Template;
+use axum::{
+    extract::State,
+    response::{Html, IntoResponse},
+};
+use cached::proc_macro::cached;
+use quick_xml::{Reader, events::Event};
+use tracing::{debug, instrument};
+
+use crate::{
+    auth::AuthSession,
+    db::DynDB,
+    handlers::{error::HandlerError, extend_public_shared_cache_headers},
+    templates::{
+        PageId,
+        auth::User,
+        site::wiki::{Page, WikiLink, WikiSection, WikiSource},
+    },
+};
+
+const WIKI_URL: &str = "/wiki";
+const MAX_LINKS_PER_SECTION: usize = 9;
+const MAX_LINKS_PER_SOURCE: usize = 4;
+
+#[derive(Debug, Clone, Copy)]
+struct FeedSource {
+    label: &'static str,
+    url: &'static str,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SectionSource {
+    id: &'static str,
+    title: &'static str,
+    summary_topic: &'static str,
+    fallback_summary: &'static str,
+    sources: &'static [FeedSource],
+}
+
+const AI_SOURCES: &[FeedSource] = &[
+    FeedSource {
+        label: "arXiv AI",
+        url: "https://export.arxiv.org/rss/cs.AI",
+    },
+    FeedSource {
+        label: "Google AI",
+        url: "https://blog.google/technology/ai/rss/",
+    },
+    FeedSource {
+        label: "OpenAI",
+        url: "https://openai.com/news/rss.xml",
+    },
+];
+
+const OPEN_SOURCE_SOURCES: &[FeedSource] = &[
+    FeedSource {
+        label: "GitHub Blog",
+        url: "https://github.blog/feed/",
+    },
+    FeedSource {
+        label: "CNCF",
+        url: "https://www.cncf.io/feed/",
+    },
+    FeedSource {
+        label: "Hacker News",
+        url: "https://hnrss.org/frontpage",
+    },
+];
+
+const ENTREPRENEURSHIP_SOURCES: &[FeedSource] = &[
+    FeedSource {
+        label: "Y Combinator",
+        url: "https://www.ycombinator.com/blog/feed",
+    },
+    FeedSource {
+        label: "a16z",
+        url: "https://a16z.com/feed/",
+    },
+    FeedSource {
+        label: "First Round Review",
+        url: "https://review.firstround.com/feed.xml",
+    },
+];
+
+const WIKI_SECTIONS: &[SectionSource] = &[
+    SectionSource {
+        id: "ai",
+        title: "AI",
+        summary_topic: "AI research, product launches, and applied machine learning",
+        fallback_summary: "Latest AI research and product updates from leading research labs and technology publishers.",
+        sources: AI_SOURCES,
+    },
+    SectionSource {
+        id: "opensource",
+        title: "Open Source",
+        summary_topic: "open-source infrastructure, developer tools, and community projects",
+        fallback_summary: "Open-source infrastructure and developer ecosystem updates from project and community sources.",
+        sources: OPEN_SOURCE_SOURCES,
+    },
+    SectionSource {
+        id: "entrepreneurship",
+        title: "Entrepreneurship",
+        summary_topic: "startup building, fundraising, product strategy, and founder lessons",
+        fallback_summary: "Startup and founder reading from accelerators, investors, and operator-focused publications.",
+        sources: ENTREPRENEURSHIP_SOURCES,
+    },
+];
+
+/// Render the public wiki page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (site_settings, sections) = tokio::join!(db.get_site_settings(), load_wiki_sections());
+    let template = Page {
+        page_id: PageId::SiteWiki,
+        path: WIKI_URL.to_string(),
+        site_settings: site_settings?,
+        user: User::from_session(auth_session).await?,
+        sections,
+    };
+
+    Ok((
+        extend_public_shared_cache_headers(&[])?,
+        Html(template.render()?),
+    ))
+}
+
+#[cached(time = 900)]
+async fn load_wiki_sections() -> Vec<WikiSection> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .user_agent("GOUP Wiki/1.0")
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
+    let mut sections = Vec::with_capacity(WIKI_SECTIONS.len());
+    for section in WIKI_SECTIONS {
+        sections.push(load_section(&client, section).await);
+    }
+
+    sections
+}
+
+async fn load_section(client: &reqwest::Client, section: &SectionSource) -> WikiSection {
+    let mut links = Vec::new();
+
+    for source in section.sources {
+        match fetch_source_links(client, source).await {
+            Ok(mut source_links) => links.append(&mut source_links),
+            Err(error) => debug!("failed to load wiki source {}: {error}", source.url),
+        }
+    }
+
+    links.truncate(MAX_LINKS_PER_SECTION);
+
+    WikiSection {
+        id: section.id.to_string(),
+        title: section.title.to_string(),
+        summary: section_summary(section, &links),
+        sources: section
+            .sources
+            .iter()
+            .map(|source| WikiSource {
+                label: source.label.to_string(),
+                url: source.url.to_string(),
+            })
+            .collect(),
+        links,
+    }
+}
+
+async fn fetch_source_links(
+    client: &reqwest::Client,
+    source: &FeedSource,
+) -> anyhow::Result<Vec<WikiLink>> {
+    let body = client.get(source.url).send().await?.error_for_status()?.text().await?;
+    Ok(parse_feed_links(&body, source.label)
+        .into_iter()
+        .take(MAX_LINKS_PER_SOURCE)
+        .collect())
+}
+
+fn section_summary(section: &SectionSource, links: &[WikiLink]) -> String {
+    if links.is_empty() {
+        return section.fallback_summary.to_string();
+    }
+
+    let sources = links
+        .iter()
+        .map(|link| link.source.as_str())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    format!(
+        "A live digest of {} pulled from {}. Start with the linked source articles and papers below.",
+        section.summary_topic, sources
+    )
+}
+
+fn parse_feed_links(feed: &str, source_label: &str) -> Vec<WikiLink> {
+    let mut reader = Reader::from_str(feed);
+    reader.config_mut().trim_text(true);
+
+    let mut links = Vec::new();
+    let mut in_item = false;
+    let mut current_tag: Option<Vec<u8>> = None;
+    let mut title = String::new();
+    let mut link = String::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Eof) => break,
+            Ok(Event::Start(event)) => {
+                let name = event.name().as_ref().to_vec();
+                if name.as_slice() == b"item" || name.as_slice() == b"entry" {
+                    in_item = true;
+                    title.clear();
+                    link.clear();
+                } else if in_item && (name.as_slice() == b"title" || name.as_slice() == b"link") {
+                    if name.as_slice() == b"link" {
+                        if let Some(href) = event
+                            .attributes()
+                            .filter_map(Result::ok)
+                            .find(|attr| attr.key.as_ref() == b"href")
+                            .and_then(|attr| String::from_utf8(attr.value.into_owned()).ok())
+                        {
+                            link = href;
+                        }
+                    }
+                    current_tag = Some(name);
+                }
+            }
+            Ok(Event::Text(text)) => {
+                if in_item
+                    && let Some(tag) = current_tag.as_deref()
+                    && let Ok(decoded) = text.decode()
+                {
+                    match tag {
+                        b"title" if title.is_empty() => title = decoded.into_owned(),
+                        b"link" if link.is_empty() => link = decoded.into_owned(),
+                        _ => {}
+                    }
+                }
+            }
+            Ok(Event::End(event)) => {
+                let name = event.name().as_ref().to_vec();
+                if name.as_slice() == b"item" || name.as_slice() == b"entry" {
+                    if !title.trim().is_empty() && !link.trim().is_empty() {
+                        links.push(WikiLink {
+                            title: title.trim().to_string(),
+                            url: link.trim().to_string(),
+                            source: source_label.to_string(),
+                        });
+                    }
+                    in_item = false;
+                    current_tag = None;
+                } else if current_tag.as_deref() == Some(name.as_slice()) {
+                    current_tag = None;
+                }
+            }
+            Ok(Event::Empty(event)) => {
+                if in_item && event.name().as_ref() == b"link" && link.is_empty() {
+                    if let Some(href) = event
+                        .attributes()
+                        .filter_map(Result::ok)
+                        .find(|attr| attr.key.as_ref() == b"href")
+                        .and_then(|attr| String::from_utf8(attr.value.into_owned()).ok())
+                    {
+                        link = href;
+                    }
+                }
+            }
+            Ok(_) => {}
+            Err(_) => break,
+        }
+    }
+
+    links
+}

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -1174,6 +1174,21 @@ pub(crate) fn sample_site_stats() -> crate::templates::site::stats::SiteStats {
             running_total: vec![],
             total: 0,
         },
+        jobs: crate::templates::site::stats::SiteStatsSection {
+            per_month: vec![],
+            running_total: vec![],
+            total: 0,
+        },
+        landscape_startups: crate::templates::site::stats::SiteStatsSection {
+            per_month: vec![],
+            running_total: vec![],
+            total: 0,
+        },
+        landscape_open_source: crate::templates::site::stats::SiteStatsSection {
+            per_month: vec![],
+            running_total: vec![],
+            total: 0,
+        },
     }
 }
 

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -286,7 +286,9 @@ pub(crate) async fn setup(
         .route("/log-in", get(auth::log_in_page))
         .route("/jobs", get(site::jobs::page))
         .route("/jobs/{slug}", get(site::jobs::details))
+        .route("/landscape", get(site::landscape::page))
         .route("/stats", get(site::stats::page))
+        .route("/wiki", get(site::wiki::page))
         // Alliance-prefixed public routes
         .route("/{alliance}", get(alliance::page))
         .route("/{alliance}/group/{group_slug}", get(group::page))

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -4,8 +4,9 @@
 //! with their respective permission-based middleware layers.
 
 use axum::{
-    Router, middleware,
+    middleware,
     routing::{delete, get, post, put},
+    Router,
 };
 
 use crate::{
@@ -71,6 +72,7 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
             "/groups/{group_id}/update",
             get(dashboard::alliance::groups::update_page),
         )
+        .route("/landscape", get(dashboard::alliance::landscape::list_page))
         .route("/logs", get(dashboard::alliance::logs::list_page))
         .route(
             "/settings/update",
@@ -83,9 +85,7 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
             "/regions/{region_id}/update",
             get(dashboard::alliance::regions::update_page),
         )
-        .route_layer(check_selected_alliance_permission(
-            AlliancePermission::Read,
-        ));
+        .route_layer(check_selected_alliance_permission(AlliancePermission::Read));
 
     // Alliance groups management endpoints
     let groups_management = Router::new()
@@ -105,6 +105,29 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
         .route(
             "/groups/{group_id}/update",
             put(dashboard::alliance::groups::update),
+        )
+        .route_layer(check_selected_alliance_permission(
+            AlliancePermission::GroupsWrite,
+        ));
+
+    // Alliance landscape management endpoints
+    let landscape_management = Router::new()
+        .route("/landscape/add", post(dashboard::alliance::landscape::add))
+        .route(
+            "/landscape/{entry_id}/delete",
+            delete(dashboard::alliance::landscape::delete),
+        )
+        .route(
+            "/landscape/{entry_id}/publish",
+            put(dashboard::alliance::landscape::publish),
+        )
+        .route(
+            "/landscape/{entry_id}/unpublish",
+            put(dashboard::alliance::landscape::unpublish),
+        )
+        .route(
+            "/landscape/{entry_id}/update",
+            put(dashboard::alliance::landscape::update),
         )
         .route_layer(check_selected_alliance_permission(
             AlliancePermission::GroupsWrite,
@@ -179,11 +202,11 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
     Router::new()
         .route(
             "/",
-            get(dashboard::alliance::home::page)
-                .route_layer(check_alliance_dashboard_permission()),
+            get(dashboard::alliance::home::page).route_layer(check_alliance_dashboard_permission()),
         )
         .merge(dashboard_read)
         .merge(groups_management)
+        .merge(landscape_management)
         .merge(settings_management)
         .merge(taxonomy_management)
         .merge(team_management)

--- a/ocg-server/src/templates.rs
+++ b/ocg-server/src/templates.rs
@@ -41,7 +41,9 @@ pub(crate) enum PageId {
     SiteExplore,
     SiteHome,
     SiteJobs,
+    SiteLandscape,
     SiteNotFound,
     SiteStats,
+    SiteWiki,
     UserDashboard,
 }

--- a/ocg-server/src/templates/dashboard/alliance.rs
+++ b/ocg-server/src/templates/dashboard/alliance.rs
@@ -5,6 +5,7 @@ pub(crate) mod event_categories;
 pub(crate) mod group_categories;
 pub(crate) mod groups;
 pub(crate) mod home;
+pub(crate) mod landscape;
 pub(crate) mod regions;
 pub(crate) mod settings;
 pub(crate) mod team;

--- a/ocg-server/src/templates/dashboard/alliance/home.rs
+++ b/ocg-server/src/templates/dashboard/alliance/home.rs
@@ -7,16 +7,17 @@ use uuid::Uuid;
 
 use crate::{
     templates::{
-        PageId,
         auth::User,
         dashboard::{
-            audit,
             alliance::{
-                analytics, event_categories, group_categories, groups, regions, settings, team,
+                analytics, event_categories, group_categories, groups, landscape, regions,
+                settings, team,
             },
+            audit,
         },
         filters,
         helpers::user_initials,
+        PageId,
     },
     types::{alliance::AllianceSummary, site::SiteSettings},
 };
@@ -54,6 +55,8 @@ pub(crate) enum Content {
     GroupCategories(group_categories::ListPage),
     /// Groups management page.
     Groups(groups::ListPage),
+    /// Landscape management page.
+    Landscape(landscape::ListPage),
     /// Audit logs page.
     Logs(audit::ListPage),
     /// Regions management page.
@@ -85,6 +88,11 @@ impl Content {
         matches!(self, Content::Groups(_))
     }
 
+    /// Check if the content is the landscape page.
+    fn is_landscape(&self) -> bool {
+        matches!(self, Content::Landscape(_))
+    }
+
     /// Check if the content is the logs page.
     fn is_logs(&self) -> bool {
         matches!(self, Content::Logs(_))
@@ -113,6 +121,7 @@ impl std::fmt::Display for Content {
             Content::EventCategories(template) => write!(f, "{}", template.render()?),
             Content::GroupCategories(template) => write!(f, "{}", template.render()?),
             Content::Groups(template) => write!(f, "{}", template.render()?),
+            Content::Landscape(template) => write!(f, "{}", template.render()?),
             Content::Logs(template) => write!(f, "{}", template.render()?),
             Content::Regions(template) => write!(f, "{}", template.render()?),
             Content::Settings(template) => write!(f, "{}", template.render()?),
@@ -137,6 +146,8 @@ pub(crate) enum Tab {
     GroupCategories,
     /// Groups management tab.
     Groups,
+    /// Landscape management tab.
+    Landscape,
     /// Audit logs tab.
     Logs,
     /// Regions management tab.

--- a/ocg-server/src/templates/dashboard/alliance/landscape.rs
+++ b/ocg-server/src/templates/dashboard/alliance/landscape.rs
@@ -1,0 +1,25 @@
+//! Templates for the alliance landscape dashboard.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{
+    landscape::{DashboardLandscapeFilters, LandscapeEntry},
+    pagination::NavigationLinks,
+};
+
+/// Alliance landscape list page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/alliance/landscape.html")]
+pub(crate) struct ListPage {
+    /// Whether the current user can manage landscape entries.
+    pub can_manage_landscape: bool,
+    /// Pagination and search filters.
+    pub filters: DashboardLandscapeFilters,
+    /// Landscape entries in the selected alliance.
+    pub entries: Vec<LandscapeEntry>,
+    /// Total entries.
+    pub total: usize,
+    /// Pagination links.
+    pub navigation_links: NavigationLinks,
+}

--- a/ocg-server/src/templates/event.rs
+++ b/ocg-server/src/templates/event.rs
@@ -2,6 +2,7 @@
 
 use askama::Template;
 use chrono::{DateTime, Utc};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use uuid::Uuid;
@@ -51,6 +52,23 @@ impl Page {
                 self.event.group.public_slug(),
                 self.event.slug
             ),
+        )
+    }
+
+    /// Returns a LinkedIn share URL for the event page.
+    pub(crate) fn linkedin_share_url(&self) -> String {
+        format!(
+            "https://www.linkedin.com/sharing/share-offsite/?url={}",
+            utf8_percent_encode(&self.canonical_url(), NON_ALPHANUMERIC)
+        )
+    }
+
+    /// Returns suggested caption text for Instagram.
+    pub(crate) fn instagram_caption(&self) -> String {
+        format!(
+            "{}\n\n{}",
+            self.preview_title(),
+            self.preview_description()
         )
     }
 

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -6,7 +6,11 @@ pub(crate) mod explore;
 pub(crate) mod home;
 /// Templates for the jobs pages.
 pub(crate) mod jobs;
+/// Templates for the landscape page.
+pub(crate) mod landscape;
 /// Templates for the not found page.
 pub(crate) mod not_found;
 /// Templates for the stats page.
 pub(crate) mod stats;
+/// Templates for the wiki page.
+pub(crate) mod wiki;

--- a/ocg-server/src/templates/site/landscape.rs
+++ b/ocg-server/src/templates/site/landscape.rs
@@ -1,0 +1,35 @@
+//! Templates and types for the public landscape page.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{auth::User, filters, helpers::user_initials, PageId},
+    types::{
+        landscape::{LandscapeEntry, LandscapeFilters},
+        pagination::NavigationLinks,
+        site::SiteSettings,
+    },
+};
+
+/// Public landscape listing page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/landscape/page.html")]
+pub(crate) struct Page {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// Search filters.
+    pub filters: LandscapeFilters,
+    /// Matching landscape entries.
+    pub entries: Vec<LandscapeEntry>,
+    /// Total matching entries.
+    pub total: usize,
+    /// Pagination links.
+    pub navigation_links: NavigationLinks,
+}

--- a/ocg-server/src/templates/site/stats.rs
+++ b/ocg-server/src/templates/site/stats.rs
@@ -35,6 +35,12 @@ pub struct SiteStats {
     pub groups: SiteStatsSection,
     /// Members statistics.
     pub members: SiteStatsSection,
+    /// Jobs statistics.
+    pub jobs: SiteStatsSection,
+    /// Startup landscape statistics.
+    pub landscape_startups: SiteStatsSection,
+    /// Open-source landscape statistics.
+    pub landscape_open_source: SiteStatsSection,
 }
 
 /// Statistics for a single site section.

--- a/ocg-server/src/templates/site/wiki.rs
+++ b/ocg-server/src/templates/site/wiki.rs
@@ -1,0 +1,60 @@
+//! Templates and types for the public wiki page.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{PageId, auth::User, filters, helpers::user_initials},
+    types::site::SiteSettings,
+};
+
+/// Public wiki page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/wiki/page.html")]
+pub(crate) struct Page {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// Wiki sections.
+    pub sections: Vec<WikiSection>,
+}
+
+/// A topical wiki digest section.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct WikiSection {
+    /// Stable section identifier.
+    pub id: String,
+    /// Display title.
+    pub title: String,
+    /// Short generated summary.
+    pub summary: String,
+    /// Source labels used for this section.
+    pub sources: Vec<WikiSource>,
+    /// Current links.
+    pub links: Vec<WikiLink>,
+}
+
+/// Source metadata for a wiki section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct WikiSource {
+    /// Source label.
+    pub label: String,
+    /// Source URL.
+    pub url: String,
+}
+
+/// A source link in a wiki section.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct WikiLink {
+    /// Link title.
+    pub title: String,
+    /// Link URL.
+    pub url: String,
+    /// Source label.
+    pub source: String,
+}

--- a/ocg-server/src/types.rs
+++ b/ocg-server/src/types.rs
@@ -4,6 +4,7 @@ pub mod alliance;
 pub mod event;
 pub mod group;
 pub(crate) mod jobs;
+pub(crate) mod landscape;
 pub mod location;
 pub mod pagination;
 pub mod payments;

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -166,6 +166,19 @@ pub(crate) struct JobSummary {
     pub application_count: i32,
     /// Poster user identifier.
     pub posted_by_user_id: Uuid,
+    /// Poster username.
+    pub poster_username: String,
+    /// Poster display name.
+    pub poster_name: Option<String>,
+    /// Poster profile photo URL.
+    pub poster_photo_url: Option<String>,
+    /// Poster title.
+    pub poster_title: Option<String>,
+    /// Poster company.
+    pub poster_company: Option<String>,
+    /// Public expiration time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub expires_at: DateTime<Utc>,
     /// Creation time.
     #[serde(with = "chrono::serde::ts_seconds")]
     pub created_at: DateTime<Utc>,

--- a/ocg-server/src/types/landscape.rs
+++ b/ocg-server/src/types/landscape.rs
@@ -1,0 +1,181 @@
+//! Landscape domain types.
+
+use chrono::{DateTime, Utc};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use uuid::Uuid;
+
+use crate::{
+    templates::dashboard,
+    types::pagination::{Pagination, ToRawQuery},
+    validation::{
+        trimmed_non_empty, trimmed_non_empty_opt, MAX_LEN_DESCRIPTION, MAX_LEN_DESCRIPTION_SHORT,
+        MAX_LEN_ENTITY_NAME, MAX_LEN_M, MAX_LEN_TAG, MAX_PAGINATION_LIMIT,
+    },
+};
+
+/// Public landscape search filters.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct LandscapeFilters {
+    /// Free-text search query.
+    #[garde(length(max = MAX_LEN_M))]
+    pub query: Option<String>,
+    /// Filter by alliance slug/name.
+    #[garde(length(max = MAX_LEN_M))]
+    pub alliance: Option<String>,
+    /// Filter by entry kind.
+    #[garde(length(max = MAX_LEN_M))]
+    pub kind: Option<String>,
+    /// Filter by category.
+    #[garde(length(max = MAX_LEN_M))]
+    pub category: Option<String>,
+    /// Number of results per page.
+    #[serde(default = "dashboard::default_limit")]
+    #[garde(range(max = MAX_PAGINATION_LIMIT))]
+    pub limit: Option<usize>,
+    /// Pagination offset.
+    #[serde(default = "dashboard::default_offset")]
+    #[garde(skip)]
+    pub offset: Option<usize>,
+}
+
+crate::impl_pagination_and_raw_query!(LandscapeFilters, limit, offset);
+
+impl Default for LandscapeFilters {
+    fn default() -> Self {
+        Self {
+            query: None,
+            alliance: None,
+            kind: None,
+            category: None,
+            limit: Some(20),
+            offset: Some(0),
+        }
+    }
+}
+
+/// Alliance dashboard landscape filters.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct DashboardLandscapeFilters {
+    /// Free-text search query.
+    #[garde(length(max = MAX_LEN_M))]
+    pub query: Option<String>,
+    /// Number of results per page.
+    #[serde(default = "dashboard::default_limit")]
+    #[garde(range(max = MAX_PAGINATION_LIMIT))]
+    pub limit: Option<usize>,
+    /// Pagination offset.
+    #[serde(default = "dashboard::default_offset")]
+    #[garde(skip)]
+    pub offset: Option<usize>,
+}
+
+crate::impl_pagination_and_raw_query!(DashboardLandscapeFilters, limit, offset);
+
+impl Default for DashboardLandscapeFilters {
+    fn default() -> Self {
+        Self {
+            query: None,
+            limit: dashboard::default_limit(),
+            offset: dashboard::default_offset(),
+        }
+    }
+}
+
+/// Landscape form input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct LandscapeEntryInput {
+    /// Entry name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub name: String,
+    /// Entry kind, either startup or github_project.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub kind: String,
+    /// Short summary.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub summary: String,
+    /// Full description.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub description: Option<String>,
+    /// Website URL.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub website_url: Option<String>,
+    /// GitHub URL.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub github_url: Option<String>,
+    /// Logo URL.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub logo_url: Option<String>,
+    /// Category label.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub category: Option<String>,
+    /// Tags, comma-separated.
+    #[garde(length(max = MAX_LEN_M))]
+    pub tags: Option<String>,
+}
+
+/// Landscape search output.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct LandscapeOutput {
+    /// Matching landscape entries.
+    pub entries: Vec<LandscapeEntry>,
+    /// Total matching entries.
+    pub total: usize,
+}
+
+/// Public or dashboard landscape entry.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LandscapeEntry {
+    /// Entry identifier.
+    pub landscape_entry_id: Uuid,
+    /// Owning alliance identifier.
+    pub alliance_id: Uuid,
+    /// User that added the entry.
+    pub added_by_user_id: Uuid,
+    /// Entry name.
+    pub name: String,
+    /// URL slug.
+    pub slug: String,
+    /// Entry kind.
+    pub kind: String,
+    /// Short summary.
+    pub summary: String,
+    /// Full description.
+    pub description: Option<String>,
+    /// Website URL.
+    pub website_url: Option<String>,
+    /// GitHub URL.
+    pub github_url: Option<String>,
+    /// Logo URL.
+    pub logo_url: Option<String>,
+    /// Category label.
+    pub category: Option<String>,
+    /// Tags.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Whether the entry is public.
+    pub published: bool,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    /// Last update time.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Tags parsed from comma-separated form input.
+pub(crate) fn parse_tags(input: Option<&str>) -> Vec<String> {
+    input
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty())
+        .take(12)
+        .map(|tag| tag.chars().take(MAX_LEN_TAG).collect())
+        .collect()
+}

--- a/ocg-server/static/js/common/modals/share-modal.js
+++ b/ocg-server/static/js/common/modals/share-modal.js
@@ -14,6 +14,7 @@ import "/static/vendor/js/sharer.v0.5.3.min.js";
  * ShareModal displays a Share button that opens a modal with share options.
  * @extends LitWrapper
  * @property {string} triggerVariant - The trigger style variant
+ * @property {string} instagramCaption - Suggested caption for Instagram sharing
  * @property {string} title - The title to share
  * @property {string} url - The URL to share
  */
@@ -24,6 +25,7 @@ export class ShareModal extends LitWrapper {
    */
   static get properties() {
     return {
+      instagramCaption: { type: String, attribute: "instagram-caption" },
       triggerVariant: { type: String, attribute: "trigger-variant" },
       title: { type: String },
       url: { type: String },
@@ -33,6 +35,7 @@ export class ShareModal extends LitWrapper {
 
   constructor() {
     super();
+    this.instagramCaption = "";
     this.triggerVariant = "button";
     this.title = "";
     this.url = "";
@@ -207,6 +210,23 @@ export class ShareModal extends LitWrapper {
   }
 
   /**
+   * Handles click on Instagram copy button.
+   * Copies the suggested caption and event link to clipboard.
+   */
+  async _handleInstagramCopyClick() {
+    const caption = this.instagramCaption?.trim() || this.title;
+    const text = `${caption}\n\n${this._getFullUrl()}`.trim();
+
+    try {
+      await navigator.clipboard.writeText(text);
+      showSuccessAlert("Instagram caption copied to clipboard!");
+      this._closeModal();
+    } catch {
+      showErrorAlert("Failed to copy Instagram caption. Please try again.");
+    }
+  }
+
+  /**
    * Renders the control that opens the share modal.
    * @returns {TemplateResult} The share trigger template
    */
@@ -269,6 +289,31 @@ export class ShareModal extends LitWrapper {
   }
 
   /**
+   * Renders an Instagram caption copy button when caption text is available.
+   * @returns {TemplateResult|string} Instagram copy button or empty string
+   */
+  _renderInstagramCopyButton() {
+    if (!this.instagramCaption) {
+      return "";
+    }
+
+    return html`
+      <button
+        type="button"
+        class="group btn-secondary-anchor flex items-center justify-center size-12 p-2"
+        title="Copy Instagram caption"
+        aria-label="Copy Instagram caption"
+        @click=${() => this._handleInstagramCopyClick()}
+      >
+        <div
+          class="svg-icon size-5 bg-primary-500 group-hover:bg-white transition-colors
+                 icon-instagram"
+        ></div>
+      </button>
+    `;
+  }
+
+  /**
    * Renders the share modal.
    * @returns {TemplateResult} The component template
    */
@@ -318,7 +363,13 @@ export class ShareModal extends LitWrapper {
                 ${this._renderShareButton("reddit", "reddit", "Reddit")}
                 ${this._renderShareButton("linkedin", "linkedin", "LinkedIn")}
                 ${this._renderShareButton("bluesky", "bluesky", "Bluesky")}
+                ${this._renderInstagramCopyButton()}
               </div>
+              ${this.instagramCaption
+                ? html`<p class="mt-3 text-xs text-stone-500">
+                    Instagram does not support prefilled web posts. Use the Instagram button to copy a caption and event link.
+                  </p>`
+                : ""}
 
               <div class="border-t border-stone-200 mt-5 pt-5">
                 <div class="text-sm font-medium text-stone-700 mb-3">Copy link</div>

--- a/ocg-server/static/js/dashboard/group/event-update.js
+++ b/ocg-server/static/js/dashboard/group/event-update.js
@@ -6,6 +6,7 @@ import {
   markDatasetReady,
 } from "/static/js/common/dom.js";
 import { parseJsonAttribute } from "/static/js/common/utils.js";
+import "/static/js/common/modals/share-modal.js";
 import { initializeSessionsRemovalWarning } from "/static/js/dashboard/group/event-form-helpers.js";
 import { initializeEventPreview } from "/static/js/dashboard/group/event-preview.js";
 import "/static/js/dashboard/group/questions-editor.js";

--- a/ocg-server/static/js/site/stats.js
+++ b/ocg-server/static/js/site/stats.js
@@ -126,6 +126,9 @@ export const initSiteStatsCharts = async (stats) => {
     { key: "members", label: "Members" },
     { key: "events", label: "Events" },
     { key: "attendees", label: "Attendees" },
+    { key: "jobs", label: "Jobs" },
+    { key: "landscape_startups", label: "Startups" },
+    { key: "landscape_open_source", label: "Open Source" },
   ];
 
   for (const section of sections) {

--- a/ocg-server/templates/common/base.html
+++ b/ocg-server/templates/common/base.html
@@ -52,7 +52,8 @@
     {#- End Twitter tags #}
 
     {% if let Some(favicon_url) = &site_settings.favicon_url -%}
-      <link rel="icon" href="{{ favicon_url }}" sizes="any">
+      <link rel="icon" type="image/png" href="{{ favicon_url }}" sizes="any">
+      <link rel="shortcut icon" type="image/png" href="{{ favicon_url }}">
 
     {% endif -%}
     <meta charset="UTF-8" />

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -29,7 +29,8 @@
         {{ header::link(content = "Explore", href = explore_events, current_path = path, path = "/explore") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
         {{ header::link(content = "Jobs", href = "/jobs", current_path = path, path = "/jobs") -}}
-        {{ header::link(content = "Landscape", href = "https://landscape.cncf.io/", current_path = path, hx_boost = "false", hx_target = "", target = "_blank") -}}
+        {{ header::link(content = "Landscape", href = "/landscape", current_path = path, path = "/landscape") -}}
+        {{ header::link(content = "Wiki", href = "/wiki", current_path = path, path = "/wiki") -}}
       </div>
       {# End desktop links -#}
     </div>
@@ -43,7 +44,7 @@
               aria-pressed="false">
         <span class="theme-toggle-icon text-base leading-none" aria-hidden="true">☾</span>
       </button>
-      {% if page_id == PageId::SiteHome || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteStats || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
+      {% if page_id == PageId::SiteHome || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
         <div hx-get="/section/user-menu"
              hx-trigger="load"
              hx-target="this"
@@ -148,15 +149,28 @@
           </li>
 
           <li class="lg:hidden" role="none">
-            <a href="https://landscape.cncf.io/"
-               hx-boost="false"
-               target="_blank"
-               rel="noopener noreferrer"
+            <a href="/landscape"
+               hx-boost="true"
+               hx-target="body"
                class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-map bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Landscape</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="/wiki"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-list bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Wiki</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/ocg-server/templates/dashboard/alliance/home.html
+++ b/ocg-server/templates/dashboard/alliance/home.html
@@ -57,6 +57,7 @@
     <div class="leading-10 pt-6 border-t border-stone-200 grid gap-y-0.5">
       {{ dashboard::menu_title(text = "Groups", extra_styles = "py-1.5") -}}
       {{ dashboard::menu_item(name = "Groups", icon = "groups", is_active = content.is_groups() , href = "/dashboard/alliance?tab=groups") -}}
+      {{ dashboard::menu_item(name = "Landscape", icon = "map", is_active = content.is_landscape() , href = "/dashboard/alliance?tab=landscape") -}}
     </div>
     {# End groups -#}
 
@@ -71,7 +72,7 @@
 
 {% block dashboard_main -%}
   <div id="dashboard-content"
-       hx-get="/dashboard/alliance/{%- if content.is_team() -%}team{%- elif content.is_settings() -%}settings/update{%- elif content.is_regions() -%}regions{%- elif content.is_logs() -%}logs{%- elif content.is_group_categories() -%}group-categories{%- elif content.is_event_categories() -%}event-categories{%- elif content.is_analytics() -%}analytics{%- else -%}groups{%- endif -%}"
+       hx-get="/dashboard/alliance/{%- if content.is_team() -%}team{%- elif content.is_settings() -%}settings/update{%- elif content.is_regions() -%}regions{%- elif content.is_logs() -%}logs{%- elif content.is_group_categories() -%}group-categories{%- elif content.is_event_categories() -%}event-categories{%- elif content.is_analytics() -%}analytics{%- elif content.is_landscape() -%}landscape{%- else -%}groups{%- endif -%}"
        hx-trigger="refresh-alliance-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -1,0 +1,203 @@
+{% import "macros/dashboard.html" as dashboard -%}
+{% import "macros/pagination.html" as pagination -%}
+
+{{ dashboard::page_title(title = "Landscape", description = "Manage startups and GitHub projects shown on the public landscape.") -}}
+
+{% if can_manage_landscape -%}
+  <section class="mt-8 rounded-2xl border border-stone-200 bg-stone-50 p-5">
+    <h2 class="text-lg font-semibold text-stone-950">Add landscape entry</h2>
+    <form class="mt-4 grid gap-4"
+          hx-post="/dashboard/alliance/landscape/add"
+          hx-target="#dashboard-content">
+      <div class="grid gap-4 lg:grid-cols-3">
+        <div>
+          <label class="label" for="new-landscape-name">Name</label>
+          <input id="new-landscape-name" name="name" class="input" required />
+        </div>
+        <div>
+          <label class="label" for="new-landscape-kind">Kind</label>
+          <select id="new-landscape-kind" name="kind" class="input" required>
+            <option value="startup">Startup</option>
+            <option value="github_project">GitHub project</option>
+          </select>
+        </div>
+        <div>
+          <label class="label" for="new-landscape-category">Category</label>
+          <input id="new-landscape-category" name="category" class="input" placeholder="AI, DevOps, Fintech" />
+        </div>
+      </div>
+      <div>
+        <label class="label" for="new-landscape-summary">Summary</label>
+        <input id="new-landscape-summary" name="summary" class="input" required maxlength="500" />
+      </div>
+      <div>
+        <label class="label" for="new-landscape-description">Description</label>
+        <textarea id="new-landscape-description" name="description" rows="4" class="input"></textarea>
+      </div>
+      <div class="grid gap-4 lg:grid-cols-4">
+        <div>
+          <label class="label" for="new-landscape-website">Website URL</label>
+          <input id="new-landscape-website" name="website_url" class="input" />
+        </div>
+        <div>
+          <label class="label" for="new-landscape-github">GitHub URL</label>
+          <input id="new-landscape-github" name="github_url" class="input" />
+        </div>
+        <div>
+          <label class="label" for="new-landscape-logo">Logo URL</label>
+          <input id="new-landscape-logo" name="logo_url" class="input" />
+        </div>
+        <div>
+          <label class="label" for="new-landscape-tags">Tags</label>
+          <input id="new-landscape-tags" name="tags" class="input" placeholder="Rust, SaaS, OSS" />
+        </div>
+      </div>
+      <div>
+        <button class="btn-primary" type="submit">Add entry</button>
+      </div>
+    </form>
+  </section>
+{% endif -%}
+
+<form method="get"
+      action="/dashboard/alliance"
+      hx-get="/dashboard/alliance/landscape"
+      hx-target="#dashboard-content"
+      class="my-8 grid gap-3 rounded-2xl border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_auto]">
+  <input type="hidden" name="tab" value="landscape" />
+  <label class="sr-only" for="landscape-dashboard-query">Search landscape</label>
+  <input id="landscape-dashboard-query"
+         name="query"
+         value="{{ filters.query.as_deref().unwrap_or("") }}"
+         class="input"
+         placeholder="Search landscape entries" />
+  <button class="btn-primary" type="submit">Search</button>
+</form>
+
+<div class="mb-5 flex items-center justify-between gap-3">
+  <div class="text-sm text-stone-600">
+    {{ pagination::range_display(offset = filters.offset.unwrap_or(0), count = entries.len(), total = total, label = "entry") }}
+  </div>
+  <a class="text-sm font-semibold text-primary-700 hover:text-primary-900" href="/landscape">Public landscape</a>
+</div>
+
+{% if entries.is_empty() -%}
+  <div class="rounded-2xl border border-dashed border-stone-300 bg-white px-6 py-16 text-center">
+    <h2 class="text-lg font-semibold text-stone-900">No landscape entries yet</h2>
+    <p class="mt-2 text-sm text-stone-600">Add startups or GitHub projects using the form above.</p>
+  </div>
+{% else -%}
+  <div class="grid gap-5">
+    {% for entry in entries -%}
+      <article class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+        <div class="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <div class="flex flex-wrap items-center gap-2">
+              <h2 class="text-lg font-semibold text-stone-950">{{ entry.name }}</h2>
+              <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">
+                {% if entry.kind == "github_project" %}GitHub project{% else %}Startup{% endif %}
+              </span>
+              {% if entry.published -%}
+                <span class="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">Published</span>
+              {% else -%}
+                <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">Draft</span>
+              {% endif -%}
+            </div>
+            <p class="mt-1 text-sm text-stone-600">{{ entry.summary }}</p>
+          </div>
+        </div>
+
+        <form class="grid gap-4"
+              hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/update"
+              hx-target="#dashboard-content">
+          <div class="grid gap-4 lg:grid-cols-3">
+            <div>
+              <label class="label" for="landscape-name-{{ entry.landscape_entry_id }}">Name</label>
+              <input id="landscape-name-{{ entry.landscape_entry_id }}" name="name" class="input" value="{{ entry.name }}" required />
+            </div>
+            <div>
+              <label class="label" for="landscape-kind-{{ entry.landscape_entry_id }}">Kind</label>
+              <select id="landscape-kind-{{ entry.landscape_entry_id }}" name="kind" class="input" required>
+                <option value="startup" {% if entry.kind == "startup" %}selected{% endif %}>Startup</option>
+                <option value="github_project" {% if entry.kind == "github_project" %}selected{% endif %}>GitHub project</option>
+              </select>
+            </div>
+            <div>
+              <label class="label" for="landscape-category-{{ entry.landscape_entry_id }}">Category</label>
+              <input id="landscape-category-{{ entry.landscape_entry_id }}"
+                     name="category"
+                     class="input"
+                     value="{{ entry.category.as_deref().unwrap_or("") }}" />
+            </div>
+          </div>
+          <div>
+            <label class="label" for="landscape-summary-{{ entry.landscape_entry_id }}">Summary</label>
+            <input id="landscape-summary-{{ entry.landscape_entry_id }}"
+                   name="summary"
+                   class="input"
+                   value="{{ entry.summary }}"
+                   required
+                   maxlength="500" />
+          </div>
+          <div>
+            <label class="label" for="landscape-description-{{ entry.landscape_entry_id }}">Description</label>
+            <textarea id="landscape-description-{{ entry.landscape_entry_id }}" name="description" rows="4" class="input">{{ entry.description.as_deref().unwrap_or("") }}</textarea>
+          </div>
+          <div class="grid gap-4 lg:grid-cols-4">
+            <div>
+              <label class="label" for="landscape-website-{{ entry.landscape_entry_id }}">Website URL</label>
+              <input id="landscape-website-{{ entry.landscape_entry_id }}"
+                     name="website_url"
+                     class="input"
+                     value="{{ entry.website_url.as_deref().unwrap_or("") }}" />
+            </div>
+            <div>
+              <label class="label" for="landscape-github-{{ entry.landscape_entry_id }}">GitHub URL</label>
+              <input id="landscape-github-{{ entry.landscape_entry_id }}"
+                     name="github_url"
+                     class="input"
+                     value="{{ entry.github_url.as_deref().unwrap_or("") }}" />
+            </div>
+            <div>
+              <label class="label" for="landscape-logo-{{ entry.landscape_entry_id }}">Logo URL</label>
+              <input id="landscape-logo-{{ entry.landscape_entry_id }}"
+                     name="logo_url"
+                     class="input"
+                     value="{{ entry.logo_url.as_deref().unwrap_or("") }}" />
+            </div>
+            <div>
+              <label class="label" for="landscape-tags-{{ entry.landscape_entry_id }}">Tags</label>
+              <input id="landscape-tags-{{ entry.landscape_entry_id }}"
+                     name="tags"
+                     class="input"
+                     value="{{ entry.tags.join(", ") }}" />
+            </div>
+          </div>
+          {% if can_manage_landscape -%}
+            <div class="flex flex-wrap gap-2">
+              <button class="btn-primary" type="submit">Save changes</button>
+              {% if entry.published -%}
+                <button class="btn-secondary"
+                        type="button"
+                        hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/unpublish"
+                        hx-target="#dashboard-content">Unpublish</button>
+              {% else -%}
+                <button class="btn-secondary"
+                        type="button"
+                        hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/publish"
+                        hx-target="#dashboard-content">Publish</button>
+              {% endif -%}
+              <button class="btn-tertiary"
+                      type="button"
+                      hx-delete="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/delete"
+                      hx-confirm="Delete this landscape entry?"
+                      hx-target="#dashboard-content">Delete</button>
+            </div>
+          {% endif -%}
+        </form>
+      </article>
+    {% endfor -%}
+  </div>
+
+  {{ pagination::navigation_links(links = navigation_links, hx_target = "#dashboard-content") }}
+{% endif -%}

--- a/ocg-server/templates/dashboard/group/events_update.html
+++ b/ocg-server/templates/dashboard/group/events_update.html
@@ -83,6 +83,8 @@
           <div class="svg-icon size-3 icon-eye shrink-0"></div>
           <span>Public page</span>
         </a>
+        <share-modal title="{{ event.name }}" url="{{ event_public_url }}" instagram-caption="Join us for {{ event.name }} with {{ event.group.name }}.">
+        </share-modal>
       {% else -%}
         <button id="event-public-page-link"
                 type="button"

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -107,7 +107,9 @@
                     <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">Draft</span>
                   {% endif -%}
                 </div>
-                <p class="mt-1 text-sm text-stone-600">{{ job.company_name }} · {{ job.application_count }} application{% if job.application_count != 1 %}s{% endif %}</p>
+                <p class="mt-1 text-sm text-stone-600">
+                  {{ job.company_name }} · {{ job.application_count }} application{% if job.application_count != 1 %}s{% endif %} · visible until {{ job.expires_at.format("%b %d, %Y") }}
+                </p>
               </div>
               <a class="text-sm font-semibold text-primary-700 hover:text-primary-900"
                  href="/jobs/{{ job.slug }}">View</a>

--- a/ocg-server/templates/event/attend_button.html
+++ b/ocg-server/templates/event/attend_button.html
@@ -409,7 +409,7 @@
         <div class="svg-icon size-4 icon-vertical-dots"></div>
       </summary>
       <div class="absolute left-4 z-20 mt-2 w-56 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-stone-200 bg-white py-1 shadow-lg sm:left-auto sm:right-0 sm:w-max sm:min-w-48">
-        <share-modal trigger-variant="menu-item" title="{{ event.group.name }} · {{ event.name }}" url="/{{ event.alliance.name }}/group/{{ event.group.public_slug() }}/event/{{ event.slug }}">
+        <share-modal trigger-variant="menu-item" title="{{ event.group.name }} · {{ event.name }}" url="/{{ event.alliance.name }}/group/{{ event.group.public_slug() }}/event/{{ event.slug }}" instagram-caption="{{ self.instagram_caption() }}">
         </share-modal>
         {% if let Some(meeting_join_url) = &event.meeting_join_url %}
           <a id="join-meeting-menu-btn-{{ attendance_instance }}"

--- a/ocg-server/templates/event/page.html
+++ b/ocg-server/templates/event/page.html
@@ -202,6 +202,16 @@
             </div>
 
             <div class="flex max-w-full flex-row flex-wrap gap-2 sm:flex-nowrap sm:gap-3 md:col-start-3 md:row-start-2 md:self-end md:justify-end md:gap-4">
+              <a href="{{ self.linkedin_share_url() }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 hx-boost="false"
+                 class="group btn-primary-outline-anchor hidden h-10 items-center justify-center gap-2 px-4 md:inline-flex"
+                 aria-label="Share on LinkedIn"
+                 title="Share on LinkedIn">
+                <div class="svg-icon size-4 icon-linkedin bg-primary-500 transition-colors group-hover:bg-white"></div>
+                <span>LinkedIn</span>
+              </a>
               {# Attend button section -#}
               {% let attendance_instance = "main" -%}
               {% include "event/attend_button.html" %}

--- a/ocg-server/templates/site/jobs/details.html
+++ b/ocg-server/templates/site/jobs/details.html
@@ -21,6 +21,7 @@
           <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">{{ location }}</span>
         {% endif -%}
         <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">Posted {{ job.summary.created_at.format("%b %d, %Y") }}</span>
+        <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">Open until {{ job.summary.expires_at.format("%b %d, %Y") }}</span>
       </div>
     </div>
   </div>
@@ -43,45 +44,71 @@
       <div class="whitespace-pre-line text-sm/7 text-stone-700">{{ job.summary.description }}</div>
     </article>
 
-    <aside class="h-fit rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
-      <h2 class="text-lg font-semibold text-stone-950">Apply</h2>
-      <p class="mt-2 text-sm/6 text-stone-600">
-        Use the employer application link or save your interest with GOUP.
-      </p>
-
-      <a class="btn-primary mt-5 w-full justify-center"
-         href="{{ job.summary.apply_url }}"
-         target="_blank"
-         rel="noopener noreferrer"
-         hx-boost="false">Apply on company site</a>
-
-      {% if user.logged_in -%}
-        {% if job.viewer_has_applied -%}
-          <div class="mt-5 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-900">
-            Your interest has been saved.
+    <aside class="h-fit overflow-hidden rounded-3xl border border-stone-200 bg-white shadow-sm">
+      <div class="border-b border-stone-100 bg-linear-to-br from-primary-50 via-white to-stone-50 p-5">
+        <div class="flex items-center gap-3">
+          <div class="flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-full bg-white text-sm font-semibold uppercase text-primary-700 ring-1 ring-inset ring-primary-100">
+            {% if let Some(photo_url) = &job.summary.poster_photo_url -%}
+              <img src="{{ photo_url }}"
+                   alt="{{ job.summary.poster_name.as_deref().unwrap_or(job.summary.poster_username.as_str()) }}"
+                   class="h-full w-full object-cover"
+                   loading="lazy" />
+            {% else -%}
+              {{ self::user_initials(job.summary.poster_name.as_deref(), job.summary.poster_username.as_str()) }}
+            {% endif -%}
           </div>
+          <div class="min-w-0">
+            <div class="text-xs font-semibold uppercase tracking-wide text-primary-700">Posted by</div>
+            <div class="truncate font-semibold text-stone-950">{{ job.summary.poster_name.as_deref().unwrap_or(job.summary.poster_username.as_str()) }}</div>
+            <div class="truncate text-xs text-stone-500">
+              {% if let Some(title) = &job.summary.poster_title -%}{{ title }}{% if job.summary.poster_company.is_some() %} · {% endif %}{% endif -%}
+              {% if let Some(company) = &job.summary.poster_company -%}{{ company }}{% endif -%}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="p-5">
+        <h2 class="text-lg font-semibold text-stone-950">Apply</h2>
+        <p class="mt-2 text-sm/6 text-stone-600">
+          Apply directly on the company site or save your interest so the GOUP member who posted this role can follow up.
+        </p>
+
+        <a class="btn-primary mt-5 w-full justify-center"
+           href="{{ job.summary.apply_url }}"
+           target="_blank"
+           rel="noopener noreferrer"
+           hx-boost="false">Apply on company site</a>
+
+        {% if user.logged_in -%}
+          {% if job.viewer_has_applied -%}
+            <div class="mt-5 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+              Your interest has been saved. The poster can see your note from the jobs dashboard.
+            </div>
+          {% else -%}
+            <form class="mt-5 rounded-2xl border border-stone-200 bg-stone-50 p-4"
+                  hx-post="/jobs/{{ job.summary.job_id }}/apply"
+                  hx-swap="none"
+                  hx-disabled-elt="button">
+              <label class="mb-2 block text-sm font-semibold text-stone-800" for="job-application-note">
+                Note to the poster
+              </label>
+              <textarea id="job-application-note"
+                        name="note"
+                        rows="5"
+                        class="input bg-white"
+                        placeholder="Briefly share why this role is interesting or how they can reach you."></textarea>
+              <p class="mt-2 text-xs text-stone-500">This does not replace the official application.</p>
+              <button class="btn-secondary mt-4 w-full justify-center" type="submit">
+                Save my interest
+              </button>
+            </form>
+          {% endif -%}
         {% else -%}
-          <form class="mt-5"
-                hx-post="/jobs/{{ job.summary.job_id }}/apply"
-                hx-swap="none"
-                hx-disabled-elt="button">
-            <label class="mb-2 block text-sm font-medium text-stone-700" for="job-application-note">
-              Optional note
-            </label>
-            <textarea id="job-application-note"
-                      name="note"
-                      rows="4"
-                      class="input"
-                      placeholder="Share a short note for the poster"></textarea>
-            <button class="btn-secondary mt-3 w-full justify-center" type="submit">
-              Save interest
-            </button>
-          </form>
+          <a class="btn-secondary mt-3 w-full justify-center"
+             href="/log-in?next_url=/jobs/{{ job.summary.slug }}">Log in to save interest</a>
         {% endif -%}
-      {% else -%}
-        <a class="btn-secondary mt-3 w-full justify-center"
-           href="/log-in?next_url=/jobs/{{ job.summary.slug }}">Log in to save interest</a>
-      {% endif -%}
+      </div>
     </aside>
   </div>
 {% endblock content -%}

--- a/ocg-server/templates/site/jobs/page.html
+++ b/ocg-server/templates/site/jobs/page.html
@@ -81,6 +81,25 @@
                   <a class="hover:text-primary-700" href="/jobs/{{ job.slug }}">{{ job.title }}</a>
                 </h2>
                 <p class="mt-2 max-w-3xl text-sm/6 text-stone-600">{{ job.summary }}</p>
+                <div class="mt-4 flex items-center gap-3 text-sm text-stone-600">
+                  <div class="flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-full bg-primary-50 text-xs font-semibold uppercase text-primary-700 ring-1 ring-inset ring-primary-100">
+                    {% if let Some(photo_url) = &job.poster_photo_url -%}
+                      <img src="{{ photo_url }}"
+                           alt="{{ job.poster_name.as_deref().unwrap_or(job.poster_username.as_str()) }}"
+                           class="h-full w-full object-cover"
+                           loading="lazy" />
+                    {% else -%}
+                      {{ self::user_initials(job.poster_name.as_deref(), job.poster_username.as_str()) }}
+                    {% endif -%}
+                  </div>
+                  <div>
+                    <div class="font-medium text-stone-800">Posted by {{ job.poster_name.as_deref().unwrap_or(job.poster_username.as_str()) }}</div>
+                    <div class="text-xs text-stone-500">
+                      {% if let Some(title) = &job.poster_title -%}{{ title }}{% if job.poster_company.is_some() %} · {% endif %}{% endif -%}
+                      {% if let Some(company) = &job.poster_company -%}{{ company }}{% endif -%}
+                    </div>
+                  </div>
+                </div>
                 {% if !job.tags.is_empty() -%}
                   <div class="mt-4 flex flex-wrap gap-2">
                     {% for tag in job.tags -%}
@@ -91,6 +110,7 @@
               </div>
               <div class="shrink-0 text-sm text-stone-500 lg:text-right">
                 <div>Posted {{ job.created_at.format("%b %d, %Y") }}</div>
+                <div>Open until {{ job.expires_at.format("%b %d, %Y") }}</div>
                 <a class="mt-3 inline-flex font-semibold text-primary-700 hover:text-primary-900"
                    href="/jobs/{{ job.slug }}">View role</a>
               </div>

--- a/ocg-server/templates/site/landscape/page.html
+++ b/ocg-server/templates/site/landscape/page.html
@@ -1,0 +1,122 @@
+{% extends "common/base.html" -%}
+{% import "macros/pagination.html" as pagination -%}
+
+{% block jumbotron -%}
+  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
+    <div class="relative max-w-3xl">
+      <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Landscape</p>
+      <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
+        Startups and open projects in the GOUP Alliance
+      </h1>
+      <p class="max-w-2xl text-base/7 text-stone-600">
+        Browse alliance startups, GitHub projects, tools, and community-built products.
+      </p>
+    </div>
+  </div>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
+    <form method="get"
+          action="/landscape"
+          class="mb-8 grid gap-3 rounded-2xl border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_180px_220px_auto]">
+      <label class="sr-only" for="landscape-query">Search landscape</label>
+      <input id="landscape-query"
+             name="query"
+             value="{{ filters.query.as_deref().unwrap_or("") }}"
+             class="input"
+             placeholder="Search startups, GitHub projects, categories, or tags" />
+
+      <label class="sr-only" for="landscape-kind">Kind</label>
+      <select id="landscape-kind" name="kind" class="input">
+        <option value="">All kinds</option>
+        <option value="startup" {% if filters.kind.as_deref() == Some("startup") %}selected{% endif %}>Startups</option>
+        <option value="github_project" {% if filters.kind.as_deref() == Some("github_project") %}selected{% endif %}>GitHub projects</option>
+      </select>
+
+      <label class="sr-only" for="landscape-category">Category</label>
+      <input id="landscape-category"
+             name="category"
+             value="{{ filters.category.as_deref().unwrap_or("") }}"
+             class="input"
+             placeholder="Category" />
+
+      <button class="btn-primary" type="submit">Search</button>
+    </form>
+
+    <div class="mb-5 flex items-center justify-between gap-3">
+      <div class="text-sm text-stone-600">
+        {{ pagination::range_display(offset = filters.offset.unwrap_or(0), count = entries.len(), total = total, label = "entry") }}
+      </div>
+      {% if user.belongs_to_alliance_team.unwrap_or(false) -%}
+        <a class="btn-secondary" href="/dashboard/alliance?tab=landscape">Manage landscape</a>
+      {% endif -%}
+    </div>
+
+    {% if entries.is_empty() -%}
+      <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-6 py-16 text-center">
+        <h2 class="text-lg font-semibold text-stone-900">No landscape entries found</h2>
+        <p class="mt-2 text-sm text-stone-600">Try a broader search or clear the filters.</p>
+      </div>
+    {% else -%}
+      <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {% for entry in entries -%}
+          <article class="flex h-full flex-col rounded-2xl border border-stone-200 bg-white p-5 shadow-sm transition hover:border-primary-200 hover:shadow-md">
+            <div class="mb-4 flex items-start gap-4">
+              <div class="flex size-14 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-stone-100 ring-1 ring-inset ring-stone-200">
+                {% if let Some(logo_url) = &entry.logo_url -%}
+                  <img src="{{ logo_url }}"
+                       alt="{{ entry.name }} logo"
+                       class="h-full w-full object-cover"
+                       loading="lazy" />
+                {% else -%}
+                  <div class="svg-icon size-7 icon-buildings bg-primary-600"></div>
+                {% endif -%}
+              </div>
+              <div class="min-w-0">
+                <div class="mb-2 flex flex-wrap items-center gap-2">
+                  <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">
+                    {% if entry.kind == "github_project" %}GitHub project{% else %}Startup{% endif %}
+                  </span>
+                  {% if let Some(category) = &entry.category -%}
+                    <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">{{ category }}</span>
+                  {% endif -%}
+                </div>
+                <h2 class="truncate text-xl font-semibold text-stone-950">{{ entry.name }}</h2>
+              </div>
+            </div>
+
+            <p class="text-sm/6 text-stone-600">{{ entry.summary }}</p>
+
+            {% if !entry.tags.is_empty() -%}
+              <div class="mt-4 flex flex-wrap gap-2">
+                {% for tag in entry.tags -%}
+                  <span class="rounded-full bg-stone-50 px-2.5 py-1 text-xs font-medium text-stone-700 ring-1 ring-inset ring-stone-200">{{ tag }}</span>
+                {% endfor -%}
+              </div>
+            {% endif -%}
+
+            <div class="mt-auto flex flex-wrap gap-2 pt-5">
+              {% if let Some(website_url) = &entry.website_url -%}
+                <a class="btn-secondary-anchor"
+                   href="{{ website_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   hx-boost="false">Website</a>
+              {% endif -%}
+              {% if let Some(github_url) = &entry.github_url -%}
+                <a class="btn-secondary-anchor"
+                   href="{{ github_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   hx-boost="false">GitHub</a>
+              {% endif -%}
+            </div>
+          </article>
+        {% endfor -%}
+      </div>
+
+      {{ pagination::navigation_links(links = navigation_links, hx_target = "body") }}
+    {% endif -%}
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/stats/page.html
+++ b/ocg-server/templates/site/stats/page.html
@@ -12,9 +12,16 @@
         </div>
       </div>
 
-      <div class="space-y-12">
-        {# Groups section #}
-        <section class="space-y-6">
+      <div class="space-y-14">
+        {# Alliance section #}
+        <section class="space-y-8 rounded-3xl border border-stone-200 bg-white/70 p-5 shadow-sm lg:p-7">
+          <div>
+            <div class="text-xl lg:text-2xl font-semibold text-stone-900">Alliance</div>
+            <p class="mt-1 text-sm/6 text-stone-500">Current alliance growth across groups, members, events, and attendees.</p>
+          </div>
+
+          {# Groups section #}
+          <div class="space-y-6">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="text-lg lg:text-xl font-semibold text-stone-900">Groups</div>
             <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
@@ -27,11 +34,11 @@
             {{ stats_macro::analytics_chart(chart_id = "groups-running-chart", data = stats.groups.running_total, class = "h-[320px]", min_points = 1) -}}
             {{ stats_macro::analytics_chart(chart_id = "groups-monthly-chart", data = stats.groups.per_month, class = "h-[320px]") -}}
           </div>
-        </section>
-        {# End groups section #}
+          </div>
+          {# End groups section #}
 
-        {# Members section #}
-        <section class="space-y-6">
+          {# Members section #}
+          <div class="space-y-6">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="text-lg lg:text-xl font-semibold text-stone-900">Members</div>
             <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
@@ -44,11 +51,11 @@
             {{ stats_macro::analytics_chart(chart_id = "members-running-chart", data = stats.members.running_total, class = "h-[320px]", min_points = 1) -}}
             {{ stats_macro::analytics_chart(chart_id = "members-monthly-chart", data = stats.members.per_month, class = "h-[320px]") -}}
           </div>
-        </section>
-        {# End members section #}
+          </div>
+          {# End members section #}
 
-        {# Events section #}
-        <section class="space-y-6">
+          {# Events section #}
+          <div class="space-y-6">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="text-lg lg:text-xl font-semibold text-stone-900">Events</div>
             <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
@@ -61,11 +68,11 @@
             {{ stats_macro::analytics_chart(chart_id = "events-running-chart", data = stats.events.running_total, class = "h-[320px]", min_points = 1) -}}
             {{ stats_macro::analytics_chart(chart_id = "events-monthly-chart", data = stats.events.per_month, class = "h-[320px]") -}}
           </div>
-        </section>
-        {# End events section #}
+          </div>
+          {# End events section #}
 
-        {# Attendees section #}
-        <section class="space-y-6">
+          {# Attendees section #}
+          <div class="space-y-6">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div class="text-lg lg:text-xl font-semibold text-stone-900">Attendees</div>
             <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
@@ -78,8 +85,69 @@
             {{ stats_macro::analytics_chart(chart_id = "attendees-running-chart", data = stats.attendees.running_total, class = "h-[320px]", min_points = 1) -}}
             {{ stats_macro::analytics_chart(chart_id = "attendees-monthly-chart", data = stats.attendees.per_month, class = "h-[320px]") -}}
           </div>
+          </div>
+          {# End attendees section #}
         </section>
-        {# End attendees section #}
+        {# End alliance section #}
+
+        {# Jobs section #}
+        <section class="space-y-6 rounded-3xl border border-stone-200 bg-white/70 p-5 shadow-sm lg:p-7">
+          <div class="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <div class="text-xl lg:text-2xl font-semibold text-stone-900">Jobs</div>
+              <p class="mt-1 text-sm/6 text-stone-500">Roles shared by GOUP members and alliance companies.</p>
+            </div>
+            <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
+              <div class="svg-icon size-4 icon-search bg-stone-500 me-2"></div>
+              Total
+              <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.jobs.total|num_fmt }}</span>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+            {{ stats_macro::analytics_chart(chart_id = "jobs-running-chart", data = stats.jobs.running_total, class = "h-[320px]", min_points = 1) -}}
+            {{ stats_macro::analytics_chart(chart_id = "jobs-monthly-chart", data = stats.jobs.per_month, class = "h-[320px]") -}}
+          </div>
+        </section>
+        {# End jobs section #}
+
+        {# Landscape section #}
+        <section class="space-y-8 rounded-3xl border border-stone-200 bg-white/70 p-5 shadow-sm lg:p-7">
+          <div>
+            <div class="text-xl lg:text-2xl font-semibold text-stone-900">Landscape</div>
+            <p class="mt-1 text-sm/6 text-stone-500">Startups and open-source projects added by alliance admins.</p>
+          </div>
+
+          <div class="space-y-6">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+              <div class="text-lg lg:text-xl font-semibold text-stone-900">Startups</div>
+              <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
+                <div class="svg-icon size-4 icon-buildings bg-stone-500 me-2"></div>
+                Total
+                <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.landscape_startups.total|num_fmt }}</span>
+              </div>
+            </div>
+            <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+              {{ stats_macro::analytics_chart(chart_id = "landscape_startups-running-chart", data = stats.landscape_startups.running_total, class = "h-[320px]", min_points = 1) -}}
+              {{ stats_macro::analytics_chart(chart_id = "landscape_startups-monthly-chart", data = stats.landscape_startups.per_month, class = "h-[320px]") -}}
+            </div>
+          </div>
+
+          <div class="space-y-6">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+              <div class="text-lg lg:text-xl font-semibold text-stone-900">Open Source</div>
+              <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
+                <div class="svg-icon size-4 icon-github bg-stone-500 me-2"></div>
+                Total
+                <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.landscape_open_source.total|num_fmt }}</span>
+              </div>
+            </div>
+            <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+              {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-running-chart", data = stats.landscape_open_source.running_total, class = "h-[320px]", min_points = 1) -}}
+              {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-monthly-chart", data = stats.landscape_open_source.per_month, class = "h-[320px]") -}}
+            </div>
+          </div>
+        </section>
+        {# End landscape section #}
       </div>
     </div>
   </div>

--- a/ocg-server/templates/site/wiki/page.html
+++ b/ocg-server/templates/site/wiki/page.html
@@ -1,0 +1,66 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
+    <div class="relative max-w-3xl">
+      <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Wiki</p>
+      <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
+        Tech reading brief for builders
+      </h1>
+      <p class="max-w-2xl text-base/7 text-stone-600">
+        A live summary of useful AI, open-source, and entrepreneurship links pulled from public tech feeds, research feeds, and founder-focused sources.
+      </p>
+    </div>
+  </div>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
+    <div class="grid gap-6 lg:grid-cols-3">
+      {% for section in sections -%}
+        <section id="{{ section.id }}"
+                 class="flex min-h-full flex-col rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
+          <div class="mb-5">
+            <div class="mb-3 inline-flex items-center rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700">
+              {{ section.title }}
+            </div>
+            <h2 class="text-2xl font-semibold tracking-tight text-stone-950">{{ section.title }}</h2>
+            <p class="mt-3 text-sm/6 text-stone-600">{{ section.summary }}</p>
+          </div>
+
+          {% if section.links.is_empty() -%}
+            <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 p-5 text-sm text-stone-600">
+              Live links are temporarily unavailable. Use the source list below.
+            </div>
+          {% else -%}
+            <div class="grid gap-3">
+              {% for link in section.links -%}
+                <a href="{{ link.url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   hx-boost="false"
+                   class="group rounded-2xl border border-stone-200 bg-stone-50 p-4 transition hover:border-primary-200 hover:bg-primary-50/40">
+                  <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-primary-700">{{ link.source }}</div>
+                  <div class="text-sm/6 font-semibold text-stone-900 group-hover:text-primary-900">{{ link.title }}</div>
+                </a>
+              {% endfor -%}
+            </div>
+          {% endif -%}
+
+          <div class="mt-auto pt-6">
+            <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-stone-500">Sources</div>
+            <div class="flex flex-wrap gap-2">
+              {% for source in section.sources -%}
+                <a class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-700 transition hover:bg-stone-200"
+                   href="{{ source.url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   hx-boost="false">{{ source.label }}</a>
+              {% endfor -%}
+            </div>
+          </div>
+        </section>
+      {% endfor -%}
+    </div>
+  </div>
+{% endblock content -%}

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -29,7 +29,10 @@ test.describe("site header", () => {
     ).toHaveAttribute("href", "/jobs");
     await expect(
       navigation.getByRole("link", { name: "Landscape" }),
-    ).toHaveAttribute("href", "https://landscape.cncf.io/");
+    ).toHaveAttribute("href", "/landscape");
+    await expect(
+      navigation.getByRole("link", { name: "Wiki" }),
+    ).toHaveAttribute("href", "/wiki");
     await expect(
       navigation.getByRole("button", { name: "Switch to dark mode" }),
     ).toBeVisible();
@@ -67,7 +70,10 @@ test.describe("site header", () => {
     ).toHaveAttribute("href", "/jobs");
     await expect(
       userMenu.getByRole("menuitem", { name: "Landscape" }),
-    ).toHaveAttribute("href", "https://landscape.cncf.io/");
+    ).toHaveAttribute("href", "/landscape");
+    await expect(
+      userMenu.getByRole("menuitem", { name: "Wiki" }),
+    ).toHaveAttribute("href", "/wiki");
     await expect(
       userMenu.getByRole("menuitem", { name: "Dark mode" }),
     ).toBeVisible();

--- a/tests/unit/common/modals/share-modal.test.js
+++ b/tests/unit/common/modals/share-modal.test.js
@@ -196,6 +196,31 @@ describe("share-modal", () => {
     expect(element._isOpen).to.equal(true);
   });
 
+  it("copies the Instagram caption and share url", async () => {
+    // Render the share-modal fixture with Instagram caption text.
+    const element = await mountLitComponent("share-modal", {
+      instagramCaption: "Join us for GOUP Demo Day.",
+      title: "GOUP Demo Day",
+      url: "/goup/group/baku/event/demo-day",
+    });
+
+    // Copy the suggested Instagram caption from the open modal.
+    element._openModal();
+    await element._handleInstagramCopyClick();
+    await element.updateComplete;
+
+    // Successful copy includes the caption and normalized share URL.
+    expect(clipboardCalls).to.deep.equal([
+      `Join us for GOUP Demo Day.\n\n${window.location.origin}/goup/group/baku/event/demo-day`,
+    ]);
+    expect(swal.calls).to.have.length(1);
+    expect(swal.calls[0]).to.include({
+      text: "Instagram caption copied to clipboard!",
+      icon: "success",
+    });
+    expect(element._isOpen).to.equal(false);
+  });
+
   it("uses sharer.js when a platform button is clicked", async () => {
     // Render the share-modal fixture.
     const element = await mountLitComponent("share-modal", {


### PR DESCRIPTION
## Summary
- Add first-party Landscape and Wiki pages, including alliance-admin Landscape management.
- Add event sharing controls for LinkedIn and Instagram copy flows.
- Polish Jobs with poster attribution, 30-day expiry, favicon fixes, and expanded Stats sections.

## Test plan
- `cargo check -p ocg-server`
- IDE lints clean for edited files
- Targeted JS test attempted earlier; local Playwright Chromium is not installed


Made with [Cursor](https://cursor.com)