### PR TITLE
Fix MCP UUID validation

### DIFF
--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -10,7 +10,7 @@ const HOST = process.env.HOST || process.env.MCP_HOST || "0.0.0.0";
 const BEARER_TOKEN = process.env.MCP_BEARER_TOKEN || "";
 const ENABLE_MUTATIONS = process.env.MCP_ENABLE_MUTATIONS === "true";
 const PROTOCOL_VERSION = "2024-11-05";
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const WIKI_SECTIONS = [
   {
     id: "ai",


### PR DESCRIPTION
## Summary
- Relax MCP UUID validation to accept any standard PostgreSQL UUID string.
- Allows MCP mutation tools to use seeded IDs such as GOUP Baku group/category IDs.

## Test plan
- `node --check mcp/server.mjs`
- `ReadLints` on `mcp/server.mjs`


Made with [Cursor](https://cursor.com)