### PR TITLE
Show job interest and document MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,23 @@ For remote deployments, protect it with `MCP_BEARER_TOKEN` and expose it behind
 HTTPS. See [`mcp/README.md`](./mcp/README.md) for setup, client config, and how
 to add more tools.
 
+To set up the remote MCP server on EC2 with a generated bearer token and a
+systemd service:
+
+```bash
+./scripts/setup-mcp-ec2.sh
+```
+
+Enable mutating tools, such as event creation and talk submission, only when the
+endpoint is protected behind HTTPS:
+
+```bash
+MCP_ENABLE_MUTATIONS=true ./scripts/setup-mcp-ec2.sh
+```
+
+The script writes `~/.config/ocg/mcp.env`, starts the `goup-mcp` service, and
+prints the NGINX `/mcp` proxy block plus the Cursor/client MCP configuration.
+
 ### Tests and Checks
 
 Run Rust server tests:

--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -49,6 +49,7 @@
 {{ template "common/search_events.sql" }}
 {{ template "common/search_groups.sql" }}
 
+{{ template "jobs/job_application_summary_json.sql" }}
 {{ template "jobs/job_summary_json.sql" }}
 {{ template "jobs/add_job.sql" }}
 {{ template "jobs/add_job_application.sql" }}

--- a/database/migrations/functions/jobs/job_application_summary_json.sql
+++ b/database/migrations/functions/jobs/job_application_summary_json.sql
@@ -1,0 +1,18 @@
+create or replace function job_application_summary_json(p_application jobs_application)
+returns jsonb language sql stable as $$
+    select jsonb_build_object(
+        'job_application_id', p_application.job_application_id,
+        'applicant_user_id', p_application.applicant_user_id,
+        'applicant_username', u.username,
+        'applicant_email', u.email,
+        'applicant_name', u.name,
+        'applicant_photo_url', u.photo_url,
+        'applicant_title', u.title,
+        'applicant_company', u.company,
+        'applicant_linkedin_url', u.linkedin_url,
+        'note', p_application.note,
+        'created_at', extract(epoch from p_application.created_at)::bigint
+    )
+    from "user" u
+    where u.user_id = p_application.applicant_user_id;
+$$;

--- a/database/migrations/functions/jobs/list_user_jobs.sql
+++ b/database/migrations/functions/jobs/list_user_jobs.sql
@@ -24,8 +24,21 @@ begin
     select
         counted.total,
         coalesce(
-            jsonb_agg(job_summary_json(paged) order by paged.created_at desc, paged.job_id desc)
-                filter (where paged.job_id is not null),
+            jsonb_agg(
+                job_summary_json(paged)
+                || jsonb_build_object(
+                    'applications',
+                    coalesce(
+                        (
+                            select jsonb_agg(job_application_summary_json(ja) order by ja.created_at desc)
+                            from jobs_application ja
+                            where ja.job_id = paged.job_id
+                        ),
+                        '[]'::jsonb
+                    )
+                )
+                order by paged.created_at desc, paged.job_id desc
+            ) filter (where paged.job_id is not null),
             '[]'::jsonb
         )
     into v_total, v_jobs

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -22,7 +22,24 @@ curl http://127.0.0.1:8787/tools
 
 ## Run Remotely
 
-Set a bearer token before exposing the server publicly:
+Use the EC2 setup helper from the repository root:
+
+```bash
+./scripts/setup-mcp-ec2.sh
+```
+
+The script generates or reuses a bearer token, writes `~/.config/ocg/mcp.env`,
+installs a `goup-mcp` systemd service, starts it, and prints both an NGINX
+`/mcp` proxy snippet and a Cursor/client config.
+
+Enable mutation tools only when the MCP endpoint is protected:
+
+```bash
+MCP_ENABLE_MUTATIONS=true ./scripts/setup-mcp-ec2.sh
+```
+
+Manual background startup is also supported. Set a bearer token before exposing
+the server publicly:
 
 ```bash
 cd ~/goup.vc/mcp
@@ -39,6 +56,12 @@ MCP_ENABLE_MUTATIONS=true
 
 The event creation tool uses `psql` and reads database connection details from
 `DATABASE_URL`, `TERN_CONF`, or `$HOME/.config/ocg/tern.conf`.
+
+Authentication is done with an HTTP bearer token. Clients must send:
+
+```text
+Authorization: Bearer <token>
+```
 
 Put it behind HTTPS, then configure your MCP client with the remote URL:
 

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -134,6 +134,35 @@ pub(crate) struct DashboardJobsOutput {
     pub total: usize,
 }
 
+/// Applicant interest saved for a job.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JobApplicationSummary {
+    /// Application identifier.
+    pub job_application_id: Uuid,
+    /// Applicant user identifier.
+    pub applicant_user_id: Uuid,
+    /// Applicant username.
+    pub applicant_username: String,
+    /// Applicant email.
+    pub applicant_email: String,
+    /// Applicant display name.
+    pub applicant_name: Option<String>,
+    /// Applicant profile photo URL.
+    pub applicant_photo_url: Option<String>,
+    /// Applicant title.
+    pub applicant_title: Option<String>,
+    /// Applicant company.
+    pub applicant_company: Option<String>,
+    /// Applicant LinkedIn URL.
+    pub applicant_linkedin_url: Option<String>,
+    /// Optional note to the job poster.
+    pub note: Option<String>,
+    /// Time the applicant saved interest.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
 /// Public job summary.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -164,6 +193,9 @@ pub(crate) struct JobSummary {
     /// Number of applications.
     #[serde(default)]
     pub application_count: i32,
+    /// Saved-interest applicants. Only populated on the poster dashboard.
+    #[serde(default)]
+    pub applications: Vec<JobApplicationSummary>,
     /// Poster user identifier.
     pub posted_by_user_id: Uuid,
     /// Poster username.

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -197,6 +197,71 @@
                         hx-target="body">Delete</button>
               </div>
             </form>
+
+            <section class="mt-5 rounded-2xl border border-stone-200 bg-stone-50 p-4">
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <h3 class="text-sm font-semibold text-stone-900">Saved interest</h3>
+                  <p class="mt-1 text-xs text-stone-500">
+                    People who saved interest from the public job page.
+                  </p>
+                </div>
+                <span class="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-stone-600 ring-1 ring-inset ring-stone-200">
+                  {{ job.applications.len() }}
+                </span>
+              </div>
+
+              {% if job.applications.is_empty() -%}
+                <p class="mt-4 rounded-xl border border-dashed border-stone-300 bg-white px-4 py-3 text-sm text-stone-500">
+                  No one has saved interest yet.
+                </p>
+              {% else -%}
+                <div class="mt-4 grid gap-3">
+                  {% for application in job.applications -%}
+                    <article class="rounded-xl border border-stone-200 bg-white p-4">
+                      <div class="flex flex-wrap items-start justify-between gap-3">
+                        <div class="min-w-0">
+                          <h4 class="truncate text-sm font-semibold text-stone-950">
+                            {{ application.applicant_name|assigned_or(application.applicant_username) }}
+                          </h4>
+                          <p class="mt-1 text-xs text-stone-500">
+                            @{{ application.applicant_username }} · saved {{ application.created_at.format("%b %d, %Y") }}
+                          </p>
+                          {% if application.applicant_title.is_some() || application.applicant_company.is_some() -%}
+                            <p class="mt-2 text-sm text-stone-700">
+                              {% if let Some(title) = &application.applicant_title -%}
+                                {{ title }}
+                              {% endif -%}
+                              {% if application.applicant_title.is_some() && application.applicant_company.is_some() -%}
+                                <span class="text-stone-400"> at </span>
+                              {% endif -%}
+                              {% if let Some(company) = &application.applicant_company -%}
+                                {{ company }}
+                              {% endif -%}
+                            </p>
+                          {% endif -%}
+                        </div>
+                        <div class="flex shrink-0 flex-wrap gap-2">
+                          <a class="btn-tertiary px-3 py-1.5 text-xs"
+                             href="mailto:{{ application.applicant_email }}">Email</a>
+                          {% if let Some(linkedin_url) = &application.applicant_linkedin_url -%}
+                            <a class="btn-tertiary px-3 py-1.5 text-xs"
+                               href="{{ linkedin_url }}"
+                               target="_blank"
+                               rel="noopener noreferrer">LinkedIn</a>
+                          {% endif -%}
+                        </div>
+                      </div>
+                      {% if let Some(note) = &application.note -%}
+                        <div class="mt-3 rounded-xl bg-stone-50 px-3 py-2 text-sm/6 text-stone-700 ring-1 ring-inset ring-stone-200">
+                          {{ note }}
+                        </div>
+                      {% endif -%}
+                    </article>
+                  {% endfor -%}
+                </div>
+              {% endif -%}
+            </section>
           </article>
         {% endfor -%}
       </div>

--- a/scripts/setup-mcp-ec2.sh
+++ b/scripts/setup-mcp-ec2.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MCP_DIR="${MCP_DIR:-$ROOT_DIR/mcp}"
+CONFIG_DIR="${OCG_CONFIG:-$HOME/.config/ocg}"
+ENV_FILE="${MCP_ENV_FILE:-$CONFIG_DIR/mcp.env}"
+TERN_CONFIG="${TERN_CONF:-$CONFIG_DIR/tern.conf}"
+
+SERVICE_NAME="${MCP_SERVICE_NAME:-goup-mcp}"
+MCP_HOST="${MCP_HOST:-127.0.0.1}"
+MCP_PORT="${MCP_PORT:-8787}"
+MCP_ENABLE_MUTATIONS="${MCP_ENABLE_MUTATIONS:-false}"
+MCP_PUBLIC_URL="${MCP_PUBLIC_URL:-https://goup.vc/mcp}"
+INSTALL_DEPS="${SETUP_MCP_INSTALL_DEPS:-true}"
+INSTALL_SYSTEMD_SERVICE="${SETUP_MCP_SYSTEMD_SERVICE:-true}"
+START_SERVICE="${SETUP_MCP_START_SERVICE:-true}"
+
+usage() {
+    cat <<'EOF'
+Set up the GOUP remote MCP server on EC2.
+
+Common environment:
+  MCP_BEARER_TOKEN            Token used by MCP clients. Generated if omitted.
+  MCP_ENABLE_MUTATIONS        Enable tools that create/change data. Default: false
+  MCP_HOST                    Local bind host. Default: 127.0.0.1
+  MCP_PORT                    Local bind port. Default: 8787
+  MCP_PUBLIC_URL              Public URL shown in client config. Default: https://goup.vc/mcp
+  TERN_CONF                   DB config used by mutation/search tools. Default: ~/.config/ocg/tern.conf
+  DATABASE_URL                Optional DB URL; if set, MCP tools use it instead of TERN_CONF.
+  SETUP_MCP_INSTALL_DEPS      Install node/npm if missing. Default: true
+  SETUP_MCP_SYSTEMD_SERVICE   Install systemd service. Default: true
+  SETUP_MCP_START_SERVICE     Start/restart service. Default: true
+
+Examples:
+  ./scripts/setup-mcp-ec2.sh
+
+  MCP_ENABLE_MUTATIONS=true \
+  MCP_PUBLIC_URL='https://goup.vc/mcp' \
+  ./scripts/setup-mcp-ec2.sh
+EOF
+}
+
+log() {
+    printf '\n==> %s\n' "$*"
+}
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+sudo_cmd() {
+    if [[ "$(id -u)" -eq 0 ]]; then
+        "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "required command not found: $1"
+}
+
+install_deps() {
+    if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+        return
+    fi
+
+    [[ "$INSTALL_DEPS" == "true" ]] || die "node/npm not found; install Node.js 20+ or set SETUP_MCP_INSTALL_DEPS=true"
+
+    log "Installing Node.js and npm"
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo_cmd apt-get update
+        sudo_cmd env DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs npm
+    elif command -v dnf >/dev/null 2>&1; then
+        sudo_cmd dnf install -y nodejs npm
+    elif command -v yum >/dev/null 2>&1; then
+        sudo_cmd yum install -y nodejs npm
+    else
+        die "unsupported package manager; install Node.js 20+ and npm manually"
+    fi
+}
+
+check_node_version() {
+    require_cmd node
+    require_cmd npm
+
+    local major
+    major="$(node -p 'Number(process.versions.node.split(".")[0])')"
+    if [[ "$major" -lt 20 ]]; then
+        die "Node.js 20+ is required; found $(node --version)"
+    fi
+}
+
+load_existing_token() {
+    if [[ -n "${MCP_BEARER_TOKEN:-}" ]]; then
+        printf '%s' "$MCP_BEARER_TOKEN"
+        return
+    fi
+
+    if [[ -f "$ENV_FILE" ]]; then
+        # shellcheck disable=SC1090
+        source "$ENV_FILE"
+        if [[ -n "${MCP_BEARER_TOKEN:-}" ]]; then
+            printf '%s' "$MCP_BEARER_TOKEN"
+            return
+        fi
+    fi
+
+    openssl rand -base64 32
+}
+
+write_env_file() {
+    local token="$1"
+
+    log "Writing MCP environment file"
+    mkdir -p "$CONFIG_DIR"
+    umask 077
+    cat > "$ENV_FILE" <<EOF
+MCP_HOST=$MCP_HOST
+MCP_PORT=$MCP_PORT
+MCP_BEARER_TOKEN=$token
+MCP_ENABLE_MUTATIONS=$MCP_ENABLE_MUTATIONS
+TERN_CONF=$TERN_CONFIG
+EOF
+
+    if [[ -n "${DATABASE_URL:-}" ]]; then
+        printf 'DATABASE_URL=%s\n' "$DATABASE_URL" >> "$ENV_FILE"
+    fi
+
+    chmod 600 "$ENV_FILE"
+}
+
+install_systemd_service() {
+    [[ "$INSTALL_SYSTEMD_SERVICE" == "true" ]] || return
+
+    log "Installing systemd service $SERVICE_NAME"
+    sudo_cmd tee "/etc/systemd/system/$SERVICE_NAME.service" >/dev/null <<EOF
+[Unit]
+Description=GOUP remote MCP server
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$MCP_DIR
+EnvironmentFile=$ENV_FILE
+ExecStart=$(command -v npm) start
+Restart=always
+RestartSec=5
+User=$(id -un)
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    sudo_cmd systemctl daemon-reload
+    sudo_cmd systemctl enable "$SERVICE_NAME"
+
+    if [[ "$START_SERVICE" == "true" ]]; then
+        sudo_cmd systemctl restart "$SERVICE_NAME"
+    fi
+}
+
+print_next_steps() {
+    local token="$1"
+
+    cat <<EOF
+
+MCP setup complete.
+
+Bearer token:
+$token
+
+Local checks:
+  curl -H "Authorization: Bearer $token" http://$MCP_HOST:$MCP_PORT/health
+  curl -H "Authorization: Bearer $token" \\
+    -H "content-type: application/json" \\
+    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \\
+    http://$MCP_HOST:$MCP_PORT/mcp
+
+NGINX location snippet:
+  location /mcp {
+      proxy_pass http://$MCP_HOST:$MCP_PORT/mcp;
+      proxy_http_version 1.1;
+      proxy_set_header Host \$host;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+  }
+
+Cursor/client config:
+{
+  "mcpServers": {
+    "goup-vc": {
+      "url": "$MCP_PUBLIC_URL",
+      "headers": {
+        "Authorization": "Bearer $token"
+      }
+    }
+  }
+}
+
+Service status:
+  sudo systemctl status $SERVICE_NAME --no-pager
+  sudo journalctl -u $SERVICE_NAME -n 100 --no-pager
+EOF
+}
+
+main() {
+    if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+        usage
+        exit 0
+    fi
+
+    [[ -d "$MCP_DIR" ]] || die "MCP directory not found: $MCP_DIR"
+    require_cmd openssl
+    install_deps
+    check_node_version
+
+    local token
+    token="$(load_existing_token)"
+    write_env_file "$token"
+    install_systemd_service
+    print_next_steps "$token"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Show saved-interest applicants, notes, and contact links in the jobs dashboard for job posters.
- Add the SQL formatter used to return applicant details from `list_user_jobs`.
- Add `scripts/setup-mcp-ec2.sh` and document remote MCP setup/authentication in the READMEs.

## Test plan
- cargo check -p ocg-server
- bash -n scripts/setup-mcp-ec2.sh


Made with [Cursor](https://cursor.com)