### PR TITLE
Polish public site content and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,8 +557,10 @@ OCG_ADMIN_EMAIL='you@example.com' \
 
 ### Update an Existing EC2 Deployment
 
-After pulling new code on EC2, run migrations before restarting whenever files
-under `database/migrations` changed:
+After pulling new code on EC2, run migrations before rebuilding and restarting
+whenever files under `database/migrations` changed. The migration script lives
+under `database/migrations`, so do not run `./migrate.sh` from the repository
+root:
 
 ```bash
 cd ~/goup.vc
@@ -568,18 +570,22 @@ cd database/migrations
 TERN_CONF="$HOME/.config/ocg/tern.conf" ./migrate.sh
 ```
 
+Or run the same migration from the repository root:
+
+```bash
+cd ~/goup.vc
+TERN_CONF="$HOME/.config/ocg/tern.conf" ./database/migrations/migrate.sh
+```
+
 Build the release binary in the background so it keeps running if the SSH
-session disconnects:
+session disconnects, then restart the deployed service after the build finishes
+successfully:
 
 ```bash
 cd ~/goup.vc
 nohup env CARGO_BUILD_JOBS=1 cargo build --release -p ocg-server > ~/goup-build.log 2>&1 &
 tail -f ~/goup-build.log
-```
 
-Restart the deployed service after the build finishes successfully:
-
-```bash
 sudo systemctl restart ocg-server
 sudo systemctl status ocg-server --no-pager
 curl -I http://127.0.0.1:9000
@@ -589,20 +595,6 @@ For small EC2 instances, keep builds single-threaded:
 
 ```bash
 CARGO_BUILD_JOBS=1 cargo build --release -p ocg-server
-```
-
-To build in the background over SSH:
-
-```bash
-nohup env CARGO_BUILD_JOBS=1 cargo build --release -p ocg-server > ~/goup-build.log 2>&1 &
-tail -f ~/goup-build.log
-```
-
-Restart the deployed service after a successful build:
-
-```bash
-sudo systemctl restart ocg-server
-sudo systemctl status ocg-server --no-pager
 ```
 
 If files under `mcp/` changed, restart the remote MCP service too:

--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -1,5 +1,6 @@
 //! HTTP handlers for the global site.
 
+pub(crate) mod about;
 pub(crate) mod explore;
 pub(crate) mod home;
 pub(crate) mod jobs;

--- a/ocg-server/src/handlers/site/about.rs
+++ b/ocg-server/src/handlers/site/about.rs
@@ -1,0 +1,32 @@
+//! HTTP handlers for the public about page.
+
+use askama::Template;
+use axum::{
+    extract::State,
+    http::Uri,
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+
+use crate::{
+    db::DynDB,
+    handlers::error::HandlerError,
+    router::PUBLIC_SHARED_CACHE_HEADERS,
+    templates::{PageId, auth::User, site::about},
+};
+
+/// Handler that renders the public about page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    State(db): State<DynDB>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let template = about::Page {
+        page_id: PageId::SiteAbout,
+        path: uri.path().to_string(),
+        site_settings: db.get_site_settings().await?,
+        user: User::default(),
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)))
+}

--- a/ocg-server/src/handlers/site/explore.rs
+++ b/ocg-server/src/handlers/site/explore.rs
@@ -54,6 +54,7 @@ pub(crate) async fn page(
     let entity: explore::Entity = query.get("entity").map(String::as_str).into();
     let mut template = explore::Page {
         entity: entity.clone(),
+        title: "Explore Events".to_string(),
         page_id: PageId::SiteExplore,
         path: uri.path().to_string(),
         site_settings,
@@ -67,11 +68,13 @@ pub(crate) async fn page(
         explore::Entity::Events => {
             let filters = SearchEventsFilters::new(&headers, &raw_query.unwrap_or_default())?;
             let events_section = prepare_events_section(&db, &filters).await?;
+            template.title = events_section.page_title();
             template.events_section = Some(events_section);
         }
         explore::Entity::Groups => {
             let filters = SearchGroupsFilters::new(&headers, &raw_query.unwrap_or_default())?;
             let groups_section = prepare_groups_section(&db, &filters).await?;
+            template.title = groups_section.page_title();
             template.groups_section = Some(groups_section);
         }
     }

--- a/ocg-server/src/handlers/site/wiki.rs
+++ b/ocg-server/src/handlers/site/wiki.rs
@@ -1,6 +1,6 @@
 //! HTTP handlers for the public wiki page.
 
-use std::time::Duration;
+use std::{cmp::Reverse, time::Duration};
 
 use askama::Template;
 use axum::{
@@ -8,6 +8,7 @@ use axum::{
     response::{Html, IntoResponse},
 };
 use cached::proc_macro::cached;
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use quick_xml::{Reader, events::Event};
 use tracing::{debug, instrument};
 
@@ -213,6 +214,7 @@ async fn load_section(client: &reqwest::Client, section: &SectionSource) -> Wiki
         }
     }
 
+    links.sort_by_key(|link| Reverse(link.published_at));
     links.truncate(MAX_LINKS_PER_SECTION);
 
     WikiSection {
@@ -276,18 +278,20 @@ fn parse_feed_links(feed: &str, source_label: &str) -> Vec<WikiLink> {
     let mut current_tag: Option<Vec<u8>> = None;
     let mut title = String::new();
     let mut link = String::new();
+    let mut published_at = String::new();
 
     loop {
         match reader.read_event() {
             Ok(Event::Eof) | Err(_) => break,
             Ok(Event::Start(event)) => {
                 let name = event.name().as_ref().to_vec();
-                if name.as_slice() == b"item" || name.as_slice() == b"entry" {
+                if tag_name_is(&name, b"item") || tag_name_is(&name, b"entry") {
                     in_item = true;
                     title.clear();
                     link.clear();
-                } else if in_item && (name.as_slice() == b"title" || name.as_slice() == b"link") {
-                    if name.as_slice() == b"link"
+                    published_at.clear();
+                } else if in_item && is_supported_item_tag(&name) {
+                    if tag_name_is(&name, b"link")
                         && let Some(href) = event
                             .attributes()
                             .filter_map(Result::ok)
@@ -305,8 +309,15 @@ fn parse_feed_links(feed: &str, source_label: &str) -> Vec<WikiLink> {
                     && let Ok(decoded) = text.decode()
                 {
                     match tag {
-                        b"title" if title.is_empty() => title = decoded.into_owned(),
-                        b"link" if link.is_empty() => link = decoded.into_owned(),
+                        tag if tag_name_is(tag, b"title") && title.is_empty() => {
+                            title = decoded.into_owned();
+                        }
+                        tag if tag_name_is(tag, b"link") && link.is_empty() => {
+                            link = decoded.into_owned();
+                        }
+                        tag if is_date_tag(tag) && published_at.is_empty() => {
+                            published_at = decoded.into_owned();
+                        }
                         _ => {}
                     }
                 }
@@ -317,20 +328,28 @@ fn parse_feed_links(feed: &str, source_label: &str) -> Vec<WikiLink> {
                     && let Ok(decoded) = text.decode()
                 {
                     match tag {
-                        b"title" if title.is_empty() => title = decoded.into_owned(),
-                        b"link" if link.is_empty() => link = decoded.into_owned(),
+                        tag if tag_name_is(tag, b"title") && title.is_empty() => {
+                            title = decoded.into_owned();
+                        }
+                        tag if tag_name_is(tag, b"link") && link.is_empty() => {
+                            link = decoded.into_owned();
+                        }
+                        tag if is_date_tag(tag) && published_at.is_empty() => {
+                            published_at = decoded.into_owned();
+                        }
                         _ => {}
                     }
                 }
             }
             Ok(Event::End(event)) => {
                 let name = event.name().as_ref().to_vec();
-                if name.as_slice() == b"item" || name.as_slice() == b"entry" {
+                if tag_name_is(&name, b"item") || tag_name_is(&name, b"entry") {
                     if !title.trim().is_empty() && !link.trim().is_empty() {
                         links.push(WikiLink {
                             title: title.trim().to_string(),
                             url: link.trim().to_string(),
                             source: source_label.to_string(),
+                            published_at: parse_feed_date(published_at.trim()),
                         });
                     }
                     in_item = false;
@@ -341,7 +360,7 @@ fn parse_feed_links(feed: &str, source_label: &str) -> Vec<WikiLink> {
             }
             Ok(Event::Empty(event)) => {
                 if in_item
-                    && event.name().as_ref() == b"link"
+                    && tag_name_is(event.name().as_ref(), b"link")
                     && link.is_empty()
                     && let Some(href) = event
                         .attributes()
@@ -357,4 +376,40 @@ fn parse_feed_links(feed: &str, source_label: &str) -> Vec<WikiLink> {
     }
 
     links
+}
+
+fn is_supported_item_tag(name: &[u8]) -> bool {
+    tag_name_is(name, b"title") || tag_name_is(name, b"link") || is_date_tag(name)
+}
+
+fn is_date_tag(name: &[u8]) -> bool {
+    tag_name_is(name, b"pubDate")
+        || tag_name_is(name, b"published")
+        || tag_name_is(name, b"updated")
+        || tag_name_is(name, b"date")
+}
+
+fn tag_name_is(name: &[u8], expected: &[u8]) -> bool {
+    name == expected
+        || name
+            .rsplit(|byte| *byte == b':')
+            .next()
+            .is_some_and(|local_name| local_name == expected)
+}
+
+fn parse_feed_date(value: &str) -> Option<DateTime<Utc>> {
+    if value.is_empty() {
+        return None;
+    }
+
+    DateTime::parse_from_rfc2822(value)
+        .or_else(|_| DateTime::parse_from_rfc3339(value))
+        .map(|date| date.with_timezone(&Utc))
+        .ok()
+        .or_else(|| {
+            NaiveDate::parse_from_str(value, "%Y-%m-%d")
+                .ok()
+                .and_then(|date| date.and_hms_opt(0, 0, 0))
+                .map(|date| Utc.from_utc_datetime(&date))
+        })
 }

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -288,6 +288,7 @@ pub(crate) async fn setup(
         .route("/images/og/{file_name}", get(images::serve_open_graph))
         .route("/images/{file_name}", get(images::serve))
         .route("/log-in", get(auth::log_in_page))
+        .route("/about", get(site::about::page))
         .route("/jobs", get(site::jobs::page))
         .route("/jobs/{slug}", get(site::jobs::details))
         .route("/landscape", get(site::landscape::page))

--- a/ocg-server/src/templates.rs
+++ b/ocg-server/src/templates.rs
@@ -38,6 +38,7 @@ pub(crate) enum PageId {
     JobsDashboard,
     LogIn,
     SignUp,
+    SiteAbout,
     SiteExplore,
     SiteHome,
     SiteJobs,

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -1,5 +1,7 @@
 //! Templates for the global site pages.
 
+/// Templates for the about page.
+pub(crate) mod about;
 /// Templates for the explore page.
 pub(crate) mod explore;
 /// Templates for the home page.

--- a/ocg-server/src/templates/site/about.rs
+++ b/ocg-server/src/templates/site/about.rs
@@ -1,0 +1,23 @@
+//! Templates for the public about page.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{PageId, auth::User, filters, helpers::user_initials},
+    types::site::SiteSettings,
+};
+
+/// Public about page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/about/page.html")]
+pub(crate) struct Page {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+}

--- a/ocg-server/src/templates/site/explore.rs
+++ b/ocg-server/src/templates/site/explore.rs
@@ -36,6 +36,8 @@ use crate::{
 pub(crate) struct Page {
     /// The type of content being explored (events or groups).
     pub entity: Entity,
+    /// Page title tailored to the selected explore filters.
+    pub title: String,
     /// Identifier for the current page.
     pub page_id: PageId,
     /// Current URL path.
@@ -64,6 +66,17 @@ pub(crate) struct EventsSection {
     pub filters_options: FiltersOptions,
     /// Results section containing matching events.
     pub results_section: EventsResultsSection,
+}
+
+impl EventsSection {
+    /// Return a descriptive page title for the current event filters.
+    pub(crate) fn page_title(&self) -> String {
+        explore_page_title(
+            Entity::Events,
+            &self.filters.alliance,
+            &self.filters_options.alliances,
+        )
+    }
 }
 
 /// Template for displaying event search results.
@@ -126,6 +139,17 @@ pub(crate) struct GroupsSection {
     pub filters_options: FiltersOptions,
     /// Results section containing matching groups.
     pub results_section: GroupsResultsSection,
+}
+
+impl GroupsSection {
+    /// Return a descriptive page title for the current group filters.
+    pub(crate) fn page_title(&self) -> String {
+        explore_page_title(
+            Entity::Groups,
+            &self.filters.alliance,
+            &self.filters_options.alliances,
+        )
+    }
 }
 
 /// Template for displaying group search results.
@@ -223,6 +247,27 @@ pub(crate) struct FilterOption {
     pub name: String,
     /// Technical value used in queries.
     pub value: String,
+}
+
+/// Build a human-readable explore page title from the selected entity and alliance filter.
+fn explore_page_title(
+    entity: Entity,
+    selected_alliances: &[String],
+    alliances: &[FilterOption],
+) -> String {
+    let entity_label = match entity {
+        Entity::Events => "Events",
+        Entity::Groups => "Groups",
+    };
+
+    if selected_alliances.len() == 1
+        && let Some(alliance) =
+            alliances.iter().find(|option| option.value == selected_alliances[0])
+    {
+        return format!("{} {}", alliance.name, entity_label);
+    }
+
+    format!("Explore {entity_label}")
 }
 
 // Helpers for rendering popovers.

--- a/ocg-server/src/templates/site/wiki.rs
+++ b/ocg-server/src/templates/site/wiki.rs
@@ -1,6 +1,7 @@
 //! Templates and types for the public wiki page.
 
 use askama::Template;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -57,4 +58,6 @@ pub(crate) struct WikiLink {
     pub url: String,
     /// Source label.
     pub source: String,
+    /// Publication timestamp from the source feed, when provided.
+    pub published_at: Option<DateTime<Utc>>,
 }

--- a/ocg-server/templates/common/footer.html
+++ b/ocg-server/templates/common/footer.html
@@ -87,6 +87,12 @@
           <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Resources</h2>
           <ul class="mt-4 space-y-3 text-sm">
             <li>
+              <a href="/about"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">About</a>
+            </li>
+            <li>
               <a href="/jobs"
                  hx-boost="true"
                  hx-target="body"

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -26,10 +26,47 @@
       {# Desktop links -#}
       <div class="hidden lg:flex lg:gap-x-8 relative mt-1.5">
         {{ header::link(content = "Home", href = "/", current_path = path) -}}
-        {{ header::link(content = "Explore", href = explore_events, current_path = path, path = "/explore") -}}
-        {{ header::link(content = "Jobs", href = "/jobs", current_path = path, path = "/jobs") -}}
-        {{ header::link(content = "Landscape", href = "/landscape", current_path = path, path = "/landscape") -}}
-        {{ header::link(content = "Wiki", href = "/wiki", current_path = path, path = "/wiki") -}}
+        {{ header::link(content = "Events & Groups", href = explore_events, current_path = path, path = "/explore") -}}
+        <div class="group relative">
+          {{ header::link(content = "Jobs", href = "/jobs", current_path = path, path = "/jobs") -}}
+          <div class="absolute left-1/2 top-full z-[100] hidden w-64 -translate-x-1/2 pt-4 group-hover:block group-focus-within:block">
+            <div class="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-xl shadow-stone-200/70">
+              <a href="/jobs"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="block px-4 py-3 text-sm font-bold text-stone-900 transition hover:bg-stone-50">
+                Browse roles
+                <span class="mt-1 block text-xs/5 font-medium text-stone-500">Open roles from GOUP members.</span>
+              </a>
+              <a href="/jobs?remote=true"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-stone-900 transition hover:bg-stone-50">
+                Remote roles
+                <span class="mt-1 block text-xs/5 font-medium text-stone-500">Find jobs you can do from anywhere.</span>
+              </a>
+              {% if user.logged_in -%}
+                <a href="/dashboard/jobs"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-primary-700 transition hover:bg-primary-50">
+                  Post a role
+                  <span class="mt-1 block text-xs/5 font-medium text-stone-500">Share a job with the builder network.</span>
+                </a>
+              {% else -%}
+                <a href="/log-in?next_url=/dashboard/jobs"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-primary-700 transition hover:bg-primary-50">
+                  Post a role
+                  <span class="mt-1 block text-xs/5 font-medium text-stone-500">Log in to share a hiring need.</span>
+                </a>
+              {% endif -%}
+            </div>
+          </div>
+        </div>
+        {{ header::link(content = "Ecosystem", href = "/landscape", current_path = path, path = "/landscape") -}}
+        {{ header::link(content = "Resources", href = "/wiki", current_path = path, path = "/wiki") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
       </div>
       {# End desktop links -#}
@@ -37,7 +74,7 @@
 
     {# Desktop user menu -#}
     <div class="flex flex-1 justify-end items-center gap-3">
-      {% if page_id == PageId::SiteHome || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
+      {% if page_id == PageId::SiteHome || page_id == PageId::SiteAbout || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
         <div hx-get="/section/user-menu"
              hx-trigger="load"
              hx-target="this"
@@ -63,7 +100,7 @@
 {% macro user_menu(user) -%}
   {# TODO: Hardcoded alliance until we add more #}
   {% let explore_events = "/explore?alliance[0]=goup" %}
-  <div class="relative">
+  <div class="relative flex items-center gap-3">
     {% if user.logged_in -%}
       <button id="user-dropdown-button"
               data-logged-in="true"
@@ -107,7 +144,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-search bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Explore</div>
+                <div class="ms-2 text-xs/6">Events & Groups</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -121,7 +158,33 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-search bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Jobs</div>
+                <div class="ms-2 text-xs/6">Browse roles</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+          <li class="lg:hidden" role="none">
+            <a href="/jobs?remote=true"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Remote roles</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+          <li class="lg:hidden" role="none">
+            <a href="/dashboard/jobs"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Post a role</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -135,7 +198,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-map bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Landscape</div>
+                <div class="ms-2 text-xs/6">Ecosystem</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -149,7 +212,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-list bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Wiki</div>
+                <div class="ms-2 text-xs/6">Resources</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -266,6 +329,11 @@
       </div>
       {# End user dropdown menu -#}
     {% else -%}
+      <a href="/log-in/oidc/linkedin"
+         hx-boost="false"
+         class="hidden rounded-full bg-stone-950 px-4 py-2 text-sm font-bold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-primary-700 hover:shadow-md sm:inline-flex">
+        Join GOUP
+      </a>
       <button id="user-dropdown-button"
               data-logged-in="false"
               class="cursor-pointer group rounded-full bg-white border text-xl border-primary-500 text-primary-700 hover:text-primary-900 hover:border-primary-900 size-[38px] p-0.5 overflow-hidden">
@@ -277,6 +345,18 @@
            class="dropdown absolute hidden z-[100] right-0 top-10 w-[250px] bg-white divide-y divide-stone-100 rounded-lg shadow border border-stone-200"
            role="menu">
         <ul class="text-stone-700 my-2" role="none">
+          <li class="border-b border-stone-200 mb-2 pb-2" role="none">
+            <a href="/log-in/oidc/linkedin"
+               hx-boost="false"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-linkedin bg-stone-600"></div>
+                <div class="ms-2 text-xs/6 font-semibold">Join GOUP</div>
+              </div>
+            </a>
+          </li>
+
           <li class="lg:hidden" role="none">
             <a href="/"
                hx-boost="true"
@@ -299,7 +379,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-search bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Explore</div>
+                <div class="ms-2 text-xs/6">Events & Groups</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -319,7 +399,7 @@
             </a>
           </li>
 
-          <li class="lg:hidden border-b border-stone-200 mb-2 pb-2" role="none">
+          <li class="lg:hidden" role="none">
             <a href="/jobs"
                hx-boost="true"
                hx-target="body"
@@ -327,7 +407,33 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-search bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Jobs</div>
+                <div class="ms-2 text-xs/6">Browse roles</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+          <li class="lg:hidden" role="none">
+            <a href="/jobs?remote=true"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Remote roles</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+          <li class="lg:hidden border-b border-stone-200 mb-2 pb-2" role="none">
+            <a href="/log-in?next_url=/dashboard/jobs"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-search bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Post a role</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -342,7 +448,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-map bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Landscape</div>
+                <div class="ms-2 text-xs/6">Ecosystem</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -4,15 +4,35 @@
 {{ dashboard::page_title(title = "Landscape", description = "Manage startups and GitHub projects shown on the public landscape.") -}}
 
 {% if can_manage_landscape -%}
-  <section class="mt-8 rounded-2xl border border-stone-200 bg-stone-50 p-5">
-    <h2 class="text-lg font-semibold text-stone-950">Add landscape entry</h2>
-    <form class="mt-4 grid gap-4"
+  <section class="mt-8 overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
+    <div class="border-b border-stone-100 bg-linear-to-br from-primary-50/80 via-white to-stone-50 px-5 py-5 sm:px-6">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div class="inline-flex rounded-full border border-primary-200 bg-white/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700">
+            New ecosystem entry
+          </div>
+          <h2 class="mt-3 text-xl font-black tracking-tight text-stone-950">Add landscape entry</h2>
+          <p class="mt-2 max-w-2xl text-sm/6 text-stone-600">
+            Add startups, open-source projects, and tools that should appear in the public GOUP
+            ecosystem map. Keep the summary clear so visitors understand what it does quickly.
+          </p>
+        </div>
+        <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+          Save as draft, then publish.
+        </div>
+      </div>
+    </div>
+    <form class="grid gap-5 p-5 sm:p-6"
           hx-post="/dashboard/alliance/landscape/add"
           hx-target="#dashboard-content">
       <div class="grid gap-4 lg:grid-cols-3">
         <div>
           <label class="label" for="new-landscape-name">Name</label>
-          <input id="new-landscape-name" name="name" class="input" required />
+          <input id="new-landscape-name"
+                 name="name"
+                 class="input"
+                 placeholder="Project or startup name"
+                 required />
         </div>
         <div>
           <label class="label" for="new-landscape-kind">Kind</label>
@@ -34,28 +54,40 @@
         <input id="new-landscape-summary"
                name="summary"
                class="input"
+               placeholder="One sentence explaining the project or startup"
                required
                maxlength="500" />
+        <p class="mt-1 text-xs text-stone-500">Shown on public landscape cards. Max 500 characters.</p>
       </div>
       <div>
         <label class="label" for="new-landscape-description">Description</label>
         <textarea id="new-landscape-description"
                   name="description"
                   rows="4"
-                  class="input"></textarea>
+                  class="input"
+                  placeholder="What it does, who it is for, and why it belongs in the ecosystem"></textarea>
       </div>
       <div class="grid gap-4 lg:grid-cols-4">
         <div>
           <label class="label" for="new-landscape-website">Website URL</label>
-          <input id="new-landscape-website" name="website_url" class="input" />
+          <input id="new-landscape-website"
+                 name="website_url"
+                 class="input"
+                 placeholder="https://..." />
         </div>
         <div>
           <label class="label" for="new-landscape-github">GitHub URL</label>
-          <input id="new-landscape-github" name="github_url" class="input" />
+          <input id="new-landscape-github"
+                 name="github_url"
+                 class="input"
+                 placeholder="https://github.com/..." />
         </div>
         <div>
           <label class="label" for="new-landscape-logo">Logo URL</label>
-          <input id="new-landscape-logo" name="logo_url" class="input" />
+          <input id="new-landscape-logo"
+                 name="logo_url"
+                 class="input"
+                 placeholder="https://..." />
         </div>
         <div>
           <label class="label" for="new-landscape-tags">Tags</label>
@@ -65,7 +97,7 @@
                  placeholder="Rust, SaaS, OSS" />
         </div>
       </div>
-      <div>
+      <div class="flex justify-end border-t border-stone-100 pt-5">
         <button class="btn-primary" type="submit">Add entry</button>
       </div>
     </form>

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -30,64 +30,99 @@
       <div class="mt-6">{{ feedback::alerts(messages) -}}</div>
     {% endif -%}
 
-    <section class="mt-8 rounded-2xl border border-stone-200 bg-stone-50 p-5">
-      <h2 class="text-lg font-semibold text-stone-950">Post a job</h2>
-      <form class="mt-4 grid gap-4"
+    <section class="mt-8 overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
+      <div class="border-b border-stone-100 bg-linear-to-br from-primary-50/80 via-white to-stone-50 px-5 py-5 sm:px-6">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div class="inline-flex rounded-full border border-primary-200 bg-white/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700">
+              New role
+            </div>
+            <h2 class="mt-3 text-xl font-black tracking-tight text-stone-950">Post a job</h2>
+            <p class="mt-2 max-w-2xl text-sm/6 text-stone-600">
+              Share a clear role with the GOUP network. Keep the summary short, then use the
+              description for responsibilities, requirements, and how candidates should apply.
+            </p>
+          </div>
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+            Draft first, publish when ready.
+          </div>
+        </div>
+      </div>
+      <form class="grid gap-6 p-5 sm:p-6 lg:p-8"
             action="/dashboard/jobs"
             method="post"
             hx-post="/dashboard/jobs"
             hx-target="body">
-        <div class="grid gap-4 lg:grid-cols-2">
-          <div>
-            <label class="label" for="new-job-title">Title</label>
-            <input id="new-job-title" name="title" class="input" required />
+        <div class="grid gap-5 lg:grid-cols-12">
+          <div class="space-y-2 lg:col-span-6">
+            <label class="form-label" for="new-job-title">Title</label>
+            <input id="new-job-title"
+                   name="title"
+                   class="input-primary"
+                   placeholder="Founding AI Engineer"
+                   required />
           </div>
-          <div>
-            <label class="label" for="new-job-company">Company</label>
-            <input id="new-job-company" name="company_name" class="input" required />
+          <div class="space-y-2 lg:col-span-6">
+            <label class="form-label" for="new-job-company">Company</label>
+            <input id="new-job-company"
+                   name="company_name"
+                   class="input-primary"
+                   placeholder="Company or project name"
+                   required />
           </div>
-        </div>
-        <div>
-          <label class="label" for="new-job-summary">Summary</label>
-          <input id="new-job-summary"
-                 name="summary"
-                 class="input"
-                 required
-                 maxlength="500" />
-        </div>
-        <div>
-          <label class="label" for="new-job-description">Description</label>
-          <textarea id="new-job-description"
-                    name="description"
-                    rows="6"
-                    class="input"
-                    required></textarea>
-        </div>
-        <div class="grid gap-4 lg:grid-cols-3">
-          <div>
-            <label class="label" for="new-job-apply-url">Apply URL</label>
-            <input id="new-job-apply-url" name="apply_url" class="input" required />
+
+          <div class="space-y-2 lg:col-span-12">
+            <label class="form-label" for="new-job-summary">Summary</label>
+            <input id="new-job-summary"
+                   name="summary"
+                   class="input-primary"
+                   placeholder="One sentence about the role and why it matters"
+                   required
+                   maxlength="500" />
+            <p class="form-legend">Shown on job cards. Max 500 characters.</p>
           </div>
-          <div>
-            <label class="label" for="new-job-location">Location</label>
-            <input id="new-job-location" name="location" class="input" />
+
+          <div class="space-y-2 lg:col-span-12">
+            <label class="form-label" for="new-job-description">Description</label>
+            <textarea id="new-job-description"
+                      name="description"
+                      rows="6"
+                      class="input-primary min-h-40 resize-y"
+                      placeholder="What the person will build, who they will work with, and what experience helps"
+                      required></textarea>
           </div>
-          <div>
-            <label class="label" for="new-job-tags">Tags</label>
+
+          <div class="space-y-2 lg:col-span-5">
+            <label class="form-label" for="new-job-apply-url">Apply URL</label>
+            <input id="new-job-apply-url"
+                   name="apply_url"
+                   class="input-primary"
+                   placeholder="https://..."
+                   required />
+          </div>
+          <div class="space-y-2 lg:col-span-4">
+            <label class="form-label" for="new-job-location">Location</label>
+            <input id="new-job-location"
+                   name="location"
+                   class="input-primary"
+                   placeholder="Baku, Remote, San Francisco" />
+          </div>
+          <div class="space-y-2 lg:col-span-3">
+            <label class="form-label" for="new-job-tags">Tags</label>
             <input id="new-job-tags"
                    name="tags"
-                   class="input"
+                   class="input-primary"
                    placeholder="Rust, Platform, DevOps" />
           </div>
         </div>
-        <label class="inline-flex items-center gap-2 text-sm text-stone-700">
-          <input type="checkbox"
-                 name="remote"
-                 value="true"
-                 class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
-          Remote-friendly role
-        </label>
-        <div>
+        <div class="flex flex-col gap-4 rounded-3xl border border-stone-100 bg-stone-50/80 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <label class="inline-flex w-fit items-center gap-3 rounded-2xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm font-medium text-stone-700">
+            <input type="checkbox"
+                   name="remote"
+                   value="true"
+                   class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
+            Remote-friendly role
+          </label>
           <button class="btn-primary" type="submit">Post job</button>
         </div>
       </form>
@@ -132,61 +167,61 @@
                   hx-put="/dashboard/jobs/{{ job.job_id }}"
                   hx-target="body">
               <div class="grid gap-4 lg:grid-cols-2">
-                <div>
-                  <label class="label" for="job-title-{{ job.job_id }}">Title</label>
+                <div class="space-y-2">
+                  <label class="form-label" for="job-title-{{ job.job_id }}">Title</label>
                   <input id="job-title-{{ job.job_id }}"
                          name="title"
-                         class="input"
+                         class="input-primary"
                          value="{{ job.title }}"
                          required />
                 </div>
-                <div>
-                  <label class="label" for="job-company-{{ job.job_id }}">Company</label>
+                <div class="space-y-2">
+                  <label class="form-label" for="job-company-{{ job.job_id }}">Company</label>
                   <input id="job-company-{{ job.job_id }}"
                          name="company_name"
-                         class="input"
+                         class="input-primary"
                          value="{{ job.company_name }}"
                          required />
                 </div>
               </div>
-              <div>
-                <label class="label" for="job-summary-{{ job.job_id }}">Summary</label>
+              <div class="space-y-2">
+                <label class="form-label" for="job-summary-{{ job.job_id }}">Summary</label>
                 <input id="job-summary-{{ job.job_id }}"
                        name="summary"
-                       class="input"
+                       class="input-primary"
                        value="{{ job.summary }}"
                        required
                        maxlength="500" />
               </div>
-              <div>
-                <label class="label" for="job-description-{{ job.job_id }}">Description</label>
+              <div class="space-y-2">
+                <label class="form-label" for="job-description-{{ job.job_id }}">Description</label>
                 <textarea id="job-description-{{ job.job_id }}"
                           name="description"
                           rows="5"
-                          class="input"
+                          class="input-primary min-h-32 resize-y"
                           required>{{ job.description }}</textarea>
               </div>
               <div class="grid gap-4 lg:grid-cols-3">
-                <div>
-                  <label class="label" for="job-apply-url-{{ job.job_id }}">Apply URL</label>
+                <div class="space-y-2">
+                  <label class="form-label" for="job-apply-url-{{ job.job_id }}">Apply URL</label>
                   <input id="job-apply-url-{{ job.job_id }}"
                          name="apply_url"
-                         class="input"
+                         class="input-primary"
                          value="{{ job.apply_url }}"
                          required />
                 </div>
-                <div>
-                  <label class="label" for="job-location-{{ job.job_id }}">Location</label>
+                <div class="space-y-2">
+                  <label class="form-label" for="job-location-{{ job.job_id }}">Location</label>
                   <input id="job-location-{{ job.job_id }}"
                          name="location"
-                         class="input"
+                         class="input-primary"
                          value="{{ job.location.as_deref().unwrap_or("") }}" />
                 </div>
-                <div>
-                  <label class="label" for="job-tags-{{ job.job_id }}">Tags</label>
+                <div class="space-y-2">
+                  <label class="form-label" for="job-tags-{{ job.job_id }}">Tags</label>
                   <input id="job-tags-{{ job.job_id }}"
                          name="tags"
-                         class="input"
+                         class="input-primary"
                          value="{{ job.tags.join(", ") }}" />
                 </div>
               </div>

--- a/ocg-server/templates/macros/stats.html
+++ b/ocg-server/templates/macros/stats.html
@@ -1,15 +1,28 @@
 {# Analytics chart container #}
-{% macro analytics_chart(chart_id, data, class = "h-80", min_points = 0, wrapper_class = "") -%}
-  <div class="bg-white border border-stone-200 rounded-lg px-2 py-4 md:p-6 {{ wrapper_class }}">
-    {% if data.len() > min_points + 0 -%}
-      <div id="{{ chart_id }}" class="{{ class }}">
-        <svg-spinner size="size-10" class="flex items-center justify-center h-full text-gray-500">
-        </svg-spinner>
-      </div>
+{% macro analytics_chart(chart_id, data, class = "h-80", min_points = 0, wrapper_class = "", href = "") -%}
+  {% if data.len() > min_points + 0 -%}
+    {% if href.len() > 0 -%}
+      <a href="{{ href }}"
+         class="group block bg-white border border-stone-200 rounded-lg px-2 py-4 transition hover:-translate-y-0.5 hover:border-primary-200 hover:shadow-xl hover:shadow-stone-200/60 md:p-6 {{ wrapper_class }}">
+        <div class="mb-3 flex justify-end">
+          <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-bold text-stone-500 transition group-hover:bg-primary-50 group-hover:text-primary-700">
+            View source
+          </span>
+        </div>
+        <div id="{{ chart_id }}" class="{{ class }}">
+          <svg-spinner size="size-10" class="flex items-center justify-center h-full text-gray-500">
+          </svg-spinner>
+        </div>
+      </a>
     {%- else -%}
-      <div class="chart-empty-state {{ class }}">No data available yet</div>
+      <div class="bg-white border border-stone-200 rounded-lg px-2 py-4 md:p-6 {{ wrapper_class }}">
+        <div id="{{ chart_id }}" class="{{ class }}">
+          <svg-spinner size="size-10" class="flex items-center justify-center h-full text-gray-500">
+          </svg-spinner>
+        </div>
+      </div>
     {%- endif %}
-  </div>
+  {%- endif %}
 {% endmacro analytics_chart -%}
 {# End analytics chart container #}
 

--- a/ocg-server/templates/site/about/page.html
+++ b/ocg-server/templates/site/about/page.html
@@ -1,0 +1,314 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <div class="relative overflow-hidden">
+    <div class="absolute inset-x-0 top-0 h-72 bg-linear-to-b from-primary-50/80 to-transparent"></div>
+    <div class="absolute -top-32 left-1/2 h-[30rem] w-[30rem] -translate-x-1/2 rounded-full bg-primary-300/20 blur-3xl">
+    </div>
+    <div class="absolute top-24 right-0 hidden h-80 w-80 rounded-full bg-sky-300/20 blur-3xl lg:block"></div>
+
+    <section class="relative container mx-auto max-w-7xl px-4 pt-10 pb-16 sm:px-6 sm:pt-14 lg:px-8 lg:pt-20 lg:pb-24">
+      <div class="mx-auto max-w-4xl text-center">
+        <div class="mb-7 inline-flex items-center rounded-full border border-primary-200 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-primary-700 shadow-sm backdrop-blur-xl">
+          About GOUP
+        </div>
+        <h1 class="text-balance text-5xl font-black tracking-[-0.055em] text-stone-950 sm:text-6xl lg:text-7xl">
+          A referral-based alliance for people who build
+        </h1>
+        <p class="mx-auto mt-7 max-w-3xl text-lg/8 font-medium text-stone-600 lg:text-xl/9">
+          Growth, opportunity, usefulness, and progress for engineers, founders, researchers,
+          community leaders, and builders moving faster together.
+        </p>
+      </div>
+    </section>
+  </div>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
+    <div class="mx-auto grid max-w-5xl gap-10 lg:gap-14">
+      <section class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+        <div class="grid gap-8 lg:grid-cols-[0.7fr_1.3fr]">
+          <div>
+            <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Our story</div>
+            <h2 class="mt-3 text-3xl font-black tracking-tight text-stone-950">From speakers chat to global alliance</h2>
+          </div>
+          <div class="space-y-5 text-base/8 text-stone-600">
+            <p>
+              What started as a small TechBrains 2025 speakers chat evolved into a 450+ person
+              alliance of engineers, founders, researchers, AI practitioners, and builders across
+              Azerbaijan, the US, Europe, and beyond.
+            </p>
+            <p>
+              We still operate with the same simple principle: help useful people find each other,
+              share what they are building, and create more value than we consume.
+            </p>
+            <blockquote class="rounded-3xl border border-primary-100 bg-primary-50/70 px-6 py-5 text-xl/8 font-black text-stone-950">
+              As long as we continue giving more than we take, the best is yet to come.
+            </blockquote>
+            <p>
+              The next five years will be transformative. AI is reshaping nearly every industry, and
+              the opportunity for serious builders has never been greater.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-stone-200 bg-stone-950 p-6 text-white shadow-sm sm:p-8 lg:p-10">
+        <div class="mb-8 max-w-2xl">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-200">GOUP stands for</div>
+          <h2 class="mt-3 text-3xl font-black tracking-tight">Growth through useful progress</h2>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+            <h3 class="font-black text-white">Growth</h3>
+            <p class="mt-2 text-sm/6 text-stone-300">Unlock potential.</p>
+          </div>
+          <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+            <h3 class="font-black text-white">Opportunity</h3>
+            <p class="mt-2 text-sm/6 text-stone-300">Open doors.</p>
+          </div>
+          <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+            <h3 class="font-black text-white">Usefulness</h3>
+            <p class="mt-2 text-sm/6 text-stone-300">Create value.</p>
+          </div>
+          <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+            <h3 class="font-black text-white">Progress</h3>
+            <p class="mt-2 text-sm/6 text-stone-300">Move forward.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-5 lg:grid-cols-2">
+        <div class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Who we are</div>
+          <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950">A global alliance of builders</h2>
+          <div class="mt-5 space-y-4 text-base/8 text-stone-600">
+            <p>GOUP is a referral-based global alliance of builders.</p>
+            <p>
+              We are founders, engineers, researchers, creators, community leaders, and lifelong
+              learners from different cultures, ages, beliefs, professions, and countries.
+            </p>
+            <p>
+              We believe diversity of experiences creates stronger ideas, better companies, and better
+              humans.
+            </p>
+            <p>We are united not by geography, titles, or credentials, but by values.</p>
+          </div>
+        </div>
+
+        <div class="rounded-[2rem] border border-stone-200 bg-stone-950 p-6 text-white shadow-sm sm:p-8">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-200">A place where</div>
+          <h2 class="mt-3 text-2xl font-black tracking-tight">People do not have to be alike</h2>
+          <div class="mt-5 grid gap-3 text-sm/6 text-stone-200">
+            <p>Alignment is more important than agreement.</p>
+            <p>Trust matters more than scale.</p>
+            <p>Relationships matter more than transactions.</p>
+            <p>Contribution matters more than credentials.</p>
+            <p>People just have to care.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+        <div class="mb-8 max-w-2xl">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Who we are looking for</div>
+          <h2 class="mt-3 text-3xl font-black tracking-tight text-stone-950">Builders who can give and grow</h2>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Startup founders</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Share what you are building and what customers, partners, investors, co-founders, or talent you need.</p>
+          </div>
+          <div class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Community leaders</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">AWS, GDG, Cursor, CNCF, AI, startup, product, design, security, data, and beyond.</p>
+          </div>
+          <div class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Open-source maintainers</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Share your project, GitHub link, and where contributors can help.</p>
+          </div>
+          <div class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Creators and educators</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Podcast hosts, writers, teachers, universities, academies, and research groups.</p>
+          </div>
+          <div class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Engineers</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Find mentorship, referrals, career guidance, collaborators, or people to hire.</p>
+          </div>
+          <div class="rounded-3xl border border-stone-200 bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Other builders</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Tell us what you are building, what you can help with, and what support you need.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-5 lg:grid-cols-[0.9fr_1.1fr]">
+        <div class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Five non-negotiable values</div>
+          <div class="mt-6 grid gap-4">
+            <div>
+              <h3 class="font-black text-stone-950">Integrity</h3>
+              <p class="mt-1 text-sm/6 text-stone-600">Doing the right thing even when nobody is watching.</p>
+            </div>
+            <div>
+              <h3 class="font-black text-stone-950">Doer</h3>
+              <p class="mt-1 text-sm/6 text-stone-600">Ideas matter only when they become action.</p>
+            </div>
+            <div>
+              <h3 class="font-black text-stone-950">Giver</h3>
+              <p class="mt-1 text-sm/6 text-stone-600">Contribute more than you consume.</p>
+            </div>
+            <div>
+              <h3 class="font-black text-stone-950">Passion</h3>
+              <p class="mt-1 text-sm/6 text-stone-600">Care deeply about what you build and who you serve.</p>
+            </div>
+            <div>
+              <h3 class="font-black text-stone-950">Resilience</h3>
+              <p class="mt-1 text-sm/6 text-stone-600">Keep going when things become difficult.</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">How we operate</div>
+          <div class="mt-6 grid gap-4 sm:grid-cols-2">
+            <div class="rounded-3xl bg-stone-50 p-5">
+              <h3 class="font-black text-stone-950">Connections</h3>
+              <p class="mt-2 text-sm/6 text-stone-600">We make introductions that create win-win outcomes.</p>
+            </div>
+            <div class="rounded-3xl bg-stone-50 p-5">
+              <h3 class="font-black text-stone-950">Collaboration</h3>
+              <p class="mt-2 text-sm/6 text-stone-600">We meet, learn, and help each other move faster.</p>
+            </div>
+            <div class="rounded-3xl bg-stone-50 p-5">
+              <h3 class="font-black text-stone-950">Education</h3>
+              <p class="mt-2 text-sm/6 text-stone-600">We share useful knowledge, opportunities, and experiences openly.</p>
+            </div>
+            <div class="rounded-3xl bg-stone-50 p-5">
+              <h3 class="font-black text-stone-950">Promotion</h3>
+              <p class="mt-2 text-sm/6 text-stone-600">We support fellow members, attend their events, promote their work, and connect them with our networks.</p>
+            </div>
+            <div class="rounded-3xl bg-stone-50 p-5 sm:col-span-2">
+              <h3 class="font-black text-stone-950">Quality</h3>
+              <p class="mt-2 text-sm/6 text-stone-600">We prioritize meaningful relationships over transactions and noise.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="grid gap-5 lg:grid-cols-2">
+        <div class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">What we do not optimize for</div>
+          <div class="mt-6 grid gap-3 text-sm/6 text-stone-600">
+            <p>Vanity metrics.</p>
+            <p>Titles and credentials.</p>
+            <p>Bureaucracy and unnecessary rules.</p>
+            <p>Status and exclusivity.</p>
+            <p>Endless busyness.</p>
+            <p>Transactions disguised as relationships.</p>
+          </div>
+          <p class="mt-6 rounded-3xl border border-primary-100 bg-primary-50/70 px-5 py-4 font-black text-stone-950">
+            Success without values eventually expires. Values compound.
+          </p>
+        </div>
+
+        <div class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">What we value</div>
+          <div class="mt-6 grid gap-3 text-sm/6 text-stone-600">
+            <p>Helping when someone asks.</p>
+            <p>Being kind, authentic, and concise.</p>
+            <p>Curiosity and continuous growth.</p>
+            <p>Context and good intentions.</p>
+            <p>Clarity, focus, and depth.</p>
+            <p>Long-term relationships.</p>
+            <p>Giving more than taking.</p>
+            <p>Becoming better humans, not just more successful professionals.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+        <div class="grid gap-8 lg:grid-cols-[0.9fr_1.1fr]">
+          <div>
+            <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Where we are going</div>
+            <h2 class="mt-3 text-3xl font-black tracking-tight text-stone-950">
+              The most aligned alliance, not the biggest network
+            </h2>
+          </div>
+          <div class="space-y-5 text-base/8 text-stone-600">
+            <p>
+              We are not trying to become the biggest network. We are trying to become the most
+              aligned alliance.
+            </p>
+            <p>We do not compete with others. We compete only with our previous selves.</p>
+            <p>
+              If we succeed, thousands of builders around the world will become stronger because
+              they helped one another become stronger.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+        <div class="mb-8 max-w-2xl">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Community leads</div>
+          <h2 class="mt-3 text-3xl font-black tracking-tight text-stone-950">People helping GOUP move forward</h2>
+          <p class="mt-3 text-sm/6 text-stone-600">
+            Thank you to the builders who keep creating mentorship, events, ideas, and connections
+            for the alliance.
+          </p>
+        </div>
+        <div class="grid gap-3 sm:grid-cols-2">
+          <div class="rounded-3xl bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Vurgun H.</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Mentorship, career guidance, and always being available to help.</p>
+          </div>
+          <div class="rounded-3xl bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Malik Mammadli</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Coffee chats, hackathons, events, and bringing people together.</p>
+          </div>
+          <div class="rounded-3xl bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Agshin Rajabov</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Startups, design, longevity, running clubs, and turning ideas into action.</p>
+          </div>
+          <div class="rounded-3xl bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Günel Aghakishiyeva</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">AI, content, and knowledge sharing.</p>
+          </div>
+          <div class="rounded-3xl bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Elshad Aghayev</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Software engineering, open source, and connecting builders across Europe.</p>
+          </div>
+          <div class="rounded-3xl bg-stone-50 p-5">
+            <h3 class="font-black text-stone-950">Tony Mamedbekov</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Cloud, engineering, and supporting builders across the US.</p>
+          </div>
+          <div class="rounded-3xl bg-stone-50 p-5 sm:col-span-2">
+            <h3 class="font-black text-stone-950">Sako M</h3>
+            <p class="mt-2 text-sm/6 text-stone-600">Platform engineering, security, AI, and hackathons.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="rounded-[2rem] border border-stone-200 bg-stone-950 p-6 text-white shadow-sm sm:p-8 lg:p-10">
+        <div class="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+          <div>
+            <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-200">How to join</div>
+            <h2 class="mt-3 text-3xl font-black tracking-tight">GOUP grows through trust</h2>
+          </div>
+          <div class="space-y-5 text-base/8 text-stone-200">
+            <p>Members invite people they genuinely believe embody our values.</p>
+            <p>We do a quick relevance check to make sure there is mutual benefit and alignment.</p>
+            <div class="grid gap-3 rounded-3xl border border-white/10 bg-white/5 p-5 text-sm/6">
+              <p>No applications.</p>
+              <p>No status requirements.</p>
+              <p>No need to prove yourself first.</p>
+            </div>
+            <p class="text-xl/8 font-black text-white">Good people refer good people. That is how alliances grow.</p>
+          </div>
+        </div>
+      </section>
+    </div>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/explore/page.html
+++ b/ocg-server/templates/site/explore/page.html
@@ -13,7 +13,7 @@
   <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
     <div class="relative max-w-7xl text-center">
       <h1 class="mb-2 xl:mb-6 text-[1.8rem] font-semibold tracking-tight leading-10 md:leading-8 sm:leading-none md:text-2xl lg:text-4xl xl:text-5xl">
-        {{ site_settings.title }}
+        {{ title }}
       </h1>
     </div>
   </div>

--- a/ocg-server/templates/site/home/page.html
+++ b/ocg-server/templates/site/home/page.html
@@ -5,32 +5,27 @@
 {% block jumbotron -%}
   {# Jumbotron -#}
   <div class="relative overflow-hidden">
-    <div class="absolute inset-x-0 top-0 h-48 bg-linear-to-b from-primary-50/70 to-transparent"></div>
-    <div class="absolute -top-36 left-1/2 h-[30rem] w-[30rem] -translate-x-1/2 rounded-full bg-primary-300/25 blur-3xl">
+    <div class="absolute inset-x-0 top-0 h-56 bg-linear-to-b from-amber-50/80 via-primary-50/60 to-transparent">
     </div>
-    <div class="absolute top-16 right-0 hidden h-96 w-96 rounded-full bg-sky-300/20 blur-3xl lg:block"></div>
-    <div class="absolute bottom-0 left-8 hidden h-80 w-80 rounded-full bg-indigo-200/20 blur-3xl lg:block"></div>
+    <div class="absolute -top-36 left-1/2 h-[30rem] w-[30rem] -translate-x-1/2 rounded-full bg-amber-200/40 blur-3xl">
+    </div>
+    <div class="absolute top-16 right-0 hidden h-96 w-96 rounded-full bg-rose-200/25 blur-3xl lg:block"></div>
+    <div class="absolute bottom-0 left-8 hidden h-80 w-80 rounded-full bg-sky-200/20 blur-3xl lg:block"></div>
 
     <section class="relative container mx-auto max-w-7xl px-4 pt-10 pb-16 sm:px-6 sm:pt-14 lg:px-8 lg:pt-20 lg:pb-24">
       <div class="mx-auto max-w-5xl text-center">
         <div class="mb-7 inline-flex items-center rounded-full border border-primary-200 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-primary-700 shadow-sm shadow-primary-100/50 backdrop-blur-xl">
-          AI. Open Source. Entrepreneurship.
+          dream. connect. achieve.
         </div>
 
         <h1 class="text-balance text-5xl font-black tracking-[-0.055em] text-stone-950 sm:text-6xl lg:text-8xl">
-          GOUP Alliance
+          Build with people who care
         </h1>
 
-        {% if !site_settings.description.is_empty() -%}
-          <div class="jumbotron-description mx-auto mt-7 max-w-2xl text-lg/8 font-medium text-stone-600 lg:text-xl/9">
-            {{ site_settings.description|md_to_html|safe }}
-          </div>
-        {% else -%}
-          <p class="mx-auto mt-7 max-w-2xl text-lg/8 font-medium text-stone-600 lg:text-xl/9">
-            Discover groups, join events, find opportunities, and connect with
-            builders shaping the next wave of open technology.
-          </p>
-        {% endif -%}
+        <p class="jumbotron-description mx-auto mt-7 max-w-3xl text-lg/8 font-medium text-stone-600 lg:text-xl/9">
+          GOUP is a warm circle of founders, engineers, researchers, creators, and community
+          leaders who share help, ideas, jobs, projects, and honest introductions.
+        </p>
 
         <div class="mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
           <a href="{{ explore_events }}"
@@ -43,14 +38,37 @@
              hx-boost="true"
              hx-target="body"
              class="inline-flex items-center justify-center rounded-full border border-stone-200 bg-white/80 px-7 py-3.5 text-base font-bold text-stone-900 shadow-sm backdrop-blur-xl transition hover:-translate-y-0.5 hover:border-stone-300 hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-500">
-            Browse groups
+            Meet the community
           </a>
+        </div>
+
+        <div class="mt-10 grid gap-3 text-left sm:grid-cols-2 lg:grid-cols-4">
+          <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-lg shadow-stone-200/50 backdrop-blur">
+            <div class="text-sm font-black text-stone-950">Ask for help</div>
+            <p class="mt-2 text-sm/6 text-stone-600">Get feedback, referrals, intros, and practical advice.</p>
+          </div>
+          <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-lg shadow-stone-200/50 backdrop-blur">
+            <div class="text-sm font-black text-stone-950">Share your work</div>
+            <p class="mt-2 text-sm/6 text-stone-600">Post launches, roles, open-source projects, and events.</p>
+          </div>
+          <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-lg shadow-stone-200/50 backdrop-blur">
+            <div class="text-sm font-black text-stone-950">Meet in real life</div>
+            <p class="mt-2 text-sm/6 text-stone-600">Coffee chats, meetups, workshops, and small gatherings.</p>
+          </div>
+          <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-lg shadow-stone-200/50 backdrop-blur">
+            <div class="text-sm font-black text-stone-950">Grow together</div>
+            <p class="mt-2 text-sm/6 text-stone-600">Give more than you take, and everyone moves faster.</p>
+          </div>
         </div>
       </div>
 
       {# Stats -#}
       <div class="relative z-10 mt-12 lg:mt-16">{% include "site/home/stats.html" %}</div>
       {# End stats -#}
+
+      <div class="mx-auto mt-6 max-w-4xl rounded-full border border-white/70 bg-white/75 px-5 py-3 text-center text-sm/6 font-medium text-stone-600 shadow-sm backdrop-blur">
+        Started from small builder chats. Growing through trust, usefulness, and real relationships.
+      </div>
     </section>
   </div>
   {# End jumbotron -#}
@@ -60,6 +78,76 @@
   {# Main content -#}
   <div class="container mx-auto max-w-7xl px-4 py-14 sm:px-6 lg:px-8 lg:py-20">
     <div class="flex flex-col gap-y-14 lg:gap-y-20">
+      {# Audience -#}
+      <section class="rounded-[2.25rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+        <div class="grid gap-8 lg:grid-cols-[0.9fr_1.3fr] lg:items-start">
+          <div>
+            <div class="inline-flex rounded-full border border-primary-200 bg-primary-50/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
+              Built for
+            </div>
+            <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">For people building in public and in community</h2>
+            <p class="mt-3 text-sm/6 text-stone-600 sm:text-base/7">
+              You do not need a big title. Bring curiosity, follow-through, and something useful to
+              offer.
+            </p>
+          </div>
+          <div class="grid gap-3 sm:grid-cols-2">
+            <div class="rounded-3xl border border-stone-200 bg-stone-50/80 p-5">
+              <div class="font-black text-stone-950">AI founders</div>
+              <p class="mt-2 text-sm/6 text-stone-600">Testing ideas, finding users, and learning what works.</p>
+            </div>
+            <div class="rounded-3xl border border-stone-200 bg-stone-50/80 p-5">
+              <div class="font-black text-stone-950">Open-source maintainers</div>
+              <p class="mt-2 text-sm/6 text-stone-600">Looking for contributors, users, feedback, and friends.</p>
+            </div>
+            <div class="rounded-3xl border border-stone-200 bg-stone-50/80 p-5">
+              <div class="font-black text-stone-950">Product builders</div>
+              <p class="mt-2 text-sm/6 text-stone-600">Engineers, designers, operators, and curious makers.</p>
+            </div>
+            <div class="rounded-3xl border border-stone-200 bg-stone-50/80 p-5">
+              <div class="font-black text-stone-950">Community hosts</div>
+              <p class="mt-2 text-sm/6 text-stone-600">People who bring others together and make rooms warmer.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      {# End audience -#}
+
+      {# Why GOUP -#}
+      <section class="overflow-hidden rounded-[2.25rem] border border-amber-100 bg-stone-950 text-white shadow-xl shadow-amber-100/60">
+        <div class="grid gap-0 lg:grid-cols-[0.95fr_1.05fr]">
+          <div class="p-6 sm:p-8 lg:p-10">
+            <div class="inline-flex rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-200">
+              Why GOUP
+            </div>
+            <h2 class="mt-4 text-3xl font-black tracking-tight sm:text-4xl">Growth through useful progress</h2>
+            <p class="mt-4 text-base/7 text-stone-300">
+              The best parts of GOUP are simple: people answer, people introduce, people show up,
+              and people celebrate when someone moves forward.
+            </p>
+          </div>
+          <div class="grid gap-3 border-0 border-t border-white/10 bg-white/[0.03] p-6 sm:grid-cols-2 sm:p-8 lg:border-l lg:border-t-0 lg:p-10">
+            <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+              <div class="text-sm font-black text-white">Growth</div>
+              <p class="mt-2 text-sm/6 text-stone-300">Unlock potential.</p>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+              <div class="text-sm font-black text-white">Opportunity</div>
+              <p class="mt-2 text-sm/6 text-stone-300">Open doors.</p>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+              <div class="text-sm font-black text-white">Usefulness</div>
+              <p class="mt-2 text-sm/6 text-stone-300">Create value.</p>
+            </div>
+            <div class="rounded-3xl border border-white/10 bg-white/10 p-5">
+              <div class="text-sm font-black text-white">Progress</div>
+              <p class="mt-2 text-sm/6 text-stone-300">Move forward.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+      {# End why GOUP -#}
+
       {# Alliances list -#}
       <div>
         <div class="mb-6 flex flex-col gap-3 sm:mb-8 lg:mb-10">
@@ -69,10 +157,10 @@
           <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div>
               <h2 class="text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">
-                Built around active communities
+                Active communities, one alliance
               </h2>
               <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
-                GOUP brings chapters, members, events, jobs, and ecosystem projects into one place.
+                Chapters, members, events, jobs, and projects in one trusted network.
               </p>
             </div>
             <a href="{{ explore_groups }}"
@@ -126,11 +214,9 @@
             <div class="inline-flex rounded-full border border-primary-200 bg-primary-50/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
               Events
             </div>
-            <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">
-              Meet the people building next
-            </h2>
+            <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">Meet builders in motion</h2>
             <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
-              Join upcoming meetups, workshops, and community gatherings across GOUP chapters.
+              Join meetups, workshops, and gatherings across GOUP chapters.
             </p>
           </div>
           <a href="{{ explore_events }}"
@@ -165,9 +251,9 @@
               <div class="inline-flex rounded-full border border-primary-200 bg-primary-50/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
                 Groups
               </div>
-              <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">New chapters and circles</h2>
+              <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">Find your circle</h2>
               <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
-                Find a local chapter or interest group and start building with the community.
+                Join a local chapter or interest group and start building.
               </p>
             </div>
             <a href="{{ explore_groups }}"

--- a/ocg-server/templates/site/jobs/page.html
+++ b/ocg-server/templates/site/jobs/page.html
@@ -6,10 +6,10 @@
     <div class="relative max-w-3xl">
       <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Jobs</p>
       <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
-        Open roles for builders in the GOUP Alliance
+        Find your next builder role
       </h1>
       <p class="max-w-2xl text-base/7 text-stone-600">
-        Discover jobs from alliance members, partners, and open source teams.
+        Explore opportunities from GOUP members, partners, and open-source teams.
       </p>
     </div>
   </div>
@@ -19,6 +19,10 @@
   <div class="container mx-auto max-w-7xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
     <form method="get"
           action="/jobs"
+          hx-get="/jobs"
+          hx-target="body"
+          hx-push-url="true"
+          hx-trigger="input changed delay:300ms from:#jobs-query, input changed delay:300ms from:#jobs-location, change from:#jobs-remote"
           class="mb-8 grid gap-3 rounded-2xl border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_240px_auto_auto]">
       <label class="sr-only" for="jobs-query">Search jobs</label>
       <input id="jobs-query"
@@ -35,7 +39,8 @@
              placeholder="Location" />
 
       <label class="inline-flex items-center gap-2 rounded-lg border border-stone-200 px-3 text-sm text-stone-700">
-        <input type="checkbox"
+        <input id="jobs-remote"
+               type="checkbox"
                name="remote"
                value="true"
                {% if filters.remote == Some(true) %}checked{% endif %}

--- a/ocg-server/templates/site/landscape/page.html
+++ b/ocg-server/templates/site/landscape/page.html
@@ -6,7 +6,7 @@
     <div class="relative max-w-3xl">
       <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Landscape</p>
       <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
-        Startups and open projects in the GOUP Alliance
+        Startups and open projects
       </h1>
       <p class="max-w-2xl text-base/7 text-stone-600">
         Browse alliance startups, GitHub projects, tools, and community-built products.
@@ -19,6 +19,10 @@
   <div class="container mx-auto max-w-7xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
     <form method="get"
           action="/landscape"
+          hx-get="/landscape"
+          hx-target="body"
+          hx-push-url="true"
+          hx-trigger="input changed delay:300ms from:#landscape-query, input changed delay:300ms from:#landscape-category, change from:#landscape-kind"
           class="mb-8 grid gap-3 rounded-2xl border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_180px_220px_auto]">
       <label class="sr-only" for="landscape-query">Search landscape</label>
       <input id="landscape-query"

--- a/ocg-server/templates/site/stats/page.html
+++ b/ocg-server/templates/site/stats/page.html
@@ -15,105 +15,90 @@
           GOUP intelligence
         </div>
         <h1 class="text-balance text-4xl font-black tracking-tight text-stone-950 sm:text-5xl lg:text-6xl">
-          Alliance stats that show momentum
+          GOUP momentum at a glance
         </h1>
         <p class="mx-auto mt-5 max-w-2xl text-lg/8 text-stone-600">
-          Track community growth, event activity, job market signals, and the
-          startup and open-source landscape across GOUP.
+          A clean view of community growth, event activity, and ecosystem signals as they come online.
         </p>
       </div>
 
       {# Summary cards #}
-      <div class="mt-10 grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-6">
+      <div class="mt-10 grid grid-cols-2 gap-4 lg:grid-cols-4">
         <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
           <div class="flex items-center justify-between gap-3">
-            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Active members</div>
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Groups</div>
+            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
+              <div class="svg-icon size-5 icon-groups bg-primary-600"></div>
+            </div>
+          </div>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.groups.total|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Active communities</p>
+        </div>
+
+        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
+          <div class="flex items-center justify-between gap-3">
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Members</div>
             <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
               <div class="svg-icon size-5 icon-members bg-primary-600"></div>
             </div>
           </div>
-          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.active_members|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Last 90 days</p>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.members.total|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">People in network</p>
         </div>
 
         <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
           <div class="flex items-center justify-between gap-3">
-            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Upcoming</div>
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Events</div>
             <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
               <div class="svg-icon size-5 icon-events bg-primary-600"></div>
             </div>
           </div>
-          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.upcoming_events|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Published events</p>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.events.total|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Published gatherings</p>
         </div>
 
         <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
           <div class="flex items-center justify-between gap-3">
-            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Active jobs</div>
-            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
-              <div class="svg-icon size-5 icon-search bg-primary-600"></div>
-            </div>
-          </div>
-          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.active_jobs|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Not expired</p>
-        </div>
-
-        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
-          <div class="flex items-center justify-between gap-3">
-            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Job interest</div>
+            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Attendees</div>
             <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
               <div class="svg-icon size-5 icon-attendees bg-primary-600"></div>
             </div>
           </div>
-          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.job_interests|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Saved interest</p>
-        </div>
-
-        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
-          <div class="flex items-center justify-between gap-3">
-            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Landscape</div>
-            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
-              <div class="svg-icon size-5 icon-buildings bg-primary-600"></div>
-            </div>
-          </div>
-          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.landscape_entries|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Published entries</p>
-        </div>
-
-        <div class="rounded-3xl border border-white/70 bg-white/85 p-5 shadow-xl shadow-stone-200/60 backdrop-blur">
-          <div class="flex items-center justify-between gap-3">
-            <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Avg turnout</div>
-            <div class="flex size-10 items-center justify-center rounded-2xl bg-primary-50">
-              <div class="svg-icon size-5 icon-charts bg-primary-600"></div>
-            </div>
-          </div>
-          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.summary.avg_attendees_per_event }}</div>
-          <p class="mt-1 text-sm text-stone-500">Attendees/event</p>
+          <div class="mt-4 text-3xl font-black tracking-tight text-stone-950">{{ stats.attendees.total|num_fmt }}</div>
+          <p class="mt-1 text-sm text-stone-500">Confirmed attendance</p>
         </div>
       </div>
       {# End summary cards #}
 
       {# Engagement cards #}
-      <div id="engagement" class="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
-          <div class="text-sm font-bold text-stone-500">Repeat attendees</div>
-          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.repeat_attendees|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Joined 2+ events</p>
-        </div>
-        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
-          <div class="text-sm font-bold text-stone-500">LinkedIn-connected</div>
-          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.linkedin_connected_members|num_fmt }}</div>
-          <p class="mt-1 text-sm text-stone-500">Members with LinkedIn</p>
-        </div>
-        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
-          <div class="text-sm font-bold text-stone-500">Members / group</div>
-          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.members_per_group_avg }}</div>
-          <p class="mt-1 text-sm text-stone-500">Average group size</p>
-        </div>
-        <div class="rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
-          <div class="text-sm font-bold text-stone-500">Events / group</div>
-          <div class="mt-2 text-2xl font-black text-stone-950">{{ stats.engagement.events_per_group_avg }}</div>
-          <p class="mt-1 text-sm text-stone-500">Activity density</p>
+      <div id="engagement"
+           class="mt-4 rounded-[2rem] border border-stone-200 bg-white/85 p-5 shadow-sm backdrop-blur lg:p-6">
+        <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+          <div>
+            <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Signals</div>
+            <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950">Quality metrics coming online</h2>
+            <p class="mt-2 max-w-2xl text-sm/6 text-stone-500">
+              Engagement, jobs, and ecosystem signals become more useful as members interact with the platform.
+            </p>
+          </div>
+          <div class="grid gap-3 sm:grid-cols-2 lg:min-w-[28rem]">
+            <div class="rounded-2xl bg-stone-50 px-4 py-3">
+              <div class="text-sm font-bold text-stone-500">Repeat attendees</div>
+              {% if stats.engagement.repeat_attendees > 0 -%}
+                <div class="mt-1 text-2xl font-black text-stone-950">{{ stats.engagement.repeat_attendees|num_fmt }}</div>
+              {% else -%}
+                <div class="mt-1 text-sm font-bold text-stone-500">Building</div>
+              {% endif -%}
+            </div>
+            <div class="rounded-2xl bg-stone-50 px-4 py-3">
+              <div class="text-sm font-bold text-stone-500">Avg turnout</div>
+              {% if stats.summary.avg_attendees_per_event > 0.0 -%}
+                <div class="mt-1 text-2xl font-black text-stone-950">{{ stats.summary.avg_attendees_per_event }}</div>
+              {% else -%}
+                <div class="mt-1 text-sm font-bold text-stone-500">Building</div>
+              {% endif -%}
+            </div>
+          </div>
         </div>
       </div>
       {# End engagement cards #}
@@ -177,8 +162,8 @@
                 </div>
               </div>
               <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {{ stats_macro::analytics_chart(chart_id = "groups-running-chart", data = stats.groups.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-                {{ stats_macro::analytics_chart(chart_id = "groups-monthly-chart", data = stats.groups.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "groups-running-chart", data = stats.groups.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=groups") -}}
+                {{ stats_macro::analytics_chart(chart_id = "groups-monthly-chart", data = stats.groups.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=groups") -}}
               </div>
             </div>
             {# End groups section #}
@@ -196,8 +181,8 @@
                 </div>
               </div>
               <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {{ stats_macro::analytics_chart(chart_id = "members-running-chart", data = stats.members.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-                {{ stats_macro::analytics_chart(chart_id = "members-monthly-chart", data = stats.members.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "members-running-chart", data = stats.members.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=groups") -}}
+                {{ stats_macro::analytics_chart(chart_id = "members-monthly-chart", data = stats.members.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=groups") -}}
               </div>
             </div>
             {# End members section #}
@@ -215,46 +200,52 @@
                 </div>
               </div>
               <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {{ stats_macro::analytics_chart(chart_id = "events-running-chart", data = stats.events.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-                {{ stats_macro::analytics_chart(chart_id = "events-monthly-chart", data = stats.events.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "events-running-chart", data = stats.events.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=events") -}}
+                {{ stats_macro::analytics_chart(chart_id = "events-monthly-chart", data = stats.events.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=events") -}}
               </div>
             </div>
             {# End events section #}
 
             {# Event breakdowns #}
-            <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
-              <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
-                <h3 class="text-lg font-black text-stone-950">Events by type</h3>
-                <div class="mt-4 space-y-3">
-                  {% if stats.event_breakdown.by_kind.len() > 0 -%}
-                    {% for (label, count) in stats.event_breakdown.by_kind -%}
-                      <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
-                        <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
-                        <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
-                      </div>
-                    {% endfor -%}
-                  {% else -%}
-                    <div class="chart-empty-state h-24">No event type data yet</div>
-                  {% endif -%}
-                </div>
-              </div>
+            {% if stats.event_breakdown.by_kind.len() > 0 || stats.event_breakdown.by_category.len() > 0 -%}
+              <div class="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                {% if stats.event_breakdown.by_kind.len() > 0 -%}
+                  <a href="/explore?alliance[0]=goup&entity=events"
+                     class="block rounded-2xl border border-stone-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-primary-200 hover:shadow-xl hover:shadow-stone-200/60">
+                    <div class="flex items-center justify-between gap-3">
+                      <h3 class="text-lg font-black text-stone-950">Events by type</h3>
+                      <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-bold text-stone-500">View source</span>
+                    </div>
+                    <div class="mt-4 space-y-3">
+                      {% for (label, count) in stats.event_breakdown.by_kind -%}
+                        <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
+                          <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
+                          <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+                        </div>
+                      {% endfor -%}
+                    </div>
+                  </a>
+                {% endif -%}
 
-              <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
-                <h3 class="text-lg font-black text-stone-950">Events by category</h3>
-                <div class="mt-4 space-y-3">
-                  {% if stats.event_breakdown.by_category.len() > 0 -%}
-                    {% for (label, count) in stats.event_breakdown.by_category -%}
-                      <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
-                        <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
-                        <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
-                      </div>
-                    {% endfor -%}
-                  {% else -%}
-                    <div class="chart-empty-state h-24">No event category data yet</div>
-                  {% endif -%}
-                </div>
+                {% if stats.event_breakdown.by_category.len() > 0 -%}
+                  <a href="/explore?alliance[0]=goup&entity=events"
+                     class="block rounded-2xl border border-stone-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-primary-200 hover:shadow-xl hover:shadow-stone-200/60">
+                    <div class="flex items-center justify-between gap-3">
+                      <h3 class="text-lg font-black text-stone-950">Events by category</h3>
+                      <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-bold text-stone-500">View source</span>
+                    </div>
+                    <div class="mt-4 space-y-3">
+                      {% for (label, count) in stats.event_breakdown.by_category -%}
+                        <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
+                          <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
+                          <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+                        </div>
+                      {% endfor -%}
+                    </div>
+                  </a>
+                {% endif -%}
               </div>
-            </div>
+            {% endif -%}
             {# End event breakdowns #}
 
             {# Attendees section #}
@@ -270,8 +261,8 @@
                 </div>
               </div>
               <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {{ stats_macro::analytics_chart(chart_id = "attendees-running-chart", data = stats.attendees.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-                {{ stats_macro::analytics_chart(chart_id = "attendees-monthly-chart", data = stats.attendees.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
+                {{ stats_macro::analytics_chart(chart_id = "attendees-running-chart", data = stats.attendees.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=events") -}}
+                {{ stats_macro::analytics_chart(chart_id = "attendees-monthly-chart", data = stats.attendees.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/explore?alliance[0]=goup&entity=events") -}}
               </div>
             </div>
             {# End attendees section #}
@@ -293,28 +284,50 @@
               Total <span class="ms-2 font-black text-stone-950">{{ stats.jobs.total|num_fmt }}</span>
             </div>
           </div>
-          <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
-            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
-              <div class="text-sm text-stone-500">Active</div>
-              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.active|num_fmt }}</div>
+          {% if stats.jobs.total > 0 -%}
+            <div class="grid grid-cols-2 gap-3 lg:grid-cols-4">
+              <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                <div class="text-sm text-stone-500">Active</div>
+                <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.active|num_fmt }}</div>
+              </div>
+              {% if stats.jobs_overview.expired > 0 -%}
+                <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                  <div class="text-sm text-stone-500">Expired</div>
+                  <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.expired|num_fmt }}</div>
+                </div>
+              {% endif -%}
+              {% if stats.jobs_overview.interests > 0 -%}
+                <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                  <div class="text-sm text-stone-500">Saved interest</div>
+                  <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.interests|num_fmt }}</div>
+                </div>
+              {% endif -%}
+              {% if stats.jobs_overview.avg_interests_per_job > 0.0 -%}
+                <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
+                  <div class="text-sm text-stone-500">Interest / job</div>
+                  <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.avg_interests_per_job }}</div>
+                </div>
+              {% endif -%}
             </div>
-            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
-              <div class="text-sm text-stone-500">Expired</div>
-              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.expired|num_fmt }}</div>
+            <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+              {{ stats_macro::analytics_chart(chart_id = "jobs-running-chart", data = stats.jobs.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/jobs") -}}
+              {{ stats_macro::analytics_chart(chart_id = "jobs-monthly-chart", data = stats.jobs.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/jobs") -}}
             </div>
-            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
-              <div class="text-sm text-stone-500">Saved interest</div>
-              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.interests|num_fmt }}</div>
+          {% else -%}
+            <div class="rounded-3xl border border-dashed border-stone-300 bg-stone-50/80 p-8 text-center">
+              <div class="mx-auto flex size-12 items-center justify-center rounded-2xl bg-white shadow-sm">
+                <div class="svg-icon size-5 icon-search bg-primary-600"></div>
+              </div>
+              <h3 class="mt-4 text-xl font-black text-stone-950">Job signals will appear here</h3>
+              <p class="mx-auto mt-2 max-w-md text-sm/6 text-stone-500">
+                Once roles are posted, this section will show active opportunities and saved interest.
+              </p>
+              <a href="/jobs"
+                 class="mt-5 inline-flex rounded-full bg-stone-950 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-stone-800">
+                View jobs
+              </a>
             </div>
-            <div class="rounded-2xl border border-stone-200 bg-white px-4 py-3">
-              <div class="text-sm text-stone-500">Interest / job</div>
-              <div class="text-2xl font-black text-stone-950">{{ stats.jobs_overview.avg_interests_per_job }}</div>
-            </div>
-          </div>
-          <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-            {{ stats_macro::analytics_chart(chart_id = "jobs-running-chart", data = stats.jobs.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-            {{ stats_macro::analytics_chart(chart_id = "jobs-monthly-chart", data = stats.jobs.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
-          </div>
+          {% endif -%}
         </section>
         {# End jobs section #}
 
@@ -341,65 +354,79 @@
             </div>
           </div>
 
-          <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div>
-                <h3 class="text-lg font-black text-stone-950">Entries by category</h3>
-                <p class="mt-1 text-sm/6 text-stone-500">Published startups and open-source projects grouped by category.</p>
+          {% if stats.landscape_overview.entries > 0 -%}
+            <div class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+              <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <h3 class="text-lg font-black text-stone-950">Entries by category</h3>
+                  <p class="mt-1 text-sm/6 text-stone-500">Published startups and open-source projects grouped by category.</p>
+                </div>
+                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                  Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_overview.entries|num_fmt }}</span>
+                </div>
               </div>
-              <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
-                Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_overview.entries|num_fmt }}</span>
+              <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {% if stats.landscape_overview.by_category.len() > 0 -%}
+                  {% for (label, count) in stats.landscape_overview.by_category -%}
+                    <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
+                      <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
+                      <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+                    </div>
+                  {% endfor -%}
+                {% endif -%}
               </div>
             </div>
-            <div class="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {% if stats.landscape_overview.by_category.len() > 0 -%}
-                {% for (label, count) in stats.landscape_overview.by_category -%}
-                  <div class="flex items-center justify-between gap-4 rounded-xl bg-stone-50 px-4 py-3">
-                    <span class="text-sm font-semibold text-stone-700">{{ label }}</span>
-                    <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+
+            <div class="space-y-8">
+              <div class="space-y-5">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <h3 class="text-xl font-black text-stone-950">Startups</h3>
+                    <p class="mt-1 text-sm/6 text-stone-500">Founder-led companies in the GOUP ecosystem.</p>
                   </div>
-                {% endfor -%}
-              {% else -%}
-                <div class="chart-empty-state h-24 sm:col-span-2 lg:col-span-3">No landscape category data yet</div>
-              {% endif -%}
-            </div>
-          </div>
+                  <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                    <div class="svg-icon me-2 size-4 icon-buildings bg-primary-600"></div>
+                    Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_startups.total|num_fmt }}</span>
+                  </div>
+                </div>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                  {{ stats_macro::analytics_chart(chart_id = "landscape_startups-running-chart", data = stats.landscape_startups.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/landscape?kind=startup") -}}
+                  {{ stats_macro::analytics_chart(chart_id = "landscape_startups-monthly-chart", data = stats.landscape_startups.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/landscape?kind=startup") -}}
+                </div>
+              </div>
 
-          <div class="space-y-8">
-            <div class="space-y-5">
-              <div class="flex flex-wrap items-center justify-between gap-4">
-                <div>
-                  <h3 class="text-xl font-black text-stone-950">Startups</h3>
-                  <p class="mt-1 text-sm/6 text-stone-500">Founder-led companies in the GOUP ecosystem.</p>
+              <div class="space-y-5">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                  <div>
+                    <h3 class="text-xl font-black text-stone-950">Open Source</h3>
+                    <p class="mt-1 text-sm/6 text-stone-500">Community projects and GitHub repositories.</p>
+                  </div>
+                  <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
+                    <div class="svg-icon me-2 size-4 icon-github bg-primary-600"></div>
+                    Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_open_source.total|num_fmt }}</span>
+                  </div>
                 </div>
-                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
-                  <div class="svg-icon me-2 size-4 icon-buildings bg-primary-600"></div>
-                  Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_startups.total|num_fmt }}</span>
+                <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
+                  {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-running-chart", data = stats.landscape_open_source.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm", href = "/landscape?kind=github_project") -}}
+                  {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-monthly-chart", data = stats.landscape_open_source.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm", href = "/landscape?kind=github_project") -}}
                 </div>
-              </div>
-              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {{ stats_macro::analytics_chart(chart_id = "landscape_startups-running-chart", data = stats.landscape_startups.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-                {{ stats_macro::analytics_chart(chart_id = "landscape_startups-monthly-chart", data = stats.landscape_startups.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
               </div>
             </div>
-
-            <div class="space-y-5">
-              <div class="flex flex-wrap items-center justify-between gap-4">
-                <div>
-                  <h3 class="text-xl font-black text-stone-950">Open Source</h3>
-                  <p class="mt-1 text-sm/6 text-stone-500">Community projects and GitHub repositories.</p>
-                </div>
-                <div class="inline-flex items-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm text-stone-500">
-                  <div class="svg-icon me-2 size-4 icon-github bg-primary-600"></div>
-                  Total <span class="ms-2 font-black text-stone-950">{{ stats.landscape_open_source.total|num_fmt }}</span>
-                </div>
+          {% else -%}
+            <div class="rounded-3xl border border-dashed border-stone-300 bg-stone-50/80 p-8 text-center">
+              <div class="mx-auto flex size-12 items-center justify-center rounded-2xl bg-white shadow-sm">
+                <div class="svg-icon size-5 icon-buildings bg-primary-600"></div>
               </div>
-              <div class="grid grid-cols-1 gap-6 xl:grid-cols-2">
-                {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-running-chart", data = stats.landscape_open_source.running_total, class = "h-[320px]", min_points = 1, wrapper_class = "rounded-2xl shadow-sm") -}}
-                {{ stats_macro::analytics_chart(chart_id = "landscape_open_source-monthly-chart", data = stats.landscape_open_source.per_month, class = "h-[320px]", wrapper_class = "rounded-2xl shadow-sm") -}}
-              </div>
+              <h3 class="mt-4 text-xl font-black text-stone-950">Ecosystem metrics will appear here</h3>
+              <p class="mx-auto mt-2 max-w-md text-sm/6 text-stone-500">
+                Once startups and open-source projects are published, this page will show category and growth trends.
+              </p>
+              <a href="/landscape"
+                 class="mt-5 inline-flex rounded-full bg-stone-950 px-5 py-2.5 text-sm font-bold text-white transition hover:bg-stone-800">
+                View ecosystem
+              </a>
             </div>
-          </div>
+          {% endif -%}
         </section>
         {# End landscape section #}
       </div>

--- a/ocg-server/templates/site/wiki/page.html
+++ b/ocg-server/templates/site/wiki/page.html
@@ -1,41 +1,97 @@
 {% extends "common/base.html" -%}
 
 {% block jumbotron -%}
-  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
-    <div class="relative max-w-3xl">
-      <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Wiki</p>
-      <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
-        Tech reading brief for builders
-      </h1>
-      <p class="max-w-2xl text-base/7 text-stone-600">
-        A live summary of useful AI, open-source, and entrepreneurship links pulled from public tech feeds, research feeds, and founder-focused sources.
-      </p>
+  <div class="relative overflow-hidden">
+    <div class="absolute inset-x-0 top-0 h-72 bg-linear-to-b from-primary-50/90 to-transparent"></div>
+    <div class="absolute -top-40 right-1/2 h-[30rem] w-[30rem] translate-x-1/2 rounded-full bg-primary-300/20 blur-3xl">
     </div>
+    <div class="absolute top-20 right-0 hidden h-80 w-80 rounded-full bg-sky-300/20 blur-3xl lg:block"></div>
+
+    <section class="relative container mx-auto max-w-7xl px-4 pt-10 pb-12 sm:px-6 sm:pt-14 lg:px-8 lg:pt-20 lg:pb-16">
+      <div class="grid items-end gap-10 lg:grid-cols-[1.15fr_0.85fr]">
+        <div class="max-w-4xl">
+          <div class="mb-7 inline-flex items-center rounded-full border border-primary-200 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-primary-700 shadow-sm backdrop-blur-xl">
+            GOUP Wiki
+          </div>
+          <h1 class="text-balance text-5xl font-black tracking-[-0.055em] text-stone-950 sm:text-6xl lg:text-7xl">
+            A daily reading brief for builders
+          </h1>
+          <p class="mt-7 max-w-3xl text-lg/8 font-medium text-stone-600 lg:text-xl/9">
+            Fresh AI, open-source, and founder links collected from public research feeds, engineering blogs, and startup operators.
+          </p>
+        </div>
+
+        <div class="rounded-[2rem] border border-stone-200 bg-white/85 p-6 shadow-xl shadow-stone-200/60 backdrop-blur-xl">
+          <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">How to use it</div>
+          <div class="mt-5 grid gap-4">
+            <div class="rounded-2xl bg-stone-50 p-4">
+              <div class="text-sm font-black text-stone-950">Scan the newest links</div>
+              <p class="mt-1 text-sm/6 text-stone-600">Items show source dates when feeds provide them.</p>
+            </div>
+            <div class="rounded-2xl bg-stone-50 p-4">
+              <div class="text-sm font-black text-stone-950">Follow the source</div>
+              <p class="mt-1 text-sm/6 text-stone-600">Each card opens the original article, paper, or newsletter.</p>
+            </div>
+            <div class="rounded-2xl bg-stone-50 p-4">
+              <div class="text-sm font-black text-stone-950">Refresh cadence</div>
+              <p class="mt-1 text-sm/6 text-stone-600">The digest refreshes about every 15 minutes.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   </div>
 {% endblock jumbotron -%}
 
 {% block content -%}
-  <div class="container mx-auto max-w-7xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
+  <div class="container mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
+    <div class="mb-8 flex flex-col justify-between gap-4 rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:flex-row sm:items-center sm:p-6">
+      <div>
+        <div class="text-xs font-bold uppercase tracking-[0.22em] text-primary-700">Live digest</div>
+        <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950">Three streams worth keeping warm</h2>
+      </div>
+      <div class="inline-flex w-fit items-center rounded-full bg-stone-100 px-4 py-2 text-sm font-semibold text-stone-700">
+        AI · Open source · Entrepreneurship
+      </div>
+    </div>
+
+    <nav class="sticky top-20 z-20 mb-6 overflow-x-auto rounded-full border border-stone-200 bg-white/90 p-2 shadow-sm backdrop-blur-xl"
+         aria-label="Wiki sections">
+      <div class="flex min-w-max items-center gap-2">
+        <span class="px-3 text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Jump to</span>
+        {% for section in sections -%}
+          <a href="#{{ section.id }}"
+             class="inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-bold text-stone-700 transition hover:bg-primary-50 hover:text-primary-800">
+            {{ section.title }}
+            <span class="rounded-full bg-stone-100 px-2 py-0.5 text-xs text-stone-500">{{ section.links.len() }}</span>
+          </a>
+        {% endfor -%}
+      </div>
+    </nav>
+
     <div class="grid gap-6 lg:grid-cols-3">
       {% for section in sections -%}
         <section id="{{ section.id }}"
-                 class="flex min-h-full flex-col rounded-3xl border border-stone-200 bg-white p-5 shadow-sm">
-          <div class="mb-5">
-            <div class="mb-3 inline-flex items-center rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700">
-              Reading brief
+                 class="scroll-mt-32 flex min-h-full flex-col overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-xl hover:shadow-stone-200/60 lg:max-h-[78vh]">
+          <div class="border-b border-stone-100 bg-linear-to-br from-white via-primary-50/50 to-stone-50 p-6">
+            <div class="mb-5 flex items-center justify-between gap-3">
+              <div class="inline-flex items-center rounded-full border border-primary-100 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700 shadow-sm">
+                Reading brief
+              </div>
+              <div class="rounded-full bg-stone-950 px-3 py-1 text-xs font-bold text-white">0{{ loop.index }}</div>
             </div>
-            <h2 class="text-2xl font-semibold tracking-tight text-stone-950">{{ section.title }}</h2>
-            <p class="mt-3 text-sm/6 text-stone-600">{{ section.summary }}</p>
+            <h2 class="text-3xl font-black tracking-tight text-stone-950">{{ section.title }}</h2>
+            <p class="mt-3 text-sm/6 font-medium text-stone-600">{{ section.summary }}</p>
           </div>
 
           {% if section.links.is_empty() -%}
-            <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 p-5">
+            <div class="m-5 rounded-3xl border border-dashed border-stone-300 bg-stone-50 p-5">
               <p class="text-sm/6 text-stone-600">
                 Live feed items are still refreshing. Open the source feeds below for the latest links.
               </p>
               <div class="mt-4 grid gap-2">
                 {% for source in section.sources -%}
-                  <a class="rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm font-medium text-primary-700 transition hover:border-primary-200 hover:bg-primary-50"
+                  <a class="rounded-xl border border-stone-200 bg-white px-3 py-2 text-sm font-semibold text-primary-700 transition hover:border-primary-200 hover:bg-primary-50"
                      href="{{ source.url }}"
                      target="_blank"
                      rel="noopener noreferrer"
@@ -44,25 +100,78 @@
               </div>
             </div>
           {% else -%}
-            <div class="grid gap-3">
+            <div class="flex items-center justify-between px-5 pt-4 text-xs font-bold uppercase tracking-[0.16em] text-stone-500">
+              <span>Newest links</span>
+              <span>{{ section.links.len() }} items</span>
+            </div>
+            <div class="min-h-0 grow overflow-y-auto overscroll-contain p-5 pt-3 lg:pr-3">
               {% for link in section.links -%}
-                <a href="{{ link.url }}"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   hx-boost="false"
-                   class="group rounded-2xl border border-stone-200 bg-stone-50 p-4 transition hover:border-primary-200 hover:bg-primary-50/40">
-                  <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-primary-700">{{ link.source }}</div>
-                  <div class="text-sm/6 font-semibold text-stone-900 group-hover:text-primary-900">{{ link.title }}</div>
-                </a>
+                {% if loop.index <= 8 -%}
+                  <a href="{{ link.url }}"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     hx-boost="false"
+                     class="group mb-3 block rounded-3xl border border-stone-200 bg-stone-50 p-4 transition last:mb-0 hover:border-primary-200 hover:bg-white hover:shadow-lg hover:shadow-stone-200/50">
+                    <div class="mb-3 flex flex-wrap items-center gap-2 text-xs font-bold uppercase tracking-[0.14em]">
+                      <span class="rounded-full bg-primary-50 px-2.5 py-1 text-primary-700">{{ link.source }}</span>
+                      {% if let Some(published_at) = &link.published_at -%}
+                        <span class="rounded-full bg-white px-2.5 py-1 text-stone-500">{{ published_at.format("%b %d, %Y") }}</span>
+                      {% else -%}
+                        <span class="rounded-full bg-white px-2.5 py-1 text-stone-500">Latest</span>
+                      {% endif -%}
+                    </div>
+                    <div class="text-base/7 font-black tracking-tight text-stone-950 group-hover:text-primary-900">
+                      {{ link.title }}
+                    </div>
+                    <div class="mt-4 inline-flex items-center text-sm font-bold text-primary-700 opacity-0 transition group-hover:opacity-100">
+                      Read source <span class="ml-1" aria-hidden="true">&rarr;</span>
+                    </div>
+                  </a>
+                {% endif -%}
               {% endfor -%}
+              {% if section.links.len() > 8 -%}
+                <details class="group/read-more mt-2 rounded-3xl border border-dashed border-primary-200 bg-primary-50/40 p-3 open:border-stone-200 open:bg-white">
+                  <summary class="flex cursor-pointer list-none items-center justify-between rounded-2xl px-2 py-1 text-sm font-black text-primary-800 marker:hidden">
+                    Read more
+                    <span class="rounded-full bg-white px-3 py-1 text-xs font-bold text-stone-500 group-open/read-more:hidden">Show more links</span>
+                    <span class="hidden rounded-full bg-stone-100 px-3 py-1 text-xs font-bold text-stone-500 group-open/read-more:inline-flex">Collapse</span>
+                  </summary>
+                  <div class="mt-3">
+                    {% for link in section.links -%}
+                      {% if loop.index > 8 -%}
+                        <a href="{{ link.url }}"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           hx-boost="false"
+                           class="group mb-3 block rounded-3xl border border-stone-200 bg-stone-50 p-4 transition last:mb-0 hover:border-primary-200 hover:bg-white hover:shadow-lg hover:shadow-stone-200/50">
+                          <div class="mb-3 flex flex-wrap items-center gap-2 text-xs font-bold uppercase tracking-[0.14em]">
+                            <span class="rounded-full bg-primary-50 px-2.5 py-1 text-primary-700">{{ link.source }}</span>
+                            {% if let Some(published_at) = &link.published_at -%}
+                              <span class="rounded-full bg-white px-2.5 py-1 text-stone-500">{{ published_at.format("%b %d, %Y") }}</span>
+                            {% else -%}
+                              <span class="rounded-full bg-white px-2.5 py-1 text-stone-500">Latest</span>
+                            {% endif -%}
+                          </div>
+                          <div class="text-base/7 font-black tracking-tight text-stone-950 group-hover:text-primary-900">
+                            {{ link.title }}
+                          </div>
+                          <div class="mt-4 inline-flex items-center text-sm font-bold text-primary-700 opacity-0 transition group-hover:opacity-100">
+                            Read source <span class="ml-1" aria-hidden="true">&rarr;</span>
+                          </div>
+                        </a>
+                      {% endif -%}
+                    {% endfor -%}
+                  </div>
+                </details>
+              {% endif -%}
             </div>
           {% endif -%}
 
-          <div class="mt-auto pt-6">
-            <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-stone-500">Sources</div>
+          <div class="mt-auto border-t border-stone-100 bg-white p-5">
+            <div class="mb-3 text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Sources</div>
             <div class="flex flex-wrap gap-2">
               {% for source in section.sources -%}
-                <a class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-700 transition hover:bg-stone-200"
+                <a class="rounded-full bg-stone-100 px-3 py-1 text-xs font-semibold text-stone-700 transition hover:bg-stone-200"
                    href="{{ source.url }}"
                    target="_blank"
                    rel="noopener noreferrer"

--- a/tests/e2e/site/about/about.spec.js
+++ b/tests/e2e/site/about/about.spec.js
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+import { navigateToPath } from "../../utils.js";
+
+test.describe("about page", () => {
+  test("renders GOUP story, values, and joining model", async ({ page }) => {
+    // Load the public about page.
+    await navigateToPath(page, "/about");
+
+    // Verify the page explains GOUP and its story.
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "A referral-based alliance for people who build",
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("TechBrains 2025 speakers chat")).toBeVisible();
+    await expect(
+      page.getByText("As long as we continue giving more than we take"),
+    ).toBeVisible();
+
+    // Verify the values and joining model are visible.
+    await expect(page.getByText("Five non-negotiable values")).toBeVisible();
+    await expect(
+      page.getByText("Growth", { exact: true }).first(),
+    ).toBeVisible();
+    await expect(page.getByText("Startup founders")).toBeVisible();
+    await expect(page.getByText("Community leads")).toBeVisible();
+    await expect(page.getByText("GOUP grows through trust")).toBeVisible();
+    await expect(page.getByText("Good people refer good people")).toBeVisible();
+  });
+});

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -19,7 +19,7 @@ test.describe("site header", () => {
       navigation.getByRole("link", { name: "Home" }),
     ).toHaveAttribute("href", "/");
     await expect(
-      navigation.getByRole("link", { name: "Explore" }),
+      navigation.getByRole("link", { name: "Events & Groups" }),
     ).toHaveAttribute("href", /\/explore/);
     await expect(
       navigation.getByRole("link", { name: "Stats" }),
@@ -27,12 +27,28 @@ test.describe("site header", () => {
     await expect(
       navigation.getByRole("link", { name: "Jobs" }),
     ).toHaveAttribute("href", "/jobs");
+    await navigation.getByRole("link", { name: "Jobs" }).hover();
     await expect(
-      navigation.getByRole("link", { name: "Landscape" }),
+      navigation.getByRole("link", { name: /Browse roles/ }),
+    ).toHaveAttribute("href", "/jobs");
+    await expect(
+      navigation.getByRole("link", { name: /Remote roles/ }),
+    ).toHaveAttribute("href", "/jobs?remote=true");
+    await expect(
+      navigation.getByRole("link", { name: /Post a role/ }),
+    ).toHaveAttribute("href", "/log-in?next_url=/dashboard/jobs");
+    await expect(
+      navigation.getByRole("link", { name: "Ecosystem" }),
     ).toHaveAttribute("href", "/landscape");
     await expect(
-      navigation.getByRole("link", { name: "Wiki" }),
+      navigation.getByRole("link", { name: "Resources" }),
     ).toHaveAttribute("href", "/wiki");
+    await expect(
+      navigation.getByRole("link", { name: "Join GOUP" }),
+    ).toHaveAttribute("href", "/log-in/oidc/linkedin");
+    await expect(navigation.getByRole("link", { name: "About" })).toHaveCount(
+      0,
+    );
     await expect(navigation.getByRole("link", { name: "Docs" })).toHaveCount(0);
   });
 
@@ -55,6 +71,9 @@ test.describe("site header", () => {
     const userMenu = page.locator("#user-dropdown");
     await expect(userMenu).toBeVisible();
     await expect(
+      userMenu.getByRole("menuitem", { name: "Join GOUP" }),
+    ).toHaveAttribute("href", "/log-in/oidc/linkedin");
+    await expect(
       userMenu.getByRole("menuitem", { name: "Sign up" }),
     ).toHaveAttribute("href", "/sign-up");
     await expect(
@@ -64,10 +83,10 @@ test.describe("site header", () => {
       0,
     );
     await expect(
-      userMenu.getByRole("menuitem", { name: "Landscape" }),
+      userMenu.getByRole("menuitem", { name: "Ecosystem" }),
     ).toHaveCount(0);
-    await expect(userMenu.getByRole("menuitem", { name: "Wiki" })).toHaveCount(
-      0,
-    );
+    await expect(
+      userMenu.getByRole("menuitem", { name: "Resources" }),
+    ).toHaveCount(0);
   });
 });

--- a/tests/e2e/site/explore/events.spec.js
+++ b/tests/e2e/site/explore/events.spec.js
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   TEST_ALLIANCE_NAME,
+  TEST_ALLIANCE_TITLE,
   TEST_EVENT_NAMES,
   navigateToPath,
 } from "../../utils.js";
@@ -113,6 +114,12 @@ test.describe("site explore events page", () => {
     );
 
     // Verify events render before applying filters.
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: `${TEST_ALLIANCE_TITLE} Events`,
+      }),
+    ).toBeVisible();
     await expect(page.getByPlaceholder("Search events")).toBeVisible();
     await expect(
       page.getByText(TEST_EVENT_NAMES.alpha[0], { exact: true }),

--- a/tests/e2e/site/explore/groups.spec.js
+++ b/tests/e2e/site/explore/groups.spec.js
@@ -2,6 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   TEST_ALLIANCE_NAME,
+  TEST_ALLIANCE_TITLE,
   TEST_GROUP_NAMES,
   navigateToPath,
 } from "../../utils.js";
@@ -20,6 +21,12 @@ test.describe("site explore groups page", () => {
     const searchInput = page.getByPlaceholder("Search groups");
 
     // Verify groups render before applying search.
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: `${TEST_ALLIANCE_TITLE} Groups`,
+      }),
+    ).toBeVisible();
     await expect(searchInput).toBeVisible();
     await expect(
       page.getByText(TEST_GROUP_NAMES.alpha, { exact: true }),

--- a/tests/e2e/site/home/home.spec.js
+++ b/tests/e2e/site/home/home.spec.js
@@ -35,6 +35,9 @@ test.describe("site home page", () => {
 
       // Verify the jumbotron description and CTA destination.
       await expect(page.locator(".jumbotron-description")).toBeVisible();
+      await expect(page.locator(".jumbotron-description")).toContainText(
+        "honest introductions",
+      );
 
       // Find the primary Explore events control.
       const ctaLink = page
@@ -42,6 +45,62 @@ test.describe("site home page", () => {
         .first();
       await expect(ctaLink).toBeVisible();
       await expect(ctaLink).toHaveAttribute("href", /\/explore/);
+    });
+
+    test("hero explains concrete member benefits", async ({ page }) => {
+      // Verify the hero answers what members get from joining GOUP.
+      for (const benefit of [
+        "Ask for help",
+        "Share your work",
+        "Meet in real life",
+        "Grow together",
+      ]) {
+        await expect(
+          page.getByText(benefit, { exact: true }).first(),
+        ).toBeVisible();
+      }
+    });
+
+    test("audience section explains who GOUP is for", async ({ page }) => {
+      // Verify the audience section makes the target community explicit.
+      await expect(
+        page.getByRole("heading", {
+          name: "For people building in public and in community",
+        }),
+      ).toBeVisible();
+
+      for (const audience of [
+        "AI founders",
+        "Open-source maintainers",
+        "Product builders",
+        "Community hosts",
+      ]) {
+        await expect(
+          page.getByText(audience, { exact: true }).first(),
+        ).toBeVisible();
+      }
+    });
+
+    test("home page includes the merged about story", async ({ page }) => {
+      // Verify the About positioning now lives on the home page.
+      await expect(
+        page.getByRole("heading", {
+          name: "Growth through useful progress",
+        }),
+      ).toBeVisible();
+      await expect(page.getByText("Why GOUP", { exact: true })).toBeVisible();
+      await expect(
+        page.getByText("Growth", { exact: true }).first(),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Opportunity", { exact: true }).first(),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Usefulness", { exact: true }).first(),
+      ).toBeVisible();
+      await expect(
+        page.getByText("Progress", { exact: true }).first(),
+      ).toBeVisible();
     });
 
     test("stats strip displays all stat labels with values", async ({

--- a/tests/e2e/site/stats/stats.spec.js
+++ b/tests/e2e/site/stats/stats.spec.js
@@ -6,7 +6,6 @@ const expectChartSettled = async (page, selector) => {
   const chart = page.locator(selector);
 
   if ((await chart.count()) === 0) {
-    await expect(page.locator(".chart-empty-state").first()).toBeVisible();
     return;
   }
 
@@ -26,12 +25,12 @@ test.describe("site stats page", () => {
     await expect(
       mainContent.getByRole("heading", {
         level: 1,
-        name: "Alliance stats that show momentum",
+        name: "GOUP momentum at a glance",
       }),
     ).toBeVisible();
     await expect(
       mainContent.getByText(
-        "Track community growth, event activity, job market signals, and the startup and open-source landscape across GOUP.",
+        "A clean view of community growth, event activity, and ecosystem signals as they come online.",
         { exact: true },
       ),
     ).toBeVisible();

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -27,7 +27,7 @@ export const TEST_REGISTRATION_QUESTIONS_EVENT = {
 };
 export const TEST_SEARCH_QUERY = "Test";
 export const TEST_SITE_TITLE = "E2E Test Site";
-export const PUBLIC_HOME_TITLE = "GOUP Alliance";
+export const PUBLIC_HOME_TITLE = "Build with people who care";
 export const TEST_ALLIANCE_TITLE = "GOUP Alliance";
 export const TEST_ALLIANCE_TITLE_2 = "Developer Experience Alliance";
 


### PR DESCRIPTION
## Summary
- Warms up the public homepage, adds About content, and improves header/footer navigation.
- Polishes Jobs, Landscape, Stats, Wiki, and Explore pages with clearer copy and better scanning controls.
- Updates E2E coverage for the changed public page titles, navigation, and page content.

## Test plan
- `cargo check -p ocg-server`
- `uvx djlint ocg-server/templates/common/header.html --check`
- `uvx djlint ocg-server/templates/site/wiki/page.html --check`
- `npx prettier --check tests/e2e/site/common/header.spec.js`
- Verified affected pages locally on `http://127.0.0.1:9000/`


Made with [Cursor](https://cursor.com)