### PR TITLE
Fix dark mode contrast on home hero and stat surfaces

### DIFF
--- a/ocg-server/static/css/styles.src.css
+++ b/ocg-server/static/css/styles.src.css
@@ -1120,10 +1120,37 @@ html.ocg-dark .shadow,
 html.ocg-dark .shadow-sm,
 html.ocg-dark .shadow-md,
 html.ocg-dark .shadow-lg,
+html.ocg-dark .shadow-xl,
+html.ocg-dark .shadow-2xl,
 html.ocg-dark .drop-shadow-sm {
   --tw-shadow-color: rgb(0 0 0 / 0.45) !important;
   --tw-shadow: 0 10px 30px -12px rgb(0 0 0 / 0.65) !important;
   box-shadow: var(--tw-shadow) !important;
+}
+
+/* Translucent white surfaces (cards, badges) read as light-on-light in dark
+   mode because the opacity modifier escapes the plain .bg-white override.
+   Low-opacity whites (5-30%) are deliberate overlays on dark sections and
+   are left untouched. */
+html.ocg-dark .bg-white\/70,
+html.ocg-dark .bg-white\/80,
+html.ocg-dark .bg-white\/85 {
+  background-color: rgb(15 23 42 / 0.85) !important;
+}
+
+html.ocg-dark .border-white\/70 {
+  border-color: rgb(51 65 85 / 0.7) !important;
+}
+
+/* The home hero wraps header and jumbotron in a white-to-dark gradient.
+   The white stops stay light in dark mode, so the inverted heading text
+   sits light-on-light. Recolor the gradient stops to the dark surface. */
+html.ocg-dark .from-white {
+  --tw-gradient-from: #0f172a !important;
+}
+
+html.ocg-dark .via-white {
+  --tw-gradient-via: #0f172a !important;
 }
 
 html.ocg-dark :is(input, textarea, select, .input) {


### PR DESCRIPTION
## Problem

In dark mode the home page renders light text on a light background, and the stat card stays bright white with a glowing halo. The hero heading "Grow with the GOUP Alliance" and its subtitle are effectively invisible.

The dark theme is implemented as a global override layer keyed on `html.ocg-dark` in `styles.src.css`, which remaps light utility classes to dark values. That layer missed three cases, so text was inverted to light while the surfaces behind it stayed light:

1. The home hero wraps the header and jumbotron in a `from-white via-white` gradient (`common/base.html`). The white gradient stops were never recolored, so the inverted heading text sat light on light.
2. Translucent white surfaces (`bg-white/70`, `bg-white/80`, `bg-white/85`) and the matching `border-white/70` (stat card, badge, events card) escape the plain `.bg-white` override because of the opacity modifier, so they stayed white while their text inverted to light.
3. `shadow-xl` was not in the shadow neutralizing group, so the stat card kept a light `shadow-stone-200` halo.

## Fix

All changes stay inside the existing `html.ocg-dark` override layer, no template changes and no new `dark:` variants:

- Recolor the `from-white` and `via-white` gradient stops to the dark surface color.
- Darken the high opacity translucent white surfaces and `border-white/70`.
- Add `shadow-xl` and `shadow-2xl` to the dark shadow group.

Low opacity whites (5 to 30 percent), used as deliberate overlays on the dark footer and stat hero, are left unchanged.

## Verification

Compiled `styles.src.css` with Tailwind v4 locally: builds clean, all four override blocks emit, and the gradient stop override propagates through `--tw-gradient-stops` as expected. Not yet rendered in a running instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)