### PR TITLE
Polish stats page and dashboard route

### DIFF
--- a/database/migrations/functions/site/get_site_stats.sql
+++ b/database/migrations/functions/site/get_site_stats.sql
@@ -37,6 +37,7 @@ members as (
         fg.group_category_id,
         fg.group_id,
         fg.region_id,
+        gm.user_id,
 
         timezone(
             'UTC',
@@ -49,6 +50,7 @@ events as (
     select
         e.event_category_id,
         e.event_id,
+        e.event_kind_id,
         e.group_id,
         e.starts_at,
         fg.group_category_id,
@@ -88,6 +90,8 @@ attendees as (
 ),
 jobs as (
     select
+        jj.expires_at,
+        jj.job_id,
         jj.created_at,
         timezone(
             'UTC',
@@ -121,6 +125,65 @@ landscape_open_source as (
     where a.active = true
       and le.published = true
       and le.kind = 'github_project'
+),
+job_applications as (
+    select ja.created_at, ja.job_id, ja.applicant_user_id
+    from jobs_application ja
+    join jobs_job jj on jj.job_id = ja.job_id
+),
+active_member_user_ids as (
+    select distinct m.user_id
+    from members m
+    where m.created_at >= current_timestamp - interval '90 days'
+
+    union
+
+    select distinct ea.user_id
+    from event_attendee ea
+    join events e on e.event_id = ea.event_id
+    where ea.status = 'confirmed'
+      and ea.created_at >= current_timestamp - interval '90 days'
+
+    union
+
+    select distinct ja.applicant_user_id
+    from job_applications ja
+    where ja.created_at >= current_timestamp - interval '90 days'
+),
+repeat_attendees as (
+    select ea.user_id
+    from event_attendee ea
+    join events e on e.event_id = ea.event_id
+    where ea.status = 'confirmed'
+    group by ea.user_id
+    having count(distinct ea.event_id) >= 2
+),
+linkedin_connected_members as (
+    select distinct m.user_id
+    from members m
+    join "user" u on u.user_id = m.user_id
+    where coalesce(u.provider ? 'linkedin', false)
+       or nullif(u.linkedin_url, '') is not null
+),
+event_kind_counts as (
+    select coalesce(ek.display_name, e.event_kind_id) as label, count(*)::int as count
+    from events e
+    join event_kind ek on ek.event_kind_id = e.event_kind_id
+    group by coalesce(ek.display_name, e.event_kind_id)
+),
+event_category_counts as (
+    select ec.name as label, count(*)::int as count
+    from events e
+    join event_category ec on ec.event_category_id = e.event_category_id
+    group by ec.name
+),
+landscape_category_counts as (
+    select coalesce(nullif(le.category, ''), 'Uncategorized') as label, count(*)::int as count
+    from landscape_entry le
+    join alliance a on a.alliance_id = le.alliance_id
+    where a.active = true
+      and le.published = true
+    group by coalesce(nullif(le.category, ''), 'Uncategorized')
 ),
 domain_running_total_counts as (
     select
@@ -199,6 +262,81 @@ domain_monthly_counts as (
     from domain_running_total_counts
 )
 select json_strip_nulls(json_build_object(
+    'summary', json_build_object(
+        'active_members', (select count(*)::int from active_member_user_ids),
+        'upcoming_events', (
+            select count(*)::int
+            from events e
+            where e.starts_at >= current_timestamp
+        ),
+        'active_jobs', (
+            select count(*)::int
+            from jobs j
+            where j.expires_at > current_timestamp
+        ),
+        'job_interests', (select count(*)::int from job_applications),
+        'landscape_entries', (
+            (select count(*)::int from landscape_startups)
+            + (select count(*)::int from landscape_open_source)
+        ),
+        'avg_attendees_per_event', coalesce((
+            select round(count(a.event_id)::numeric / nullif(count(distinct e.event_id), 0), 1)
+            from events e
+            left join attendees a on a.event_id = e.event_id
+        ), 0)
+    ),
+    'engagement', json_build_object(
+        'repeat_attendees', (select count(*)::int from repeat_attendees),
+        'linkedin_connected_members', (select count(*)::int from linkedin_connected_members),
+        'members_per_group_avg', coalesce((
+            select round(count(m.user_id)::numeric / nullif(count(distinct fg.group_id), 0), 1)
+            from filtered_groups fg
+            left join members m on m.group_id = fg.group_id
+        ), 0),
+        'events_per_group_avg', coalesce((
+            select round(count(e.event_id)::numeric / nullif(count(distinct fg.group_id), 0), 1)
+            from filtered_groups fg
+            left join events e on e.group_id = fg.group_id
+        ), 0)
+    ),
+    'event_breakdown', json_build_object(
+        'by_kind', coalesce((
+            select json_agg(json_build_array(label, count) order by count desc, label)
+            from event_kind_counts
+        ), '[]'::json),
+        'by_category', coalesce((
+            select json_agg(json_build_array(label, count) order by count desc, label)
+            from event_category_counts
+        ), '[]'::json)
+    ),
+    'jobs_overview', json_build_object(
+        'active', (
+            select count(*)::int
+            from jobs j
+            where j.expires_at > current_timestamp
+        ),
+        'expired', (
+            select count(*)::int
+            from jobs j
+            where j.expires_at <= current_timestamp
+        ),
+        'interests', (select count(*)::int from job_applications),
+        'avg_interests_per_job', coalesce((
+            select round(count(ja.job_id)::numeric / nullif(count(distinct j.job_id), 0), 1)
+            from jobs j
+            left join job_applications ja on ja.job_id = j.job_id
+        ), 0)
+    ),
+    'landscape_overview', json_build_object(
+        'entries', (
+            (select count(*)::int from landscape_startups)
+            + (select count(*)::int from landscape_open_source)
+        ),
+        'by_category', coalesce((
+            select json_agg(json_build_array(label, count) order by count desc, label)
+            from landscape_category_counts
+        ), '[]'::json)
+    ),
     'groups', json_build_object(
         'per_month', stats_label_count_series((
             select jsonb_agg(to_jsonb(counts))

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -1155,6 +1155,34 @@ pub(crate) fn sample_site_settings() -> SiteSettings {
 /// Sample site stats for stats page tests.
 pub(crate) fn sample_site_stats() -> crate::templates::site::stats::SiteStats {
     crate::templates::site::stats::SiteStats {
+        summary: crate::templates::site::stats::SiteStatsSummary {
+            active_members: 0,
+            upcoming_events: 0,
+            active_jobs: 0,
+            job_interests: 0,
+            landscape_entries: 0,
+            avg_attendees_per_event: 0.0,
+        },
+        engagement: crate::templates::site::stats::SiteEngagementStats {
+            repeat_attendees: 0,
+            linkedin_connected_members: 0,
+            members_per_group_avg: 0.0,
+            events_per_group_avg: 0.0,
+        },
+        event_breakdown: crate::templates::site::stats::SiteEventBreakdown {
+            by_kind: vec![],
+            by_category: vec![],
+        },
+        jobs_overview: crate::templates::site::stats::SiteJobsOverview {
+            active: 0,
+            expired: 0,
+            interests: 0,
+            avg_interests_per_job: 0.0,
+        },
+        landscape_overview: crate::templates::site::stats::SiteLandscapeOverview {
+            entries: 0,
+            by_category: vec![],
+        },
         attendees: crate::templates::site::stats::SiteStatsSection {
             per_month: vec![],
             running_total: vec![],

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -224,6 +224,10 @@ pub(crate) async fn setup(
             put(auth::update_user_password),
         )
         .route(
+            "/dashboard",
+            get(|| async { Redirect::to("/dashboard/user") }),
+        )
+        .route(
             "/dashboard/jobs",
             get(crate::handlers::dashboard::jobs::page).post(crate::handlers::dashboard::jobs::add),
         )

--- a/ocg-server/src/templates/site/stats.rs
+++ b/ocg-server/src/templates/site/stats.rs
@@ -27,6 +27,16 @@ pub struct Page {
 /// Aggregated site statistics used across charts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SiteStats {
+    /// High-level summary metrics.
+    pub summary: SiteStatsSummary,
+    /// Engagement and quality metrics.
+    pub engagement: SiteEngagementStats,
+    /// Event breakdown metrics.
+    pub event_breakdown: SiteEventBreakdown,
+    /// Jobs overview metrics.
+    pub jobs_overview: SiteJobsOverview,
+    /// Landscape overview metrics.
+    pub landscape_overview: SiteLandscapeOverview,
     /// Attendees statistics.
     pub attendees: SiteStatsSection,
     /// Events statistics.
@@ -52,4 +62,65 @@ pub struct SiteStatsSection {
     pub running_total: Vec<(i64, i64)>,
     /// Total count.
     pub total: i64,
+}
+
+/// High-level summary metrics for the public stats page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteStatsSummary {
+    /// Members active in the last 90 days.
+    pub active_members: i64,
+    /// Published future events.
+    pub upcoming_events: i64,
+    /// Published jobs that have not expired.
+    pub active_jobs: i64,
+    /// Saved-interest job applications.
+    pub job_interests: i64,
+    /// Published landscape entries.
+    pub landscape_entries: i64,
+    /// Average confirmed attendees per published event.
+    pub avg_attendees_per_event: f64,
+}
+
+/// Engagement and quality metrics for the public stats page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteEngagementStats {
+    /// Confirmed attendees who joined two or more events.
+    pub repeat_attendees: i64,
+    /// Members with LinkedIn identity or profile data.
+    pub linkedin_connected_members: i64,
+    /// Average members per active group.
+    pub members_per_group_avg: f64,
+    /// Average published events per active group.
+    pub events_per_group_avg: f64,
+}
+
+/// Event breakdown metrics for the public stats page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteEventBreakdown {
+    /// Published events by event kind.
+    pub by_kind: Vec<(String, i64)>,
+    /// Published events by event category.
+    pub by_category: Vec<(String, i64)>,
+}
+
+/// Jobs overview metrics for the public stats page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteJobsOverview {
+    /// Active jobs that have not expired.
+    pub active: i64,
+    /// Published jobs that are expired.
+    pub expired: i64,
+    /// Saved-interest job applications.
+    pub interests: i64,
+    /// Average saved-interest applications per job.
+    pub avg_interests_per_job: f64,
+}
+
+/// Landscape overview metrics for the public stats page.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SiteLandscapeOverview {
+    /// Published landscape entries.
+    pub entries: i64,
+    /// Published landscape entries by category.
+    pub by_category: Vec<(String, i64)>,
 }

--- a/ocg-server/templates/common/footer.html
+++ b/ocg-server/templates/common/footer.html
@@ -40,7 +40,7 @@
              class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-bold text-stone-950 shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-primary-50 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
             Explore events
           </a>
-          <a href="/dashboard"
+          <a href="/dashboard/user"
              hx-boost="true"
              hx-target="body"
              class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 py-3 text-sm font-bold text-white backdrop-blur transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">

--- a/ocg-server/templates/site/stats/page.html
+++ b/ocg-server/templates/site/stats/page.html
@@ -3,147 +3,403 @@
 {% import "macros/stats.html" as stats_macro -%}
 
 {% block content -%}
-  <div class="container mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 py-10 lg:py-16">
-    <div class="flex flex-col gap-y-10">
-      <div>
-        <div class="text-2xl lg:text-3xl font-medium text-stone-900">Stats</div>
-        <div class="mt-1 flex flex-wrap items-center gap-3">
-          <p class="text-sm/6 text-stone-500 m-0">Global growth trends across all alliances.</p>
+  <div class="relative overflow-hidden">
+    <div class="absolute inset-x-0 top-0 h-72 bg-linear-to-b from-primary-50/80 to-transparent"></div>
+    <div class="absolute -top-24 left-1/2 h-80 w-80 -translate-x-1/2 rounded-full bg-primary-300/20 blur-3xl"></div>
+    <div class="absolute top-24 right-0 hidden h-72 w-72 rounded-full bg-sky-300/20 blur-3xl lg:block"></div>
+
+    <div class="relative container mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8 lg:py-16">
+      <div class="mx-auto max-w-3xl text-center">
+        <div class="mb-5 inline-flex rounded-full border border-primary-200 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-primary-700 shadow-sm backdrop-blur">
+          GOUP intelligence
         </div>
+        <h1 class="text-balance text-4xl font-black tracking-tight text-stone-950 sm:text-5xl lg:text-6xl">
+          Alliance stats that show momentum
+        </h1>
+        <p class="mx-auto mt-5 max-w-2xl text-lg/8 text-stone-600">
+          Track community growth, event activity, job market signals, and the
+          startup and open-source landscape across GOUP.
+        </p>
       </div>
 
-      <div class="space-y-14">
+      {# Summary cards #}
+      <div class="mt-10 grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Active members</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-members bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.active_members|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Last 90 days</p>
+        </div>
+
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Upcoming</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-events bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.upcoming_events|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Published events</p>
+        </div>
+
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Active jobs</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-search bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.active_jobs|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Not expired</p>
+        </div>
+
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Job interest</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-attendees bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.job_interests|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Saved interest</p>
+        </div>
+
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Landscape</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-buildings bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.landscape_entries|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Published entries</p>
+        </div>
+
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Avg turnout</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-charts bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.avg_attendees_per_event }}</div>
+          <p class="mt-1 text-sm text-stone-500">Attendees/event</p>
+        </div>
+      </div>
+      {# End summary cards #}
+
+      {# Engagement cards #}
+      <div id="engagement"
+           class="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
+          <div class="text-sm font-bold text-stone-500">Repeat attendees</div>
+          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.repeat_attendees|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Joined 2+ events</p>
+        </div>
+        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
+          <div class="text-sm font-bold text-stone-500">LinkedIn-connected</div>
+          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.linkedin_connected_members|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Members with LinkedIn</p>
+        </div>
+        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
+          <div class="text-sm font-bold text-stone-500">Members / group</div>
+          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.members_per_group_avg }}</div>
+          <p class="mt-1 text-sm text-stone-500">Average group size</p>
+        </div>
+        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
+          <div class="text-sm font-bold text-stone-500">Events / group</div>
+          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.events_per_group_avg }}</div>
+          <p class="mt-1 text-sm text-stone-500">Activity density</p>
+        </div>
+      </div>
+      {# End engagement cards #}
+
+      <div class="mt-12 flex flex-wrap justify-center gap-2">
+        <a href="#alliance"
+           class="rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-bold text-stone-700 shadow-sm transition hover:border-primary-200 hover:text-primary-700">Alliance</a>
+        <a href="#engagement"
+           class="rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-bold text-stone-700 shadow-sm transition hover:border-primary-200 hover:text-primary-700">Engagement</a>
+        <a href="#jobs"
+           class="rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-bold text-stone-700 shadow-sm transition hover:border-primary-200 hover:text-primary-700">Jobs</a>
+        <a href="#landscape"
+           class="rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-bold text-stone-700 shadow-sm transition hover:border-primary-200 hover:text-primary-700">Landscape</a>
+      </div>
+
+      <div class="mt-12 space-y-12">
         {# Alliance section #}
-        <section class="space-y-8 rounded-3xl border border-stone-200 bg-white/70 p-5 shadow-sm lg:p-7">
-          <div>
-            <div class="text-xl lg:text-2xl font-semibold text-stone-900">Alliance</div>
-            <p class="mt-1 text-sm/6 text-stone-500">Current alliance growth across groups, members, events, and attendees.</p>
-          </div>
-
-          {# Groups section #}
-          <div class="space-y-6">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="text-lg lg:text-xl font-semibold text-stone-900">Groups</div>
-            <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-              <div class="svg-icon size-4 icon-groups bg-stone-500 me-2"></div>
-              Total
-              <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.groups.total|num_fmt }}</span>
+        <section id="alliance"
+                 class="overflow-hidden rounded-[2rem] border border-stone-200 bg-white/80 shadow-xl shadow-stone-200/50">
+          <div class="border-0 border-b border-solid border-stone-200 bg-linear-to-r from-stone-950 to-stone-800 p-6 text-white lg:p-8">
+            <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-200">Alliance</div>
+                <h2 class="mt-2 text-2xl font-black tracking-tight lg:text-4xl">Community growth</h2>
+                <p class="mt-2 max-w-2xl text-sm/6 text-stone-300">
+                  Groups, members, events, and attendee growth across active GOUP alliances.
+                </p>
+              </div>
+              <div class="grid grid-cols-2 gap-2 text-sm sm:grid-cols-4">
+                <div class="rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
+                  <div class="text-stone-300">Groups</div>
+                  <div class="text-xl font-black">{{ stats.groups.total|num_fmt }}</div>
+                </div>
+                <div class="rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
+                  <div class="text-stone-300">Members</div>
+                  <div class="text-xl font-black">{{ stats.members.total|num_fmt }}</div>
+                </div>
+                <div class="rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
+                  <div class="text-stone-300">Events</div>
+                  <div class="text-xl font-black">{{ stats.events.total|num_fmt }}</div>
+                </div>
+                <div class="rounded-2xl bg-white/10 px-4 py-3 backdrop-blur">
+                  <div class="text-stone-300">Attendees</div>
+                  <div class="text-xl font-black">{{ stats.attendees.total|num_fmt }}</div>
+                </div>
+              </div>
             </div>
           </div>
-          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-            {{ stats_macro::analytics_chart(chart_id = "groups-running-chart", data = stats.groups.running_total, class = "h-[320px]", min_points = 1) -}}
-            {{ stats_macro::analytics_chart(chart_id = "groups-monthly-chart", data = stats.groups.per_month, class = "h-[320px]") -}}
-          </div>
-          </div>
-          {# End groups section #}
 
-          {# Members section #}
-          <div class="space-y-6">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="text-lg lg:text-xl font-semibold text-stone-900">Members</div>
-            <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-              <div class="svg-icon size-4 icon-members bg-stone-500 me-2"></div>
-              Total
-              <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.members.total|num_fmt }}</span>
+          <div class="space-y-10 p-5 lg:p-8">
+            {# Groups section #}
+            <div class="space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">Groups</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">Chapter and interest group creation over time.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  <div class="svg-icon me-2 size-4 icon-groups bg-primary-600"></div>
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.groups.total|num_fmt }}</span>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                {{ stats_macro::analytics_chart(chart_id = "groups-running-chart", data = stats.groups.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "groups-monthly-chart", data = stats.groups.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+              </div>
             </div>
-          </div>
-          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-            {{ stats_macro::analytics_chart(chart_id = "members-running-chart", data = stats.members.running_total, class = "h-[320px]", min_points = 1) -}}
-            {{ stats_macro::analytics_chart(chart_id = "members-monthly-chart", data = stats.members.per_month, class = "h-[320px]") -}}
-          </div>
-          </div>
-          {# End members section #}
+            {# End groups section #}
 
-          {# Events section #}
-          <div class="space-y-6">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="text-lg lg:text-xl font-semibold text-stone-900">Events</div>
-            <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-              <div class="svg-icon size-4 icon-events bg-stone-500 me-2"></div>
-              Total
-              <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.events.total|num_fmt }}</span>
+            {# Members section #}
+            <div class="space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">Members</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">People joining groups and building inside GOUP.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  <div class="svg-icon me-2 size-4 icon-members bg-primary-600"></div>
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.members.total|num_fmt }}</span>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                {{ stats_macro::analytics_chart(chart_id = "members-running-chart", data = stats.members.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "members-monthly-chart", data = stats.members.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+              </div>
             </div>
-          </div>
-          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-            {{ stats_macro::analytics_chart(chart_id = "events-running-chart", data = stats.events.running_total, class = "h-[320px]", min_points = 1) -}}
-            {{ stats_macro::analytics_chart(chart_id = "events-monthly-chart", data = stats.events.per_month, class = "h-[320px]") -}}
-          </div>
-          </div>
-          {# End events section #}
+            {# End members section #}
 
-          {# Attendees section #}
-          <div class="space-y-6">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="text-lg lg:text-xl font-semibold text-stone-900">Attendees</div>
-            <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-              <div class="svg-icon size-4 icon-attendees bg-stone-500 me-2"></div>
-              Total
-              <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.attendees.total|num_fmt }}</span>
+            {# Events section #}
+            <div class="space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">Events</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">Published meetups, workshops, and alliance gatherings.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  <div class="svg-icon me-2 size-4 icon-events bg-primary-600"></div>
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.events.total|num_fmt }}</span>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                {{ stats_macro::analytics_chart(chart_id = "events-running-chart", data = stats.events.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "events-monthly-chart", data = stats.events.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+              </div>
             </div>
+            {# End events section #}
+
+            {# Event breakdowns #}
+            <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+                <h3 class="text-lg font-black text-stone-950">Events by type</h3>
+                <div class="mt-4 space-y-3">
+                  {% if stats.event_breakdown.by_kind.len() > 0 -%}
+                    {% for (label, count) in stats.event_breakdown.by_kind -%}
+                      <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
+                        <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
+                        <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+                      </div>
+                    {% endfor -%}
+                  {% else -%}
+                    <div class="chart-empty-state h-24">No event type data yet</div>
+                  {% endif -%}
+                </div>
+              </div>
+
+              <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+                <h3 class="text-lg font-black text-stone-950">Events by category</h3>
+                <div class="mt-4 space-y-3">
+                  {% if stats.event_breakdown.by_category.len() > 0 -%}
+                    {% for (label, count) in stats.event_breakdown.by_category -%}
+                      <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
+                        <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
+                        <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+                      </div>
+                    {% endfor -%}
+                  {% else -%}
+                    <div class="chart-empty-state h-24">No event category data yet</div>
+                  {% endif -%}
+                </div>
+              </div>
+            </div>
+            {# End event breakdowns #}
+
+            {# Attendees section #}
+            <div class="space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">Attendees</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">Confirmed attendees across all published events.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  <div class="svg-icon me-2 size-4 icon-attendees bg-primary-600"></div>
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.attendees.total|num_fmt }}</span>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                {{ stats_macro::analytics_chart(chart_id = "attendees-running-chart", data = stats.attendees.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "attendees-monthly-chart", data = stats.attendees.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+              </div>
+            </div>
+            {# End attendees section #}
           </div>
-          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-            {{ stats_macro::analytics_chart(chart_id = "attendees-running-chart", data = stats.attendees.running_total, class = "h-[320px]", min_points = 1) -}}
-            {{ stats_macro::analytics_chart(chart_id = "attendees-monthly-chart", data = stats.attendees.per_month, class = "h-[320px]") -}}
-          </div>
-          </div>
-          {# End attendees section #}
         </section>
         {# End alliance section #}
 
         {# Jobs section #}
-        <section class="space-y-6 rounded-3xl border border-stone-200 bg-white/70 p-5 shadow-sm lg:p-7">
+        <section id="jobs"
+                 class="space-y-6 rounded-[2rem] border border-stone-200 bg-white/85 p-5 shadow-xl shadow-stone-200/50 lg:p-8">
           <div class="flex flex-wrap items-start justify-between gap-4">
             <div>
-              <div class="text-xl lg:text-2xl font-semibold text-stone-900">Jobs</div>
-              <p class="mt-1 text-sm/6 text-stone-500">Roles shared by GOUP members and alliance companies.</p>
+              <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Jobs</div>
+              <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">Opportunity flow</h2>
+              <p class="mt-2 max-w-2xl text-sm/6 text-stone-500">
+                Roles shared by GOUP members and alliance companies.
+              </p>
             </div>
-            <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-              <div class="svg-icon size-4 icon-search bg-stone-500 me-2"></div>
-              Total
-              <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.jobs.total|num_fmt }}</span>
+            <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+              <div class="svg-icon me-2 size-4 icon-search bg-primary-600"></div>
+              Total <span class="ms-2 font-black text-stone-950">{{ stats.jobs.total|num_fmt }}</span>
             </div>
           </div>
-          <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-            {{ stats_macro::analytics_chart(chart_id = "jobs-running-chart", data = stats.jobs.running_total, class = "h-[320px]", min_points = 1) -}}
-            {{ stats_macro::analytics_chart(chart_id = "jobs-monthly-chart", data = stats.jobs.per_month, class = "h-[320px]") -}}
+          <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+              <div class="text-sm text-stone-500">Active</div>
+              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.active|num_fmt }}</div>
+            </div>
+            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+              <div class="text-sm text-stone-500">Expired</div>
+              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.expired|num_fmt }}</div>
+            </div>
+            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+              <div class="text-sm text-stone-500">Saved interest</div>
+              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.interests|num_fmt }}</div>
+            </div>
+            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+              <div class="text-sm text-stone-500">Interest / job</div>
+              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.avg_interests_per_job }}</div>
+            </div>
+          </div>
+          <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+            {{ stats_macro::analytics_chart(chart_id = "jobs-running-chart", data = stats.jobs.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+            {{ stats_macro::analytics_chart(chart_id = "jobs-monthly-chart", data = stats.jobs.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
           </div>
         </section>
         {# End jobs section #}
 
         {# Landscape section #}
-        <section class="space-y-8 rounded-3xl border border-stone-200 bg-white/70 p-5 shadow-sm lg:p-7">
-          <div>
-            <div class="text-xl lg:text-2xl font-semibold text-stone-900">Landscape</div>
-            <p class="mt-1 text-sm/6 text-stone-500">Startups and open-source projects added by alliance admins.</p>
-          </div>
-
-          <div class="space-y-6">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div class="text-lg lg:text-xl font-semibold text-stone-900">Startups</div>
-              <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-                <div class="svg-icon size-4 icon-buildings bg-stone-500 me-2"></div>
-                Total
-                <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.landscape_startups.total|num_fmt }}</span>
+        <section id="landscape"
+                 class="space-y-8 rounded-[2rem] border border-stone-200 bg-white/85 p-5 shadow-xl shadow-stone-200/50 lg:p-8">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+            <div>
+              <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Landscape</div>
+              <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">Ecosystem map</h2>
+              <p class="mt-2 max-w-2xl text-sm/6 text-stone-500">
+                Startups and open-source projects added by alliance admins.
+              </p>
+            </div>
+            <div class="grid grid-cols-2 gap-2 text-sm">
+              <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                <div class="text-stone-500">Startups</div>
+                <div class="text-xl font-black text-stone-950">{{ stats.landscape_startups.total|num_fmt }}</div>
+              </div>
+              <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                <div class="text-stone-500">Open source</div>
+                <div class="text-xl font-black text-stone-950">{{ stats.landscape_open_source.total|num_fmt }}</div>
               </div>
             </div>
-            <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-              {{ stats_macro::analytics_chart(chart_id = "landscape_startups-running-chart", data = stats.landscape_startups.running_total, class = "h-[320px]", min_points = 1) -}}
-              {{ stats_macro::analytics_chart(chart_id = "landscape_startups-monthly-chart", data = stats.landscape_startups.per_month, class = "h-[320px]") -}}
+          </div>
+
+          <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <h3 class="text-lg font-black text-stone-950">Entries by category</h3>
+                <p class="mt-1 text-sm/6 text-stone-500">Published startups and open-source projects grouped by category.</p>
+              </div>
+              <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_overview.entries|num_fmt }}</span>
+              </div>
+            </div>
+            <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {% if stats.landscape_overview.by_category.len() > 0 -%}
+                {% for (label, count) in stats.landscape_overview.by_category -%}
+                  <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
+                    <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
+                    <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+                  </div>
+                {% endfor -%}
+              {% else -%}
+                <div class="chart-empty-state h-24 sm:col-span-2 lg:col-span-3">No landscape category data yet</div>
+              {% endif -%}
             </div>
           </div>
 
-          <div class="space-y-6">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div class="text-lg lg:text-xl font-semibold text-stone-900">Open Source</div>
-              <div class="bg-white border border-stone-200 rounded-lg px-4 py-2 text-sm text-stone-500 flex items-center justify-center w-[170px]">
-                <div class="svg-icon size-4 icon-github bg-stone-500 me-2"></div>
-                Total
-                <span class="ms-2 text-base font-semibold text-stone-900">{{ stats.landscape_open_source.total|num_fmt }}</span>
+          <div class="space-y-8">
+            <div class="space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">Startups</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">Founder-led companies in the GOUP ecosystem.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  <div class="svg-icon me-2 size-4 icon-buildings bg-primary-600"></div>
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_startups.total|num_fmt }}</span>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                {{ stats_macro::analytics_chart(chart_id = "landscape_startups-running-chart", data = stats.landscape_startups.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "landscape_startups-monthly-chart", data = stats.landscape_startups.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
               </div>
             </div>
-            <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
-              {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-running-chart", data = stats.landscape_open_source.running_total, class = "h-[320px]", min_points = 1) -}}
-              {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-monthly-chart", data = stats.landscape_open_source.per_month, class = "h-[320px]") -}}
+
+            <div class="space-y-5">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">Open Source</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">Community projects and GitHub repositories.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  <div class="svg-icon me-2 size-4 icon-github bg-primary-600"></div>
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_open_source.total|num_fmt }}</span>
+                </div>
+              </div>
+              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-running-chart", data = stats.landscape_open_source.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-monthly-chart", data = stats.landscape_open_source.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Add richer public stats metrics for activity, engagement, jobs, events, and landscape.
- Redesign the public stats page around summary cards, breakdowns, and polished chart sections.
- Add a `/dashboard` redirect to `/dashboard/user` and update the footer dashboard link.

## Test plan
- `cargo check -p ocg-server`
- `cargo test -p ocg-server handlers::site::stats::tests -- --quiet`


Made with [Cursor](https://cursor.com)