### PR TITLE
Add Docker Compose development environment and setup guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+target/
+node_modules/
+.git/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Chart.lock
 chart/charts
 ocg-server/dist
 ocg-server/static/css/styles.css
+.config/ocg/server.yml
+.config/ocg/tern.conf

--- a/README.md
+++ b/README.md
@@ -338,6 +338,54 @@ Run with auto-reload when `watchexec` is installed:
 just server-watch
 ```
 
+### Run with Docker Compose
+
+If you prefer a containerized local setup, use the development compose file.
+It starts PostgreSQL with PostGIS, runs migrations, seeds the initial local
+data, and runs the Rust server with file watching enabled.
+
+Build and start the development stack:
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+Run it in detached mode:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d --build
+```
+
+Open the app at:
+
+```text
+http://127.0.0.1:9000
+```
+
+The development server watches the repository for changes and rebuilds on
+updates to:
+
+- Rust code under `ocg-server/` and `ocg-redirector/`
+- Askama templates under `ocg-server/templates/`
+- Frontend JavaScript under `ocg-server/static/js/`
+- CSS sources under `ocg-server/static/css/`
+- Local server config under `.config/ocg/server.yml`
+
+Useful compose commands:
+
+```bash
+docker compose -f docker-compose.dev.yml logs -f server
+docker compose -f docker-compose.dev.yml up -d --build seed server
+docker compose -f docker-compose.dev.yml down
+```
+
+The database data is stored in the named `postgres-data` volume, so it
+persists across restarts. To remove the containers and the database volume:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v
+```
+
 Build without running:
 
 ```bash

--- a/database/Dockerfile.dev
+++ b/database/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM postgres:16
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        postgis \
+        postgresql-16-postgis-3 \
+    && rm -rf /var/lib/apt/lists/*

--- a/database/dev-seed.sql
+++ b/database/dev-seed.sql
@@ -1,0 +1,52 @@
+insert into site (site_id, title, description, theme)
+values (
+  '00000000-0000-0000-0000-000000000000',
+  'GOUP Alliance',
+  'GOUP Alliance',
+  '{"primary_color":"#0EA5E9"}'
+)
+on conflict do nothing;
+
+insert into alliance (
+  alliance_id,
+  name,
+  display_name,
+  description,
+  banner_url,
+  banner_mobile_url,
+  logo_url
+) values (
+  '11111111-1111-1111-1111-111111111111',
+  'goup',
+  'GOUP Alliance',
+  'GOUP Alliance',
+  '/static/images/e2e/alliance-primary-banner.svg',
+  '/static/images/e2e/alliance-primary-banner-mobile.svg',
+  '/static/images/e2e/alliance-primary-logo.svg'
+)
+on conflict do nothing;
+
+insert into group_category (group_category_id, alliance_id, name)
+values (
+  '22222222-2222-2222-2222-222222222222',
+  '11111111-1111-1111-1111-111111111111',
+  'General'
+)
+on conflict do nothing;
+
+insert into "group" (
+  group_id,
+  alliance_id,
+  group_category_id,
+  name,
+  slug,
+  description
+) values (
+  '33333333-3333-3333-3333-333333333333',
+  '11111111-1111-1111-1111-111111111111',
+  '22222222-2222-2222-2222-222222222222',
+  'GOUP Baku',
+  'goup-baku',
+  'Default development group'
+)
+on conflict do nothing;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,104 @@
+services:
+  db:
+    build:
+      context: .
+      dockerfile: database/Dockerfile.dev
+    environment:
+      POSTGRES_DB: ocg
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d ocg"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  migrate:
+    build:
+      context: .
+      dockerfile: database/migrations/Dockerfile
+    working_dir: /workspace/database/migrations
+    environment:
+      TERN_CONF: /workspace/.config/ocg/tern.conf
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - .:/workspace
+    command:
+      - sh
+      - -lc
+      - ./migrate.sh
+    restart: "no"
+
+  seed:
+    build:
+      context: .
+      dockerfile: database/Dockerfile.dev
+    environment:
+      PGPASSWORD: postgres
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    volumes:
+      - .:/workspace
+    command:
+      - sh
+      - -lc
+      - psql -h db -U postgres -d ocg -v ON_ERROR_STOP=1 -f /workspace/database/dev-seed.sql
+    restart: "no"
+
+  server:
+    build:
+      context: .
+      dockerfile: ocg-server/Dockerfile.dev
+    working_dir: /workspace
+    environment:
+      OCG_SERVER_CONFIG: /workspace/.config/ocg/server.yml
+      OCG_CONFIG: /workspace/.config/ocg
+      CARGO_TARGET_DIR: /cargo-target
+    depends_on:
+      db:
+        condition: service_healthy
+      seed:
+        condition: service_completed_successfully
+    ports:
+      - "9000:9000"
+    volumes:
+      - .:/workspace
+      - cargo-target:/cargo-target
+      - cargo-registry:/usr/local/cargo/registry
+      - cargo-git:/usr/local/cargo/git
+    command:
+      - watchexec
+      - --restart
+      - --watch
+      - /workspace/Cargo.toml
+      - --watch
+      - /workspace/Cargo.lock
+      - --watch
+      - /workspace/ocg-server
+      - --watch
+      - /workspace/ocg-redirector
+      - --watch
+      - /workspace/.config/ocg/server.yml
+      - --
+      - cargo
+      - run
+      - -p
+      - ocg-server
+      - --
+      - -c
+      - /workspace/.config/ocg/server.yml
+
+volumes:
+  postgres-data:
+  cargo-target:
+  cargo-registry:
+  cargo-git:

--- a/ocg-server/Dockerfile.dev
+++ b/ocg-server/Dockerfile.dev
@@ -1,0 +1,32 @@
+FROM rust:1.95.0-bookworm
+
+ARG TARGETARCH
+
+ENV CARGO_HOME=/usr/local/cargo
+ENV CARGO_TARGET_DIR=/cargo-target
+ENV PATH=/usr/local/cargo/bin:${PATH}
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        perl \
+        pkg-config \
+        postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN case "${TARGETARCH}" in \
+        "amd64") tailwind_arch="x64" ;; \
+        "arm64") tailwind_arch="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL \
+        "https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.10/tailwindcss-linux-${tailwind_arch}" \
+        -o /usr/local/bin/tailwindcss \
+    && chmod +x /usr/local/bin/tailwindcss
+
+RUN cargo install --locked watchexec-cli
+
+WORKDIR /workspace


### PR DESCRIPTION
## Summary

Adds a Docker Compose-based local development setup and documents how to run it.

## Changes

- add development compose file
- add dev Dockerfiles for server and database
- add migration and seed steps for local startup
- support live reload for Rust, templates, CSS, and frontend JS
- add README instructions for Docker-based development

## Testing

- ran the dev stack locally with Docker Compose
- confirmed the app starts and is reachable on `127.0.0.1:9000`

## Notes

- local development only
- no production deployment changes