### PR TITLE
Add MCP update tool and polish public pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,24 @@ updates:
       - "*"
     multi-ecosystem-group: "backend"
 
+  - package-ecosystem: "npm"
+    directory: "/mcp"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/tests/unit"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "backend"
+
+  - package-ecosystem: "npm"
+    directory: "/tests/e2e"
+    patterns:
+      - "*"
+    multi-ecosystem-group: "backend"
+
   - package-ecosystem: "docker"
     directory: "/database/migrations"
     patterns:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,93 +4,54 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 env:
-  OCI_CLI_FINGERPRINT: ${{ secrets.OCI_CLI_FINGERPRINT }}
-  OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
-  OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
-  OCI_CLI_TENANCY: ${{ secrets.OCI_CLI_TENANCY }}
-  OCI_CLI_USER: ${{ secrets.OCI_CLI_USER }}
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository }}
 
 jobs:
-  build-ocg-dbmigrator-image:
-    if: github.ref == 'refs/heads/main'
+  build-images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: dbmigrator
+            dockerfile: database/migrations/Dockerfile
+          - image: redirector
+            dockerfile: ocg-redirector/Dockerfile
+          - image: server
+            dockerfile: ocg-server/Dockerfile
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-      - name: Login to OCI Registry
-        id: login-ocir
-        uses: oracle-actions/login-ocir@v1.3.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          auth_token: ${{ secrets.OCI_AUTH_TOKEN }}
-      - name: Get ocg-dbmigrator OCIR repository
-        id: get-ocir-repository-dbmigrator
-        uses: oracle-actions/get-ocir-repository@v1.3.0
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          name: ocg/dbmigrator
-          compartment: ${{ secrets.OCI_COMPARTMENT_OCID }}
-      - name: Build and push ocg-dbmigrator image
-        env:
-          OCIR_REPOSITORY: ${{ steps.get-ocir-repository-dbmigrator.outputs.repo_path }}
-        run: |
-          docker build \
-            -f database/migrations/Dockerfile \
-            -t $OCIR_REPOSITORY:$GITHUB_SHA \
-            .
-          docker push $OCIR_REPOSITORY:$GITHUB_SHA
-
-  build-ocg-redirector-image:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Login to OCI Registry
-        id: login-ocir
-        uses: oracle-actions/login-ocir@v1.3.0
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push ${{ matrix.image }} image
+        uses: docker/build-push-action@v6
         with:
-          auth_token: ${{ secrets.OCI_AUTH_TOKEN }}
-      - name: Get ocg-redirector OCIR repository
-        id: get-ocir-repository-redirector
-        uses: oracle-actions/get-ocir-repository@v1.3.0
-        with:
-          name: ocg/redirector
-          compartment: ${{ secrets.OCI_COMPARTMENT_OCID }}
-      - name: Build and push ocg-redirector image
-        env:
-          OCIR_REPOSITORY: ${{ steps.get-ocir-repository-redirector.outputs.repo_path }}
-        run: |
-          docker build \
-            -f ocg-redirector/Dockerfile \
-            -t $OCIR_REPOSITORY:$GITHUB_SHA \
-            .
-          docker push $OCIR_REPOSITORY:$GITHUB_SHA
-
-  build-ocg-server-image:
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-      - name: Login to OCI Registry
-        id: login-ocir
-        uses: oracle-actions/login-ocir@v1.3.0
-        with:
-          auth_token: ${{ secrets.OCI_AUTH_TOKEN }}
-      - name: Get ocg-server OCIR repository
-        id: get-ocir-repository-server
-        uses: oracle-actions/get-ocir-repository@v1.3.0
-        with:
-          name: ocg/server
-          compartment: ${{ secrets.OCI_COMPARTMENT_OCID }}
-      - name: Build and push ocg-server image
-        env:
-          OCIR_REPOSITORY: ${{ steps.get-ocir-repository-server.outputs.repo_path }}
-        run: |
-          docker build \
-            --build-arg OCG_COMMIT_SHA=$GITHUB_SHA \
-            -f ocg-server/Dockerfile \
-            -t $OCIR_REPOSITORY:$GITHUB_SHA \
-            .
-          docker push $OCIR_REPOSITORY:$GITHUB_SHA
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          build-args: |
+            OCG_COMMIT_SHA=${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       dependencies: ${{ steps.filter.outputs.dependencies }}
       javascript: ${{ steps.filter.outputs.javascript }}
       markdown: ${{ steps.filter.outputs.markdown }}
+      mcp: ${{ steps.filter.outputs.mcp }}
       server: ${{ steps.filter.outputs.server }}
       templates: ${{ steps.filter.outputs.templates }}
     steps:
@@ -55,6 +56,9 @@ jobs:
             markdown:
               - '.github/workflows/ci.yml'
               - '**/*.md'
+            mcp:
+              - '.github/workflows/ci.yml'
+              - 'mcp/**'
             server:
               - '.github/workflows/ci.yml'
               - '.rustfmt.toml'
@@ -73,8 +77,7 @@ jobs:
     permissions:
       checks: write
       contents: read
-    runs-on:
-      labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -86,8 +89,7 @@ jobs:
   check-js-files-format:
     needs: changes
     if: needs.changes.outputs.javascript == 'true'
-    runs-on:
-      labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -100,8 +102,7 @@ jobs:
   lint-and-test-server:
     needs: changes
     if: needs.changes.outputs.server == 'true'
-    runs-on:
-      labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -124,21 +125,19 @@ jobs:
   lint-markdown-files:
     needs: changes
     if: needs.changes.outputs.markdown == 'true'
-    runs-on:
-      labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
       - name: Run markdownlint
         uses: DavidAnson/markdownlint-cli2-action@v22
         with:
-          globs: 'docs/**/*.md'
+          globs: '**/*.md'
 
   lint-templates:
     needs: changes
     if: needs.changes.outputs.templates == 'true'
-    runs-on:
-      labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -147,7 +146,7 @@ jobs:
       - name: Run djlint
         run: |
           djlint \
-            --reformat \
+            --check \
             --configuration ocg-server/templates/.djlintrc \
             ocg-server/templates
 
@@ -157,11 +156,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
-    container: ghcr.io/cncf/open-alliance-groups/db-tests
     services:
       postgres:
-        image: ghcr.io/cncf/open-alliance-groups/postgres-db-tests
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_USER: tests
           POSTGRES_PASSWORD: tests
@@ -172,14 +169,35 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+      - name: Install PostgreSQL, pgTAP, and tern clients
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client pgtap
+          curl -sL https://github.com/jackc/tern/releases/download/v2.3.2/tern_2.3.2_linux_amd64.tar.gz -o tern.tar.gz
+          tar -xzf tern.tar.gz
+          sudo mv tern /usr/local/bin/tern
+      - name: Install pgTAP extension in PostgreSQL service
+        run: |
+          docker exec -u root ${{ job.services.postgres.id }} sh -lc \
+            'apt-get update && (apt-get install -y postgresql-17-pgtap || apt-get install -y pgtap)'
+      - name: Create database test tern config
+        run: |
+          cat >/tmp/ocg-tern-tests.conf <<EOF
+          [database]
+          host = 127.0.0.1
+          port = ${{ job.services.postgres.ports[5432] }}
+          database = tests
+          user = tests
+          password = tests
+          EOF
       - name: Apply database migrations
         working-directory: ./database/migrations
-        run: TERN_CONF=../../../.github/workflows/tern.conf PGPORT=${{ job.services.postgres.ports[5432] }} ./migrate.sh
+        run: TERN_CONF=/tmp/ocg-tern-tests.conf ./migrate.sh
       - name: Install pgtap database extension
-        run: PGPASSWORD=tests psql -h postgres -p ${{ job.services.postgres.ports[5432] }} -U tests tests -c 'create extension pgtap;'
+        run: PGPASSWORD=tests psql -h 127.0.0.1 -p ${{ job.services.postgres.ports[5432] }} -U tests tests -c 'create extension pgtap;'
       - name: Run database tests
         working-directory: ./database/tests
-        run: PGPASSWORD=tests pg_prove --host postgres --dbname tests --username tests --verbose schema/*.sql functions/*/*.sql
+        run: PGPASSWORD=tests pg_prove --host 127.0.0.1 --port ${{ job.services.postgres.ports[5432] }} --dbname tests --username tests --verbose schema/*.sql functions/*/*.sql
 
   test-database-contracts:
     needs: changes
@@ -187,10 +205,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
     services:
       postgres:
-        image: ghcr.io/cncf/open-alliance-groups/postgres-db-tests
+        image: postgis/postgis:17-3.5
         env:
           POSTGRES_USER: tests
           POSTGRES_PASSWORD: tests
@@ -242,8 +259,7 @@ jobs:
   test-frontend:
     needs: changes
     if: needs.changes.outputs.javascript == 'true'
-    runs-on:
-      labels: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -262,3 +278,19 @@ jobs:
       - name: Run frontend unit tests
         working-directory: tests/unit
         run: npm test
+
+  test-mcp:
+    needs: changes
+    if: needs.changes.outputs.mcp == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+      - name: Check MCP server syntax
+        run: node --check mcp/server.mjs
+      - name: Validate MCP tool catalog
+        run: node -e "JSON.parse(require('fs').readFileSync('mcp/tools.json', 'utf8'))"

--- a/README.md
+++ b/README.md
@@ -403,6 +403,32 @@ Format and lint frontend/template code:
 just frontend-fmt-and-lint
 ```
 
+### GitHub Actions CI/CD
+
+Pull requests to `main` run the relevant CI jobs based on changed paths:
+
+- Rust formatting, clippy, and tests for server changes.
+- Database migrations, pgTAP tests, and Rust database contract tests for
+  database changes.
+- Frontend unit tests and formatting checks for browser JavaScript changes.
+- MCP syntax and tool catalog validation for files under `mcp/`.
+- Playwright e2e suites when app, database, or e2e files change.
+
+Pushes to `main` publish Docker images to GitHub Container Registry under this
+repository:
+
+```text
+ghcr.io/sakomws/goup.vc/server
+ghcr.io/sakomws/goup.vc/redirector
+ghcr.io/sakomws/goup.vc/dbmigrator
+```
+
+Images are tagged with `sha-<commit>` and `latest` on `main`. The workflow uses
+the built-in `GITHUB_TOKEN`; no Oracle/OCI registry secrets are required.
+
+The production EC2 deployment is still updated by pulling from Git and
+restarting systemd services, as documented below.
+
 ### Common Development Workflow
 
 For a fresh local checkout:
@@ -491,6 +517,13 @@ Restart the deployed service after a successful build:
 ```bash
 sudo systemctl restart ocg-server
 sudo systemctl status ocg-server --no-pager
+```
+
+If files under `mcp/` changed, restart the remote MCP service too:
+
+```bash
+sudo systemctl restart goup-mcp
+sudo systemctl status goup-mcp --no-pager
 ```
 
 ### Troubleshooting

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -114,6 +114,7 @@ through the standard `tools/list` method.
 - `goup_release_build_background`: build `ocg-server` in the background.
 - `goup_service_status`: inspect systemd logs and local HTTP status.
 - `goup_create_event`: create an unpublished draft event through `add_event`.
+- `goup_update_event`: update an existing event through `update_event`.
 - `goup_search_groups`: list or search groups.
 - `goup_search_events`: list or search events.
 - `goup_search_members`: list or search regular group members.

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -242,6 +242,8 @@ async function runAction(action, args) {
   switch (action) {
     case "create_event":
       return createEvent(args);
+    case "update_event":
+      return updateEvent(args);
     case "search_groups":
       return searchGroups(args);
     case "search_events":
@@ -621,6 +623,39 @@ from created;
   return output.trim();
 }
 
+async function updateEvent(args) {
+  if (!ENABLE_MUTATIONS) {
+    throw new Error("Mutating MCP tools are disabled. Set MCP_ENABLE_MUTATIONS=true to allow event updates.");
+  }
+
+  const event = buildEventPayload(args);
+  const eventJsonBase64 = Buffer.from(JSON.stringify(event), "utf8").toString("base64");
+  const actorUserId = requireUuid(args.actor_user_id, "actor_user_id");
+  const groupId = requireUuid(args.group_id, "group_id");
+  const eventId = requireUuid(args.event_id, "event_id");
+
+  const sql = `
+with updated as (
+  select update_event(
+    '${actorUserId}'::uuid,
+    '${groupId}'::uuid,
+    '${eventId}'::uuid,
+    convert_from(decode('${eventJsonBase64}', 'base64'), 'UTF8')::jsonb,
+    '{}'::jsonb
+  ) as promoted_user_ids
+)
+select json_build_object(
+  'event_id', '${eventId}',
+  'status', 'updated',
+  'promoted_user_ids', promoted_user_ids
+)::text
+from updated;
+`;
+
+  const output = await runPsql(sql);
+  return output.trim();
+}
+
 function buildSearchFilters(args) {
   const filters = {
     limit: normalizeLimit(args.limit),
@@ -726,6 +761,8 @@ function buildEventPayload(args) {
     attendee_approval_required: Boolean(args.attendee_approval_required),
     waitlist_enabled: Boolean(args.waitlist_enabled),
     test_event: Boolean(args.test_event),
+    banner_mobile_url: args.banner_mobile_url || "",
+    banner_url: args.banner_url || "",
     event_reminder_enabled: args.event_reminder_enabled ?? true,
     cfs_enabled: false,
     cfs_labels: [],
@@ -740,6 +777,7 @@ function buildEventPayload(args) {
     meeting_requested: false,
     meetup_url: args.meetup_url || "",
     luma_url: args.luma_url || "",
+    logo_url: args.logo_url || "",
     payment_currency_code: "",
     photos_urls: [],
     registration_questions: [],

--- a/mcp/tools.json
+++ b/mcp/tools.json
@@ -155,6 +155,146 @@
     "action": "create_event"
   },
   {
+    "name": "goup_update_event",
+    "title": "GOUP Update Draft Event",
+    "description": "Update an existing GOUP event through the database update_event function. Requires MCP_ENABLE_MUTATIONS=true and database access through DATABASE_URL or TERN_CONF.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "actor_user_id": {
+          "type": "string",
+          "description": "User ID that should be recorded as the event updater."
+        },
+        "group_id": {
+          "type": "string",
+          "description": "Group ID that owns the event."
+        },
+        "event_id": {
+          "type": "string",
+          "description": "Event ID to update."
+        },
+        "category_id": {
+          "type": "string",
+          "description": "Event category ID from the same alliance as the group."
+        },
+        "kind_id": {
+          "type": "string",
+          "enum": ["in-person", "virtual", "hybrid"],
+          "description": "Event type."
+        },
+        "name": {
+          "type": "string",
+          "description": "Event name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Full event description."
+        },
+        "description_short": {
+          "type": "string",
+          "description": "Optional short description for event cards."
+        },
+        "timezone": {
+          "type": "string",
+          "description": "IANA timezone, for example Asia/Baku."
+        },
+        "starts_at": {
+          "type": "string",
+          "description": "Local start datetime in the event timezone, for example 2026-07-01T18:00:00."
+        },
+        "ends_at": {
+          "type": "string",
+          "description": "Local end datetime in the event timezone, for example 2026-07-01T20:00:00."
+        },
+        "capacity": {
+          "type": "integer",
+          "description": "Optional attendee capacity."
+        },
+        "registration_required": {
+          "type": "boolean",
+          "description": "Whether attendees must register."
+        },
+        "attendee_approval_required": {
+          "type": "boolean",
+          "description": "Whether registrations require organizer approval."
+        },
+        "waitlist_enabled": {
+          "type": "boolean",
+          "description": "Whether the waitlist is enabled when capacity is full."
+        },
+        "event_reminder_enabled": {
+          "type": "boolean",
+          "description": "Whether reminder notifications are enabled."
+        },
+        "meeting_join_url": {
+          "type": "string",
+          "description": "Optional manual meeting link."
+        },
+        "logo_url": {
+          "type": "string",
+          "description": "Optional event logo URL."
+        },
+        "banner_url": {
+          "type": "string",
+          "description": "Optional event desktop banner URL."
+        },
+        "banner_mobile_url": {
+          "type": "string",
+          "description": "Optional event mobile banner URL."
+        },
+        "venue_name": {
+          "type": "string",
+          "description": "Optional venue name."
+        },
+        "venue_address": {
+          "type": "string",
+          "description": "Optional venue street address."
+        },
+        "venue_city": {
+          "type": "string",
+          "description": "Optional venue city."
+        },
+        "venue_country_code": {
+          "type": "string",
+          "description": "Optional venue country code."
+        },
+        "venue_country_name": {
+          "type": "string",
+          "description": "Optional venue country name."
+        },
+        "venue_state": {
+          "type": "string",
+          "description": "Optional venue state or region."
+        },
+        "venue_zip_code": {
+          "type": "string",
+          "description": "Optional venue postal code."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Optional event tags."
+        }
+      },
+      "required": [
+        "actor_user_id",
+        "group_id",
+        "event_id",
+        "category_id",
+        "kind_id",
+        "name",
+        "description",
+        "timezone",
+        "starts_at",
+        "ends_at"
+      ],
+      "additionalProperties": false
+    },
+    "action": "update_event"
+  },
+  {
     "name": "goup_search_groups",
     "title": "GOUP Search Groups",
     "description": "List or search GOUP groups by alliance, name, slug, category, location, or description.",

--- a/ocg-server/templates/common/footer.html
+++ b/ocg-server/templates/common/footer.html
@@ -1,43 +1,154 @@
 {# Footer -#}
-<footer class="flex-none bg-stone-950 text-center text-white text-surface/75 lg:text-left"
+<footer class="relative flex-none overflow-hidden bg-stone-950 text-white"
         role="contentinfo"
         aria-label="Site footer">
-  <div class="px-8 py-7 lg:px-16 lg:py-12">
-    <div class="pb-8 sm:pb-10 text-center md:text-left">
-      <div class="flex flex-col justify-between items-center gap-6 md:flex-row">
-        {# Footer logo -#}
+  <div class="absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-primary-400/70 to-transparent"></div>
+  <div class="absolute -top-32 right-0 h-72 w-72 rounded-full bg-primary-500/15 blur-3xl"></div>
+  <div class="absolute -bottom-40 left-8 h-80 w-80 rounded-full bg-sky-400/10 blur-3xl"></div>
+
+  <div class="relative mx-auto max-w-7xl px-6 py-12 sm:px-8 lg:px-16 lg:py-16">
+    <div class="grid gap-10 lg:grid-cols-[minmax(0,1.25fr)_minmax(0,1fr)] lg:gap-16">
+      {# Brand section -#}
+      <div class="max-w-xl">
         {% if let Some(footer_logo_url) = &self.site_settings.footer_logo_url -%}
-          <div class="inline-flex">
-            <img class="w-auto max-w-[518px] h-[48px]"
+          <a href="/"
+             class="inline-flex rounded-2xl focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300"
+             aria-label="{{ site_settings.title }} home">
+            <img class="h-12 w-auto max-w-[260px] object-contain sm:max-w-[360px]"
                  width="auto"
                  height="48"
                  data-ocg-broken-image-bg-class="bg-stone-950"
                  src="{{ footer_logo_url }}"
                  alt="{{ site_settings.title }} footer logo" />
-          </div>
+          </a>
+        {% else -%}
+          <a href="/"
+             class="inline-flex items-center rounded-2xl text-2xl font-black tracking-tight text-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
+            {{ site_settings.title }}
+          </a>
         {% endif -%}
-        {# End footer logo -#}
 
-        {# GitHub link -#}
-        <a href="https://github.com/sakomws/goup.vc"
-           target="_blank"
-           rel="noopener noreferrer"
-           class="group p-2 flex items-center justify-center rounded-lg hover:bg-stone-800 transition-colors"
-           title="GitHub">
-          <div class="svg-icon size-6 bg-white icon-github"></div>
-        </a>
-        {# End GitHub link -#}
+        <p class="mt-5 max-w-lg text-sm leading-6 text-stone-300 sm:text-base">
+          A home for builders, founders, and open source communities to discover groups,
+          host events, share opportunities, and grow the GOUP Alliance.
+        </p>
+
+        <div class="mt-7 flex flex-col gap-3 sm:flex-row">
+          <a href="/explore?alliance[0]=goup&entity=events"
+             hx-boost="true"
+             hx-target="body"
+             class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-bold text-stone-950 shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-primary-50 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
+            Explore events
+          </a>
+          <a href="/dashboard"
+             hx-boost="true"
+             hx-target="body"
+             class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 py-3 text-sm font-bold text-white backdrop-blur transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
+            Open dashboard
+          </a>
+        </div>
       </div>
+      {# End brand section -#}
+
+      {# Navigation section -#}
+      <div class="grid grid-cols-2 gap-8 sm:grid-cols-3">
+        <div>
+          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Explore</h2>
+          <ul class="mt-4 space-y-3 text-sm">
+            <li>
+              <a href="/explore?alliance[0]=goup&entity=events"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Events</a>
+            </li>
+            <li>
+              <a href="/explore?alliance[0]=goup&entity=groups"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Groups</a>
+            </li>
+            <li>
+              <a href="/landscape"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Landscape</a>
+            </li>
+            <li>
+              <a href="/stats"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Stats</a>
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Resources</h2>
+          <ul class="mt-4 space-y-3 text-sm">
+            <li>
+              <a href="/jobs"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Jobs</a>
+            </li>
+            <li>
+              <a href="/wiki"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Wiki</a>
+            </li>
+            <li>
+              <a href="https://github.com/sakomws/gitjobs"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="inline-flex items-center gap-1.5 text-stone-300 transition hover:text-white">
+                GitJobs
+                <span class="svg-icon size-3 icon-external-link bg-current"></span>
+              </a>
+            </li>
+          </ul>
+        </div>
+
+        <div class="col-span-2 sm:col-span-1">
+          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Connect</h2>
+          <div class="mt-4 flex items-center gap-3">
+            <a href="https://github.com/sakomws/goup.vc"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="group inline-flex size-11 items-center justify-center rounded-full border border-white/15 bg-white/5 transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300"
+               title="GOUP on GitHub"
+               aria-label="GOUP on GitHub">
+              <div class="svg-icon size-5 bg-stone-200 icon-github transition group-hover:bg-white"></div>
+            </a>
+            <a href="https://www.linkedin.com/company/goupaz"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="group inline-flex size-11 items-center justify-center rounded-full border border-white/15 bg-white/5 transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300"
+               title="GOUP on LinkedIn"
+               aria-label="GOUP on LinkedIn">
+              <div class="svg-icon size-5 bg-stone-200 icon-linkedin transition group-hover:bg-white"></div>
+            </a>
+          </div>
+          <p class="mt-4 text-sm leading-6 text-stone-400">
+            Open source, alliance-driven, and built for communities that ship.
+          </p>
+        </div>
+      </div>
+      {# End navigation section -#}
     </div>
 
     {# Copyright section -#}
-    <div class="pt-8 border-solid border-0 border-t border-stone-800 text-xs text-stone-300">
-      {% if let Some(copyright_notice) = &self.site_settings.copyright_notice -%}
-        <div class="mb-4 copyright">{{ copyright_notice|md_to_html|safe }}</div>
-      {% endif -%}
+    <div class="mt-12 flex flex-col gap-4 border-0 border-t border-solid border-white/10 pt-6 text-sm text-stone-400 md:flex-row md:items-center md:justify-between">
+      <div>
+        {% if let Some(copyright_notice) = &self.site_settings.copyright_notice -%}
+          <div class="copyright">{{ copyright_notice|md_to_html|safe }}</div>
+        {% else -%}
+          <p>{{ site_settings.title }}. All rights reserved.</p>
+        {% endif -%}
+      </div>
       <p>
         Powered by <a href="https://github.com/sakomws/goup.vc"
-    class="font-bold text-white"
+    class="font-bold text-white underline decoration-white/20 underline-offset-4 transition hover:decoration-white"
     target="_blank"
     rel="noopener noreferrer">GOUP Alliance</a>.
       </p>

--- a/ocg-server/templates/site/home/page.html
+++ b/ocg-server/templates/site/home/page.html
@@ -4,33 +4,51 @@
 
 {% block jumbotron -%}
   {# Jumbotron -#}
-  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 pb-10 sm:px-6 lg:px-8">
-    <section>
-      <div class="relative z-10 max-w-7xl pb-6 lg:pb-10 text-center">
-        {# Site title -#}
-        <h1 class="mb-8 text-[1.8rem] font-semibold tracking-tight leading-10 md:leading-8 sm:leading-none md:text-2xl lg:text-4xl xl:text-5xl">
-          {{ site_settings.title }}
-        </h1>
-        {# End site title -#}
+  <div class="relative overflow-hidden">
+    <div class="absolute inset-x-0 top-0 h-32 bg-linear-to-b from-primary-50/70 to-transparent"></div>
+    <div class="absolute -top-28 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-primary-300/20 blur-3xl"></div>
+    <div class="absolute top-24 right-0 hidden h-72 w-72 rounded-full bg-sky-300/20 blur-3xl lg:block"></div>
 
-        {# Site description -#}
+    <section class="relative container mx-auto max-w-7xl px-4 pt-8 pb-12 sm:px-6 sm:pt-12 lg:px-8 lg:pt-16 lg:pb-18">
+      <div class="mx-auto max-w-4xl text-center">
+        <div class="mb-6 inline-flex items-center rounded-full border border-primary-200 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-primary-700 shadow-sm backdrop-blur">
+          Builders. Founders. Open source.
+        </div>
+
+        <h1 class="text-balance text-4xl font-black tracking-tight text-stone-950 sm:text-5xl lg:text-7xl">
+          Grow with the GOUP Alliance
+        </h1>
+
         {% if !site_settings.description.is_empty() -%}
-          <div class="font-normal text-lg/8 lg:text-[22px]/10 mb-8 mt-6 lg:mt-12 lg:mb-14 text-stone-600 jumbotron-description">
+          <div class="jumbotron-description mx-auto mt-6 max-w-2xl text-lg/8 text-stone-600 lg:text-xl/9">
             {{ site_settings.description|md_to_html|safe }}
           </div>
+        {% else -%}
+          <p class="mx-auto mt-6 max-w-2xl text-lg/8 text-stone-600 lg:text-xl/9">
+            Discover groups, join events, find opportunities, and connect with
+            builders shaping the next wave of open technology.
+          </p>
         {% endif -%}
-        {# End site description -#}
 
-        {# Stats -#}
-        <div class="mb-8 lg:mb-14">{% include "site/home/stats.html" %}</div>
-        {# End stats -#}
-
-        <a href="{{ explore_events }}"
-           hx-boost="true"
-           hx-target="body"
-           class="btn-primary-anchor text-md lg:text-lg py-3 px-8 font-semibold">Explore groups and events</a>
-
+        <div class="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <a href="{{ explore_events }}"
+             hx-boost="true"
+             hx-target="body"
+             class="inline-flex items-center justify-center rounded-full bg-primary-600 px-7 py-3.5 text-base font-bold text-white shadow-lg shadow-primary-600/25 transition hover:-translate-y-0.5 hover:bg-primary-700 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-500">
+            Explore events
+          </a>
+          <a href="{{ explore_groups }}"
+             hx-boost="true"
+             hx-target="body"
+             class="inline-flex items-center justify-center rounded-full border border-stone-300 bg-white px-7 py-3.5 text-base font-bold text-stone-900 shadow-sm transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-50 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-500">
+            Browse groups
+          </a>
+        </div>
       </div>
+
+      {# Stats -#}
+      <div class="relative z-10 mt-10 lg:mt-14">{% include "site/home/stats.html" %}</div>
+      {# End stats -#}
     </section>
   </div>
   {# End jumbotron -#}
@@ -38,21 +56,41 @@
 
 {% block content -%}
   {# Main content -#}
-  <div class="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 lg:py-16">
-    <div class="flex flex-col gap-y-6 sm:gap-y-8 lg:gap-y-12">
+  <div class="container mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-18">
+    <div class="flex flex-col gap-y-12 lg:gap-y-16">
       {# Alliances list -#}
       <div>
-        <div class="uppercase text-lg lg:text-2xl tracking-wide font-bold leading-10 pb-6 sm:pb-8 lg:pt-2 lg:pb-14">
-          Alliances
+        <div class="mb-6 flex flex-col gap-3 sm:mb-8 lg:mb-10">
+          <div class="inline-flex w-fit rounded-full bg-primary-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
+            Alliance
+          </div>
+          <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <h2 class="text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">
+                Built around active communities
+              </h2>
+              <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
+                GOUP brings chapters, members, events, jobs, and ecosystem projects into one place.
+              </p>
+            </div>
+            <a href="{{ explore_groups }}"
+               hx-boost="true"
+               hx-target="body"
+               class="hidden rounded-full border border-stone-300 bg-white px-5 py-2.5 text-sm font-bold text-stone-900 shadow-sm transition hover:border-stone-400 hover:bg-stone-50 md:inline-flex">
+              Explore groups
+            </a>
+          </div>
         </div>
         {% if alliances.len() > 0 -%}
           <div class="flex flex-col gap-8">
             {% for alliance in alliances -%}
               <a href="/{{ alliance.name }}"
-                 class="block bg-white rounded-lg border border-stone-200 hover:shadow-md transition-shadow overflow-hidden">
+                 hx-boost="true"
+                 hx-target="body"
+                 class="group block overflow-hidden rounded-3xl border border-stone-200 bg-white shadow-sm transition hover:-translate-y-1 hover:border-primary-200 hover:shadow-xl hover:shadow-stone-200/70">
                 {# Mobile banner -#}
                 <div class="aspect-[61/12] sm:hidden">
-                  <img class="w-full h-full object-cover"
+                  <img class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.02]"
                        height="auto"
                        width="auto"
                        src="{{ alliance.banner_mobile_url }}"
@@ -62,7 +100,7 @@
 
                 {# Desktop banner -#}
                 <div class="aspect-[607/48] hidden sm:block">
-                  <img class="w-full h-full object-cover"
+                  <img class="h-full w-full object-cover transition duration-500 group-hover:scale-[1.02]"
                        height="auto"
                        width="auto"
                        src="{{ alliance.banner_url }}"
@@ -80,57 +118,85 @@
       {# End alliances list -#}
 
       {# Events -#}
-      <div class="flex flex-col gap-y-6 sm:gap-y-8 lg:gap-y-12">
+      <div class="rounded-[2rem] border border-stone-200 bg-white/70 p-5 shadow-sm sm:p-8 lg:p-10">
+        <div class="mb-8 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+          <div>
+            <div class="inline-flex rounded-full bg-primary-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
+              Events
+            </div>
+            <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">
+              Meet the people building next
+            </h2>
+            <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
+              Join upcoming meetups, workshops, and community gatherings across GOUP chapters.
+            </p>
+          </div>
+          <a href="{{ explore_events }}"
+             hx-boost="true"
+             hx-target="body"
+             class="hidden rounded-full bg-stone-950 px-5 py-2.5 text-sm font-bold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-stone-800 md:inline-flex">
+            Explore all events
+          </a>
+        </div>
+
+        <div class="flex flex-col gap-y-10 lg:gap-y-12">
         {# Events in-person -#}
         {% if upcoming_in_person_events.len() > 0 -%}
-          {{ ui::events_list(title = "upcoming in-person events", link = explore_events, events = upcoming_in_person_events) -}}
+          {{ ui::events_list(title = "upcoming in-person", link = explore_events, events = upcoming_in_person_events) -}}
         {% endif -%}
         {# End events in-person -#}
 
         {# Events online -#}
         {% if upcoming_virtual_events.len() > 0 -%}
-          {{ ui::events_list(title = "upcoming virtual events", link = explore_events, events = upcoming_virtual_events) -}}
+          {{ ui::events_list(title = "upcoming virtual", link = explore_events, events = upcoming_virtual_events) -}}
         {% endif -%}
         {# End events online -#}
-
-        {# Latest groups added -#}
-        {% if recently_added_groups.len() > 0 -%}
-          <div>
-            <div class="flex items-center justify-between pb-6 sm:pb-8 lg:pb-12">
-              <div class="uppercase text-lg lg:text-2xl tracking-wide font-bold leading-10 lg:py-2">
-                Latest groups added
-              </div>
-              {# See all groups on desktop -#}
-              <div class="hidden justify-self-end md:flex">
-                <a href="{{ explore_groups }}"
-                   hx-boost="true"
-                   hx-target="body"
-                   class="btn-secondary-anchor ms-4">Explore all groups</a>
-              </div>
-              {# End see all groups on desktop -#}
-            </div>
-            <div>
-              {# Groups cards -#}
-              <div class="grid grid-cols-1 gap-6 md:gap-8 md:grid-cols-2 [&>a:nth-child(n+6)]:hidden md:[&>a:nth-child(n+6)]:flex">
-                {% for group in recently_added_groups -%}
-                  {{- group|safe -}}
-                {% endfor -%}
-              </div>
-              {# End groups cards -#}
-              {# See all groups mobile button -#}
-              <div class="flex mt-9 justify-self-center md:hidden md:mt-0">
-                <a href="{{ explore_groups }}"
-                   hx-boost="true"
-                   hx-target="body"
-                   class="btn-secondary-anchor">Explore all groups</a>
-              </div>
-              {# End see all groups mobile button -#}
-            </div>
-          </div>
-        {% endif -%}
-        {# End latest groups added -#}
+        </div>
       </div>
       {# End events -#}
+
+      {# Latest groups added -#}
+      {% if recently_added_groups.len() > 0 -%}
+        <div>
+          <div class="mb-8 flex flex-col gap-3 md:flex-row md:items-end md:justify-between lg:mb-10">
+            <div>
+              <div class="inline-flex rounded-full bg-primary-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
+                Groups
+              </div>
+              <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">
+                New chapters and circles
+              </h2>
+              <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
+                Find a local chapter or interest group and start building with the community.
+              </p>
+            </div>
+            <a href="{{ explore_groups }}"
+               hx-boost="true"
+               hx-target="body"
+               class="hidden rounded-full border border-stone-300 bg-white px-5 py-2.5 text-sm font-bold text-stone-900 shadow-sm transition hover:border-stone-400 hover:bg-stone-50 md:inline-flex">
+              Explore all groups
+            </a>
+          </div>
+          <div>
+            {# Groups cards -#}
+            <div class="grid grid-cols-1 gap-6 md:gap-8 md:grid-cols-2 [&>a:nth-child(n+6)]:hidden md:[&>a:nth-child(n+6)]:flex">
+              {% for group in recently_added_groups -%}
+                {{- group|safe -}}
+              {% endfor -%}
+            </div>
+            {# End groups cards -#}
+            {# See all groups mobile button -#}
+            <div class="flex mt-9 justify-self-center md:hidden md:mt-0">
+              <a href="{{ explore_groups }}"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="btn-secondary-anchor">Explore all groups</a>
+            </div>
+            {# End see all groups mobile button -#}
+          </div>
+        </div>
+      {% endif -%}
+      {# End latest groups added -#}
     </div>
   </div>
   {# End main content -#}

--- a/ocg-server/templates/site/home/stats.html
+++ b/ocg-server/templates/site/home/stats.html
@@ -2,24 +2,24 @@
 
 {# Stats -#}
 {# Desktop -#}
-<div class="hidden lg:flex w-full flex-row justify-around items-center border-4 border-double border-stone-200 bg-white rounded-lg p-10 mx-auto">
+<div class="hidden w-full flex-row items-center justify-around rounded-[2rem] border border-white/70 bg-white/85 p-8 shadow-xl shadow-stone-200/60 backdrop-blur lg:flex">
   {# Groups stats -#}
   {{ stats_macros::stat_block(kind = "groups", title = "Groups", value = stats.groups) -}}
   {# End groups stats -#}
 
-  <div class="inline-block h-[50px] min-h-[1em] w-0.5 self-stretch bg-neutral-200"></div>
+  <div class="inline-block h-[56px] min-h-[1em] w-px self-stretch bg-stone-200"></div>
 
   {# Members stats -#}
   {{ stats_macros::stat_block(kind = "members", title = "Members", value = stats.groups_members) -}}
   {# End members stats -#}
 
-  <div class="inline-block h-[50px] min-h-[1em] w-0.5 self-stretch bg-neutral-200"></div>
+  <div class="inline-block h-[56px] min-h-[1em] w-px self-stretch bg-stone-200"></div>
 
   {# Events stats -#}
   {{ stats_macros::stat_block(kind = "events", title = "Events", value = stats.events) -}}
   {# End events stats -#}
 
-  <div class="inline-block h-[50px] min-h-[1em] w-0.5 self-stretch bg-neutral-200"></div>
+  <div class="inline-block h-[56px] min-h-[1em] w-px self-stretch bg-stone-200"></div>
 
   {# Attendees stats -#}
   {{ stats_macros::stat_block(kind = "attendees", title = "Attendees", value = stats.events_attendees) -}}
@@ -28,7 +28,7 @@
 {# End desktop -#}
 
 {# Mobile -#}
-<div class="grid grid-cols-2 gap-x-0 gap-y-8 justify-around lg:hidden w-full border-4 border-double border-stone-200 rounded-lg py-6 mx-auto bg-white">
+<div class="grid w-full grid-cols-2 justify-around gap-x-0 gap-y-8 rounded-[1.5rem] border border-white/70 bg-white/85 py-6 shadow-xl shadow-stone-200/60 backdrop-blur lg:hidden">
   {# Groups stats -#}
   {{ stats_macros::stat_block(kind = "groups", title = "Groups", value = stats.groups, extra_styles = Some("place-self-center w-[130px] -ms-4") ) -}}
   {# End groups stats -#}


### PR DESCRIPTION
## Summary
- Add `goup_update_event` to the remote MCP server and tool catalog.
- Retarget CI/CD for this repo by removing upstream CNCF/OCI assumptions, adding MCP validation, GHCR image publishing, and Dependabot npm coverage.
- Polish the public home page and footer with stronger branding, CTAs, navigation, and responsive layout.

## Test plan
- `cargo check -p ocg-server`
- `node --check mcp/server.mjs`
- `node -e "JSON.parse(require('fs').readFileSync('mcp/tools.json','utf8'))"`
- Workflow/dependabot YAML parsed with Ruby YAML loader
- ReadLints on edited workflow/docs/template/MCP files


Made with [Cursor](https://cursor.com)