### PR TITLE
Add public site search and social links

### DIFF
--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -6,5 +6,6 @@ pub(crate) mod home;
 pub(crate) mod jobs;
 pub(crate) mod landscape;
 pub(crate) mod not_found;
+pub(crate) mod search;
 pub(crate) mod stats;
 pub(crate) mod wiki;

--- a/ocg-server/src/handlers/site/search.rs
+++ b/ocg-server/src/handlers/site/search.rs
@@ -1,0 +1,243 @@
+//! HTTP handlers for the public site search page.
+
+use std::collections::HashMap;
+
+use askama::Template;
+use axum::{
+    extract::{Query, State},
+    http::Uri,
+    response::{Html, IntoResponse},
+};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
+use tracing::{instrument, warn};
+
+use crate::{
+    db::DynDB,
+    handlers::error::HandlerError,
+    router::PUBLIC_SHARED_CACHE_HEADERS,
+    templates::{
+        PageId,
+        auth::User,
+        site::{
+            search::{self, SearchResult, SearchSection},
+            wiki::WikiSection,
+        },
+    },
+    types::{
+        jobs::JobsFilters,
+        landscape::LandscapeFilters,
+        search::{SearchEventsFilters, SearchGroupsFilters},
+    },
+};
+
+const SEARCH_LIMIT: usize = 4;
+
+/// Handler that renders the public search page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    State(db): State<DynDB>,
+    Query(query): Query<HashMap<String, String>>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let search_query = query
+        .get("query")
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default();
+    let encoded_query = utf8_percent_encode(&search_query, NON_ALPHANUMERIC).to_string();
+    let sections = if search_query.is_empty() {
+        Vec::new()
+    } else {
+        search_all(&db, &search_query, &encoded_query).await
+    };
+    let total = sections.iter().map(|section| section.total).sum();
+
+    let template = search::Page {
+        page_id: PageId::SiteSearch,
+        path: uri.path().to_string(),
+        site_settings: db.get_site_settings().await?,
+        user: User::default(),
+        query: search_query,
+        encoded_query,
+        sections,
+        total,
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)))
+}
+
+async fn search_all(db: &DynDB, query: &str, encoded_query: &str) -> Vec<SearchSection> {
+    let events_filters = SearchEventsFilters {
+        alliance: vec!["goup".to_string()],
+        ts_query: Some(query.to_string()),
+        limit: Some(SEARCH_LIMIT),
+        offset: Some(0),
+        ..SearchEventsFilters::default()
+    };
+    let groups_filters = SearchGroupsFilters {
+        alliance: vec!["goup".to_string()],
+        ts_query: Some(query.to_string()),
+        limit: Some(SEARCH_LIMIT),
+        offset: Some(0),
+        ..SearchGroupsFilters::default()
+    };
+    let jobs_filters = JobsFilters {
+        query: Some(query.to_string()),
+        limit: Some(SEARCH_LIMIT),
+        offset: Some(0),
+        ..JobsFilters::default()
+    };
+    let landscape_filters = LandscapeFilters {
+        query: Some(query.to_string()),
+        limit: Some(SEARCH_LIMIT),
+        offset: Some(0),
+        ..LandscapeFilters::default()
+    };
+
+    let (events, groups, jobs, landscape, wiki_sections) = tokio::join!(
+        db.search_events(&events_filters),
+        db.search_groups(&groups_filters),
+        db.search_jobs(&jobs_filters),
+        db.search_landscape_entries(&landscape_filters),
+        crate::handlers::site::wiki::load_wiki_sections(),
+    );
+    let events = events.unwrap_or_else(|error| {
+        warn!("site search events source failed: {error}");
+        Default::default()
+    });
+    let groups = groups.unwrap_or_else(|error| {
+        warn!("site search groups source failed: {error}");
+        Default::default()
+    });
+    let jobs = jobs.unwrap_or_else(|error| {
+        warn!("site search jobs source failed: {error}");
+        Default::default()
+    });
+    let landscape = landscape.unwrap_or_else(|error| {
+        warn!("site search landscape source failed: {error}");
+        Default::default()
+    });
+
+    let mut sections = Vec::new();
+    sections.push(SearchSection {
+        title: "Events".to_string(),
+        href: format!("/explore?alliance[0]=goup&entity=events&ts_query={encoded_query}"),
+        total: events.total,
+        results: events
+            .events
+            .into_iter()
+            .map(|event| {
+                let href = format!(
+                    "/{}/group/{}/event/{}",
+                    event.alliance_name,
+                    event.public_group_slug(),
+                    event.slug
+                );
+                let summary = event
+                    .description_short
+                    .clone()
+                    .or_else(|| event.starts_at.map(|date| date.format("%b %d, %Y").to_string()))
+                    .unwrap_or_else(|| event.group_name.clone());
+                SearchResult {
+                    title: event.name,
+                    href,
+                    summary,
+                    eyebrow: format!("{} · {}", event.group_name, event.group_category_name),
+                    hx_boost: true,
+                }
+            })
+            .collect(),
+    });
+    sections.push(SearchSection {
+        title: "Groups".to_string(),
+        href: format!("/explore?alliance[0]=goup&entity=groups&ts_query={encoded_query}"),
+        total: groups.total,
+        results: groups
+            .groups
+            .into_iter()
+            .map(|group| {
+                let href = format!("/{}/group/{}", group.alliance_name, group.public_slug());
+                let summary = group
+                    .description_short
+                    .clone()
+                    .or_else(|| group.location(80))
+                    .unwrap_or_else(|| group.category.name.clone());
+                SearchResult {
+                    title: group.name,
+                    href,
+                    summary,
+                    eyebrow: group.alliance_display_name,
+                    hx_boost: true,
+                }
+            })
+            .collect(),
+    });
+    sections.push(SearchSection {
+        title: "Jobs".to_string(),
+        href: format!("/jobs?query={encoded_query}"),
+        total: jobs.total,
+        results: jobs
+            .jobs
+            .into_iter()
+            .map(|job| SearchResult {
+                title: job.title,
+                href: format!("/jobs/{}", job.slug),
+                summary: job.summary,
+                eyebrow: job.company_name,
+                hx_boost: true,
+            })
+            .collect(),
+    });
+    sections.push(SearchSection {
+        title: "Ecosystem".to_string(),
+        href: format!("/landscape?query={encoded_query}"),
+        total: landscape.total,
+        results: landscape
+            .entries
+            .into_iter()
+            .map(|entry| SearchResult {
+                title: entry.name,
+                href: entry
+                    .website_url
+                    .or(entry.github_url)
+                    .unwrap_or_else(|| format!("/landscape?query={encoded_query}")),
+                summary: entry.summary,
+                eyebrow: entry.category.unwrap_or(entry.kind),
+                hx_boost: false,
+            })
+            .collect(),
+    });
+    sections.push(search_wiki(query, &wiki_sections));
+
+    sections
+}
+
+fn search_wiki(query: &str, wiki_sections: &[WikiSection]) -> SearchSection {
+    let terms = query.split_whitespace().map(str::to_lowercase).collect::<Vec<_>>();
+    let mut results = Vec::new();
+
+    for section in wiki_sections {
+        for link in &section.links {
+            let haystack =
+                format!("{} {} {}", link.title, link.source, section.title).to_lowercase();
+            if terms.iter().all(|term| haystack.contains(term)) {
+                results.push(SearchResult {
+                    title: link.title.clone(),
+                    href: link.url.clone(),
+                    summary: section.summary.clone(),
+                    eyebrow: format!("{} · {}", section.title, link.source),
+                    hx_boost: false,
+                });
+            }
+        }
+    }
+
+    let total = results.len();
+    results.truncate(SEARCH_LIMIT);
+
+    SearchSection {
+        title: "Reading Brief".to_string(),
+        href: "/wiki".to_string(),
+        total,
+        results,
+    }
+}

--- a/ocg-server/src/handlers/site/wiki.rs
+++ b/ocg-server/src/handlers/site/wiki.rs
@@ -189,7 +189,7 @@ pub(crate) async fn page(
 }
 
 #[cached(time = 900)]
-async fn load_wiki_sections() -> Vec<WikiSection> {
+pub(crate) async fn load_wiki_sections() -> Vec<WikiSection> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(8))
         .user_agent("GOUP Wiki/1.0")

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -292,6 +292,7 @@ pub(crate) async fn setup(
         .route("/jobs", get(site::jobs::page))
         .route("/jobs/{slug}", get(site::jobs::details))
         .route("/landscape", get(site::landscape::page))
+        .route("/search", get(site::search::page))
         .route("/stats", get(site::stats::page))
         .route("/wiki", get(site::wiki::page))
         // Alliance-prefixed public routes

--- a/ocg-server/src/templates.rs
+++ b/ocg-server/src/templates.rs
@@ -44,6 +44,7 @@ pub(crate) enum PageId {
     SiteJobs,
     SiteLandscape,
     SiteNotFound,
+    SiteSearch,
     SiteStats,
     SiteWiki,
     UserDashboard,

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -12,6 +12,8 @@ pub(crate) mod jobs;
 pub(crate) mod landscape;
 /// Templates for the not found page.
 pub(crate) mod not_found;
+/// Templates for the site search page.
+pub(crate) mod search;
 /// Templates for the stats page.
 pub(crate) mod stats;
 /// Templates for the wiki page.

--- a/ocg-server/src/templates/site/search.rs
+++ b/ocg-server/src/templates/site/search.rs
@@ -1,0 +1,59 @@
+//! Templates for the public site search page.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{PageId, auth::User, filters, helpers::user_initials},
+    types::site::SiteSettings,
+};
+
+/// Public site search page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/search/page.html")]
+pub(crate) struct Page {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// User-provided search query.
+    pub query: String,
+    /// URL-encoded search query for linking into searchable pages.
+    pub encoded_query: String,
+    /// Categorized search results.
+    pub sections: Vec<SearchSection>,
+    /// Total matches across all result sections.
+    pub total: usize,
+}
+
+/// Categorized search results.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct SearchSection {
+    /// Section label.
+    pub title: String,
+    /// Link to continue searching in the source page.
+    pub href: String,
+    /// Total matches reported by the source.
+    pub total: usize,
+    /// Result cards.
+    pub results: Vec<SearchResult>,
+}
+
+/// One search result card.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SearchResult {
+    /// Result title.
+    pub title: String,
+    /// Result URL.
+    pub href: String,
+    /// Short result context.
+    pub summary: String,
+    /// Small source/type label.
+    pub eyebrow: String,
+    /// Whether the link should be boosted by HTMX.
+    pub hx_boost: bool,
+}

--- a/ocg-server/static/js/alliance/explore/page-controls.js
+++ b/ocg-server/static/js/alliance/explore/page-controls.js
@@ -37,6 +37,9 @@ const EXPLORE_WIDGET_READY_KEY = "exploreWidgetReady";
 const CURRENT_MONTH_BUTTON_ID = "current-month-btn";
 const PREV_MONTH_BUTTON_ID = "prev-month-btn";
 const NEXT_MONTH_BUTTON_ID = "next-month-btn";
+const SEARCH_INPUT_DEBOUNCE_MS = 300;
+
+let searchInputTimer = null;
 
 /**
  * Gets the active desktop explore form id.
@@ -153,6 +156,30 @@ const handleExploreKeydown = (event) => {
   if (formId) {
     searchOnEnter(event, formId);
   }
+};
+
+/**
+ * Handles type-ahead search for explore text input.
+ * @param {InputEvent} event - Input event
+ */
+const handleExploreInput = (event) => {
+  if (!(event.target instanceof HTMLInputElement) || event.target.id !== SEARCH_INPUT_ID) {
+    return;
+  }
+
+  const formId = getExploreFormId();
+  if (!formId) {
+    return;
+  }
+
+  if (searchInputTimer) {
+    window.clearTimeout(searchInputTimer);
+  }
+
+  searchInputTimer = window.setTimeout(() => {
+    triggerChangeOnForm(formId);
+    searchInputTimer = null;
+  }, SEARCH_INPUT_DEBOUNCE_MS);
 };
 
 /**
@@ -287,6 +314,7 @@ const initializeExploreControls = (root = document) => {
 
   root.addEventListener("click", handleExploreClick);
   root.addEventListener("keydown", handleExploreKeydown);
+  root.addEventListener("input", handleExploreInput);
   root.addEventListener("change", handleExploreChange);
   root.addEventListener(FILTER_CHANGE_EVENT, handleFilterChange);
   root.addEventListener("htmx:afterSwap", handleExploreAfterSwap);

--- a/ocg-server/templates/common/footer.html
+++ b/ocg-server/templates/common/footer.html
@@ -30,8 +30,8 @@
         {% endif -%}
 
         <p class="mt-5 max-w-lg text-sm leading-6 text-stone-300 sm:text-base">
-          A home for builders, founders, and open source communities to discover groups,
-          host events, share opportunities, and grow the GOUP Alliance.
+          A warm builder community for people who dream, connect, achieve, and help each
+          other move forward.
         </p>
 
         <div class="mt-7 flex flex-col gap-3 sm:flex-row">
@@ -39,14 +39,23 @@
              hx-boost="true"
              hx-target="body"
              class="inline-flex items-center justify-center rounded-full bg-white px-5 py-3 text-sm font-bold text-stone-950 shadow-lg shadow-black/20 transition hover:-translate-y-0.5 hover:bg-primary-50 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
-            Explore events
+            Explore events & groups
           </a>
-          <a href="/dashboard/user"
-             hx-boost="true"
-             hx-target="body"
-             class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 py-3 text-sm font-bold text-white backdrop-blur transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
-            Open dashboard
-          </a>
+          {% if user.logged_in -%}
+            <a href="/dashboard/jobs"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 py-3 text-sm font-bold text-white backdrop-blur transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
+              Post a role
+            </a>
+          {% else -%}
+            <a href="/log-in?next_url=/dashboard/jobs"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-flex items-center justify-center rounded-full border border-white/15 bg-white/5 px-5 py-3 text-sm font-bold text-white backdrop-blur transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300">
+              Post a role
+            </a>
+          {% endif -%}
         </div>
       </div>
       {# End brand section -#}
@@ -54,25 +63,19 @@
       {# Navigation section -#}
       <div class="grid grid-cols-2 gap-8 sm:grid-cols-3">
         <div>
-          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Explore</h2>
+          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Community</h2>
           <ul class="mt-4 space-y-3 text-sm">
             <li>
               <a href="/explore?alliance[0]=goup&entity=events"
                  hx-boost="true"
                  hx-target="body"
-                 class="text-stone-300 transition hover:text-white">Events</a>
-            </li>
-            <li>
-              <a href="/explore?alliance[0]=goup&entity=groups"
-                 hx-boost="true"
-                 hx-target="body"
-                 class="text-stone-300 transition hover:text-white">Groups</a>
+                 class="text-stone-300 transition hover:text-white">Events & Groups</a>
             </li>
             <li>
               <a href="/landscape"
                  hx-boost="true"
                  hx-target="body"
-                 class="text-stone-300 transition hover:text-white">Landscape</a>
+                 class="text-stone-300 transition hover:text-white">Ecosystem</a>
             </li>
             <li>
               <a href="/stats"
@@ -80,38 +83,54 @@
                  hx-target="body"
                  class="text-stone-300 transition hover:text-white">Stats</a>
             </li>
-          </ul>
-        </div>
-
-        <div>
-          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Resources</h2>
-          <ul class="mt-4 space-y-3 text-sm">
             <li>
               <a href="/about"
                  hx-boost="true"
                  hx-target="body"
-                 class="text-stone-300 transition hover:text-white">About</a>
+                 class="text-stone-300 transition hover:text-white">About GOUP</a>
             </li>
+            <li>
+              <a href="/search"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Search GOUP</a>
+            </li>
+          </ul>
+        </div>
+
+        <div>
+          <h2 class="text-xs font-bold uppercase tracking-[0.22em] text-stone-400">Jobs</h2>
+          <ul class="mt-4 space-y-3 text-sm">
             <li>
               <a href="/jobs"
                  hx-boost="true"
                  hx-target="body"
-                 class="text-stone-300 transition hover:text-white">Jobs</a>
+                 class="text-stone-300 transition hover:text-white">Browse roles</a>
+            </li>
+            <li>
+              <a href="/jobs?remote=true"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="text-stone-300 transition hover:text-white">Remote roles</a>
+            </li>
+            <li>
+              {% if user.logged_in -%}
+                <a href="/dashboard/jobs"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="text-stone-300 transition hover:text-white">Post a role</a>
+              {% else -%}
+                <a href="/log-in?next_url=/dashboard/jobs"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="text-stone-300 transition hover:text-white">Post a role</a>
+              {% endif -%}
             </li>
             <li>
               <a href="/wiki"
                  hx-boost="true"
                  hx-target="body"
-                 class="text-stone-300 transition hover:text-white">Wiki</a>
-            </li>
-            <li>
-              <a href="https://github.com/sakomws/gitjobs"
-                 target="_blank"
-                 rel="noopener noreferrer"
-                 class="inline-flex items-center gap-1.5 text-stone-300 transition hover:text-white">
-                GitJobs
-                <span class="svg-icon size-3 icon-external-link bg-current"></span>
-              </a>
+                 class="text-stone-300 transition hover:text-white">Reading brief</a>
             </li>
           </ul>
         </div>
@@ -135,9 +154,25 @@
                aria-label="GOUP on LinkedIn">
               <div class="svg-icon size-5 bg-stone-200 icon-linkedin transition group-hover:bg-white"></div>
             </a>
+            <a href="https://www.instagram.com/goupaz/"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="group inline-flex size-11 items-center justify-center rounded-full border border-white/15 bg-white/5 transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300"
+               title="GOUP on Instagram"
+               aria-label="GOUP on Instagram">
+              <div class="svg-icon size-5 bg-stone-200 icon-instagram transition group-hover:bg-white"></div>
+            </a>
+            <a href="https://youtube.com/goupaz"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="group inline-flex size-11 items-center justify-center rounded-full border border-white/15 bg-white/5 transition hover:-translate-y-0.5 hover:border-white/30 hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary-300"
+               title="GOUP on YouTube"
+               aria-label="GOUP on YouTube">
+              <div class="svg-icon size-5 bg-stone-200 icon-youtube transition group-hover:bg-white"></div>
+            </a>
           </div>
           <p class="mt-4 text-sm leading-6 text-stone-400">
-            Open source, alliance-driven, and built for communities that ship.
+            Open source, community-led, and built for people who ship.
           </p>
         </div>
       </div>
@@ -157,7 +192,7 @@
         Powered by <a href="https://github.com/sakomws/goup.vc"
     class="font-bold text-white underline decoration-white/20 underline-offset-4 transition hover:decoration-white"
     target="_blank"
-    rel="noopener noreferrer">GOUP Alliance</a>.
+    rel="noopener noreferrer">GOUP</a>.
       </p>
     </div>
     {# End copyright section -#}

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -38,13 +38,6 @@
                 Browse roles
                 <span class="mt-1 block text-xs/5 font-medium text-stone-500">Open roles from GOUP members.</span>
               </a>
-              <a href="/jobs?remote=true"
-                 hx-boost="true"
-                 hx-target="body"
-                 class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-stone-900 transition hover:bg-stone-50">
-                Remote roles
-                <span class="mt-1 block text-xs/5 font-medium text-stone-500">Find jobs you can do from anywhere.</span>
-              </a>
               {% if user.logged_in -%}
                 <a href="/dashboard/jobs"
                    hx-boost="true"
@@ -74,7 +67,24 @@
 
     {# Desktop user menu -#}
     <div class="flex flex-1 justify-end items-center gap-3">
-      {% if page_id == PageId::SiteHome || page_id == PageId::SiteAbout || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
+      <form action="/search"
+            method="get"
+            role="search"
+            class="relative hidden xl:block">
+        <label class="sr-only" for="header-site-search">Search GOUP</label>
+        <input id="header-site-search"
+               name="query"
+               type="search"
+               autocomplete="off"
+               placeholder="Search GOUP"
+               class="w-44 rounded-full border border-stone-200 bg-white/80 px-4 py-2 pr-9 text-sm font-medium text-stone-900 placeholder-stone-400 shadow-sm transition focus:w-56 focus:border-primary-500 focus:bg-white focus:outline-none focus:ring-0" />
+        <button type="submit"
+                class="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-primary-600 transition hover:bg-primary-50"
+                aria-label="Search GOUP">
+          <span class="svg-icon block size-4 bg-current icon-magnifying-glass"></span>
+        </button>
+      </form>
+      {% if page_id == PageId::SiteHome || page_id == PageId::SiteAbout || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteSearch || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
         <div hx-get="/section/user-menu"
              hx-trigger="load"
              hx-target="this"
@@ -131,6 +141,20 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-home bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Home</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="/search"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-magnifying-glass bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Search GOUP</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/ocg-server/templates/site/search/page.html
+++ b/ocg-server/templates/site/search/page.html
@@ -1,0 +1,96 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <section class="container mx-auto max-w-5xl px-4 pt-10 pb-8 sm:px-6 lg:px-8 lg:pt-16">
+    <div class="rounded-[2.25rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+      <div class="inline-flex rounded-full border border-primary-200 bg-primary-50/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
+        Search GOUP
+      </div>
+      <h1 class="mt-4 text-4xl font-black tracking-tight text-stone-950 sm:text-5xl">Find what you need</h1>
+      <p class="mt-4 max-w-2xl text-base/7 text-stone-600">
+        Search events, groups, jobs, ecosystem entries, and the GOUP reading brief from one place.
+      </p>
+      <form action="/search"
+            method="get"
+            class="mt-7 flex flex-col gap-3 sm:flex-row">
+        <label class="sr-only" for="site-search-query">Search GOUP</label>
+        <input id="site-search-query"
+               name="query"
+               value="{{ query }}"
+               type="search"
+               autocomplete="off"
+               placeholder="Search events, jobs, groups, startups..."
+               class="min-w-0 flex-1 rounded-full border border-stone-200 bg-stone-50 px-5 py-3 text-base font-medium text-stone-900 placeholder-stone-400 transition focus:border-primary-500 focus:bg-white focus:outline-none focus:ring-0" />
+        <button type="submit"
+                class="inline-flex items-center justify-center rounded-full bg-stone-950 px-6 py-3 text-base font-bold text-white shadow-lg shadow-stone-950/15 transition hover:-translate-y-0.5 hover:bg-primary-700">
+          Search
+        </button>
+      </form>
+    </div>
+  </section>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-5xl px-4 pb-14 sm:px-6 lg:px-8 lg:pb-20">
+    {% if query.is_empty() -%}
+      <div class="rounded-[2rem] border border-dashed border-stone-300 bg-stone-50 p-6 text-center">
+        <h2 class="text-xl font-black text-stone-950">Start with a keyword</h2>
+        <p class="mt-2 text-sm/6 text-stone-600">Try a topic, city, company, role, technology, or community name.</p>
+      </div>
+    {% else -%}
+      <div class="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div class="text-xs font-bold uppercase tracking-[0.2em] text-primary-700">Search results</div>
+          <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950">Search for "{{ query }}"</h2>
+        </div>
+        <div class="text-sm font-medium text-stone-500">{{ total }} total matches</div>
+      </div>
+
+      {% if total == 0 -%}
+        <div class="rounded-[2rem] border border-dashed border-stone-300 bg-stone-50 p-6 text-center">
+          <h2 class="text-xl font-black text-stone-950">No matches yet</h2>
+          <p class="mt-2 text-sm/6 text-stone-600">Try a broader term, a city, a technology, or a company name.</p>
+        </div>
+      {% else -%}
+        <div class="grid gap-5">
+          {% for section in sections -%}
+            <section class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm">
+              <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h3 class="text-xl font-black text-stone-950">{{ section.title }}</h3>
+                  <p class="mt-1 text-sm font-medium text-stone-500">{{ section.total }} matches</p>
+                </div>
+                <a href="{{ section.href }}"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="text-sm font-bold text-primary-700 transition hover:text-primary-900">View all</a>
+              </div>
+
+              {% if section.results.is_empty() -%}
+                <div class="rounded-2xl border border-dashed border-stone-200 bg-stone-50 p-4 text-sm/6 text-stone-600">
+                  No results in {{ section.title|lower }} for this query.
+                </div>
+              {% else -%}
+                <div class="grid gap-3 sm:grid-cols-2">
+                  {% for result in section.results -%}
+                    <a href="{{ result.href }}"
+                       {% if result.hx_boost %}
+                         hx-boost="true" hx-target="body"
+                       {% else %}
+                         hx-boost="false" target="_blank" rel="noopener noreferrer"
+                       {% endif %}
+                       class="group rounded-3xl border border-stone-200 bg-stone-50 p-4 transition hover:border-primary-200 hover:bg-white hover:shadow-lg hover:shadow-stone-200/50">
+                      <div class="text-xs font-bold uppercase tracking-[0.14em] text-primary-700">{{ result.eyebrow }}</div>
+                      <div class="mt-2 text-base/7 font-black text-stone-950 group-hover:text-primary-900">{{ result.title }}</div>
+                      <p class="mt-2 line-clamp-3 text-sm/6 text-stone-600">{{ result.summary }}</p>
+                    </a>
+                  {% endfor -%}
+                </div>
+              {% endif -%}
+            </section>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    {% endif -%}
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/wiki/page.html
+++ b/ocg-server/templates/site/wiki/page.html
@@ -72,7 +72,7 @@
     <div class="grid gap-6 lg:grid-cols-3">
       {% for section in sections -%}
         <section id="{{ section.id }}"
-                 class="scroll-mt-32 flex min-h-full flex-col overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-xl hover:shadow-stone-200/60 lg:max-h-[78vh]">
+                 class="scroll-mt-32 flex min-h-full flex-col overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-xl hover:shadow-stone-200/60">
           <div class="border-b border-stone-100 bg-linear-to-br from-white via-primary-50/50 to-stone-50 p-6">
             <div class="mb-5 flex items-center justify-between gap-3">
               <div class="inline-flex items-center rounded-full border border-primary-100 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700 shadow-sm">
@@ -104,7 +104,7 @@
               <span>Newest links</span>
               <span>{{ section.links.len() }} items</span>
             </div>
-            <div class="min-h-0 grow overflow-y-auto overscroll-contain p-5 pt-3 lg:pr-3">
+            <div class="grow p-5 pt-3">
               {% for link in section.links -%}
                 {% if loop.index <= 8 -%}
                   <a href="{{ link.url }}"

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -33,7 +33,7 @@ test.describe("site header", () => {
     ).toHaveAttribute("href", "/jobs");
     await expect(
       navigation.getByRole("link", { name: /Remote roles/ }),
-    ).toHaveAttribute("href", "/jobs?remote=true");
+    ).toHaveCount(0);
     await expect(
       navigation.getByRole("link", { name: /Post a role/ }),
     ).toHaveAttribute("href", "/log-in?next_url=/dashboard/jobs");
@@ -46,6 +46,9 @@ test.describe("site header", () => {
     await expect(
       navigation.getByRole("link", { name: "Join GOUP" }),
     ).toHaveAttribute("href", "/log-in/oidc/linkedin");
+    await expect(
+      navigation.getByRole("search").getByPlaceholder("Search GOUP"),
+    ).toBeVisible();
     await expect(navigation.getByRole("link", { name: "About" })).toHaveCount(
       0,
     );

--- a/tests/e2e/site/explore/events.spec.js
+++ b/tests/e2e/site/explore/events.spec.js
@@ -182,7 +182,7 @@ test.describe("site explore events page", () => {
     const searchInput = page.getByPlaceholder("Search events");
     await expect(searchInput).toBeVisible();
 
-    // Submit the unmatched search query and wait for filtered results.
+    // Type the unmatched search query and wait for filtered results.
     await Promise.all([
       page.waitForResponse(
         (response) =>
@@ -191,9 +191,7 @@ test.describe("site explore events page", () => {
           response.url().includes("ts_query=No%20matching%20event") &&
           response.ok(),
       ),
-      searchInput
-        .fill("No matching event")
-        .then(() => searchInput.press("Enter")),
+      searchInput.fill("No matching event"),
     ]);
 
     // Find the filtered empty state.

--- a/tests/e2e/site/explore/groups.spec.js
+++ b/tests/e2e/site/explore/groups.spec.js
@@ -35,7 +35,7 @@ test.describe("site explore groups page", () => {
       page.getByText(TEST_GROUP_NAMES.gamma, { exact: true }),
     ).toBeVisible();
 
-    // Submit a group search and wait for the results to refresh.
+    // Type a group search and wait for the results to refresh.
     await Promise.all([
       page.waitForResponse(
         (response) =>
@@ -44,7 +44,7 @@ test.describe("site explore groups page", () => {
           response.url().includes("ts_query=Observability") &&
           response.ok(),
       ),
-      searchInput.fill("Observability").then(() => searchInput.press("Enter")),
+      searchInput.fill("Observability"),
     ]);
 
     // Verify the search narrows the list to the matching group.
@@ -86,7 +86,7 @@ test.describe("site explore groups page", () => {
     const searchInput = page.getByPlaceholder("Search groups");
     await expect(searchInput).toBeVisible();
 
-    // Submit the unmatched search query and wait for filtered results.
+    // Type the unmatched search query and wait for filtered results.
     await Promise.all([
       page.waitForResponse(
         (response) =>
@@ -95,9 +95,7 @@ test.describe("site explore groups page", () => {
           response.url().includes("ts_query=No%20matching%20group") &&
           response.ok(),
       ),
-      searchInput
-        .fill("No matching group")
-        .then(() => searchInput.press("Enter")),
+      searchInput.fill("No matching group"),
     ]);
 
     // Verify the filtered empty state explains the missing matches.

--- a/tests/e2e/site/search/search.spec.js
+++ b/tests/e2e/site/search/search.spec.js
@@ -1,0 +1,54 @@
+import { expect, test } from "@playwright/test";
+
+import { navigateToPath } from "../../utils.js";
+
+const getSearchSection = (page, title) =>
+  page
+    .getByRole("heading", { name: title, exact: true })
+    .locator("..")
+    .locator("..");
+
+test.describe("site search page", () => {
+  test("renders aggregated search sections with continue-search links", async ({
+    page,
+  }) => {
+    await navigateToPath(page, "/search?query=AI");
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Find what you need" }),
+    ).toBeVisible();
+    await expect(page.getByDisplayValue("AI")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Search for/ }),
+    ).toContainText('Search for "AI"');
+
+    await expect(page.getByText("total matches")).toBeVisible();
+
+    await expect(getSearchSection(page, "Events")).toBeVisible();
+    await expect(getSearchSection(page, "Groups")).toBeVisible();
+    await expect(getSearchSection(page, "Jobs")).toBeVisible();
+    await expect(getSearchSection(page, "Ecosystem")).toBeVisible();
+    await expect(getSearchSection(page, "Reading Brief")).toBeVisible();
+
+    await expect(
+      getSearchSection(page, "Events").getByRole("link", { name: "View all" }),
+    ).toHaveAttribute(
+      "href",
+      /\/explore\?alliance\[0\]=goup&entity=events&ts_query=AI/,
+    );
+    await expect(
+      getSearchSection(page, "Groups").getByRole("link", { name: "View all" }),
+    ).toHaveAttribute(
+      "href",
+      /\/explore\?alliance\[0\]=goup&entity=groups&ts_query=AI/,
+    );
+    await expect(
+      getSearchSection(page, "Jobs").getByRole("link", { name: "View all" }),
+    ).toHaveAttribute("href", "/jobs?query=AI");
+    await expect(
+      getSearchSection(page, "Ecosystem").getByRole("link", {
+        name: "View all",
+      }),
+    ).toHaveAttribute("href", "/landscape?query=AI");
+  });
+});


### PR DESCRIPTION
## Summary
- Add an aggregated public `/search` page for events, groups, jobs, ecosystem entries, and wiki links.
- Add header/footer search entry points, type-ahead explore search, and simplified Jobs dropdown.
- Refresh footer navigation and add Instagram/YouTube social links.

## Test plan
- `cargo check -p ocg-server`
- `cargo fmt --package ocg-server --check`
- `uvx djlint ocg-server/templates/site/search/page.html --check`
- `npx prettier --check tests/e2e/site/search/search.spec.js`
- Verified locally at `http://127.0.0.1:9000/search?query=AI`


Made with [Cursor](https://cursor.com)