### PR TITLE
Add dynamic homepage feed

### DIFF
--- a/ocg-server/src/handlers/site/home.rs
+++ b/ocg-server/src/handlers/site/home.rs
@@ -6,14 +6,18 @@ use axum::{
     http::Uri,
     response::{Html, IntoResponse},
 };
-use tracing::instrument;
+use tracing::{instrument, warn};
 
 use crate::{
     db::DynDB,
     handlers::error::HandlerError,
     router::PUBLIC_SHARED_CACHE_HEADERS,
     templates::{PageId, auth::User, site::home},
-    types::event::EventKind,
+    types::{
+        event::{EventKind, EventSummary},
+        jobs::JobsFilters,
+        landscape::LandscapeFilters,
+    },
 };
 
 #[cfg(test)]
@@ -41,8 +45,11 @@ pub(crate) async fn page(
         db.get_site_upcoming_events(vec![EventKind::InPerson, EventKind::Hybrid]),
         db.get_site_upcoming_events(vec![EventKind::Virtual, EventKind::Hybrid]),
     )?;
+    let latest_feed =
+        load_latest_feed(&db, &upcoming_in_person_events, &upcoming_virtual_events).await;
     let template = home::Page {
         alliances,
+        latest_feed,
         page_id: PageId::SiteHome,
         path: uri.path().to_string(),
         recently_added_groups: recently_added_groups
@@ -63,4 +70,115 @@ pub(crate) async fn page(
     };
 
     Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)))
+}
+
+async fn load_latest_feed(
+    db: &DynDB,
+    upcoming_in_person_events: &[EventSummary],
+    upcoming_virtual_events: &[EventSummary],
+) -> Vec<home::HomeFeedItem> {
+    let jobs_filters = JobsFilters {
+        limit: Some(2),
+        offset: Some(0),
+        ..JobsFilters::default()
+    };
+    let landscape_filters = LandscapeFilters {
+        limit: Some(2),
+        offset: Some(0),
+        ..LandscapeFilters::default()
+    };
+
+    let (jobs, landscape, wiki_sections) = tokio::join!(
+        db.search_jobs(&jobs_filters),
+        db.search_landscape_entries(&landscape_filters),
+        load_home_wiki_sections(),
+    );
+    let jobs = jobs.unwrap_or_else(|error| {
+        warn!("home latest feed jobs source failed: {error}");
+        Default::default()
+    });
+    let landscape = landscape.unwrap_or_else(|error| {
+        warn!("home latest feed landscape source failed: {error}");
+        Default::default()
+    });
+
+    let mut feed = Vec::new();
+    feed.extend(
+        upcoming_in_person_events
+            .iter()
+            .chain(upcoming_virtual_events.iter())
+            .map(event_feed_item)
+            .take(2),
+    );
+    feed.extend(jobs.jobs.into_iter().take(2).map(|job| home::HomeFeedItem {
+        label: "Job".to_string(),
+        title: job.title,
+        summary: job.summary,
+        href: format!("/jobs/{}", job.slug),
+        meta: job.company_name,
+        hx_boost: true,
+    }));
+    feed.extend(landscape.entries.into_iter().take(2).map(|entry| {
+        home::HomeFeedItem {
+            label: "Ecosystem".to_string(),
+            title: entry.name,
+            summary: entry.summary,
+            href: entry
+                .website_url
+                .or(entry.github_url)
+                .unwrap_or_else(|| "/landscape".to_string()),
+            meta: entry.category.unwrap_or(entry.kind),
+            hx_boost: false,
+        }
+    }));
+    feed.extend(
+        wiki_sections
+            .iter()
+            .flat_map(|section| {
+                section.links.iter().take(1).map(|link| home::HomeFeedItem {
+                    label: "Reading".to_string(),
+                    title: link.title.clone(),
+                    summary: section.summary.clone(),
+                    href: link.url.clone(),
+                    meta: format!("{} · {}", section.title, link.source),
+                    hx_boost: false,
+                })
+            })
+            .take(2),
+    );
+
+    feed.truncate(8);
+    feed
+}
+
+fn event_feed_item(event: &EventSummary) -> home::HomeFeedItem {
+    home::HomeFeedItem {
+        label: "Event".to_string(),
+        title: event.name.clone(),
+        summary: event
+            .description_short
+            .clone()
+            .unwrap_or_else(|| event.group_name.clone()),
+        href: format!(
+            "/{}/group/{}/event/{}",
+            event.alliance_name,
+            event.public_group_slug(),
+            event.slug
+        ),
+        meta: event
+            .starts_at
+            .map(|date| date.format("%b %d").to_string())
+            .unwrap_or_else(|| event.group_name.clone()),
+        hx_boost: true,
+    }
+}
+
+#[cfg(not(test))]
+async fn load_home_wiki_sections() -> Vec<crate::templates::site::wiki::WikiSection> {
+    crate::handlers::site::wiki::load_wiki_sections().await
+}
+
+#[cfg(test)]
+async fn load_home_wiki_sections() -> Vec<crate::templates::site::wiki::WikiSection> {
+    Vec::new()
 }

--- a/ocg-server/src/handlers/site/home/tests.rs
+++ b/ocg-server/src/handlers/site/home/tests.rs
@@ -57,6 +57,10 @@ async fn test_page_success() {
     db.expect_get_site_upcoming_events()
         .times(2)
         .returning(|_| Ok(vec![]));
+    db.expect_search_jobs().times(1).returning(|_| Ok(Default::default()));
+    db.expect_search_landscape_entries()
+        .times(1)
+        .returning(|_| Ok(Default::default()));
     db.expect_list_alliances().times(1).returning(|| Ok(vec![]));
 
     // Setup notifications manager mock

--- a/ocg-server/src/templates/site/home.rs
+++ b/ocg-server/src/templates/site/home.rs
@@ -27,6 +27,8 @@ pub struct Page {
     pub path: String,
     /// List of groups recently added across all alliances.
     pub recently_added_groups: Vec<GroupCard>,
+    /// Latest dynamic feed items across public GOUP content.
+    pub latest_feed: Vec<HomeFeedItem>,
     /// Global site settings.
     pub site_settings: SiteSettings,
     /// Site statistics.
@@ -53,4 +55,21 @@ pub struct EventCard {
 pub struct GroupCard {
     /// Group data.
     pub group: GroupSummary,
+}
+
+/// Latest homepage feed item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HomeFeedItem {
+    /// Source label, e.g. Event, Job, Ecosystem, Reading.
+    pub label: String,
+    /// Result title.
+    pub title: String,
+    /// Short result summary.
+    pub summary: String,
+    /// Link target.
+    pub href: String,
+    /// Small metadata line.
+    pub meta: String,
+    /// Whether the link should use HTMX page navigation.
+    pub hx_boost: bool,
 }

--- a/ocg-server/templates/site/home/page.html
+++ b/ocg-server/templates/site/home/page.html
@@ -148,6 +148,53 @@
       </section>
       {# End why GOUP -#}
 
+      {# Latest feed -#}
+      {% if latest_feed.len() > 0 -%}
+        <section class="rounded-[2.25rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+          <div class="mb-7 flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+            <div>
+              <div class="inline-flex rounded-full border border-primary-200 bg-primary-50/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-primary-700">
+                Latest from GOUP
+              </div>
+              <h2 class="mt-3 text-2xl font-black tracking-tight text-stone-950 lg:text-4xl">What is moving now</h2>
+              <p class="mt-2 max-w-2xl text-sm/6 text-stone-600 sm:text-base/7">
+                Fresh events, roles, ecosystem updates, and reading links from across the community.
+              </p>
+            </div>
+            <a href="/search"
+               hx-boost="true"
+               hx-target="body"
+               class="hidden rounded-full border border-stone-200 bg-white px-5 py-2.5 text-sm font-bold text-stone-900 shadow-sm transition hover:border-primary-200 hover:text-primary-700 md:inline-flex">
+              Search all
+            </a>
+          </div>
+          <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {% for item in latest_feed -%}
+              <a href="{{ item.href }}"
+                 {% if item.hx_boost %}
+                   hx-boost="true" hx-target="body"
+                 {% else %}
+                   hx-boost="false" target="_blank" rel="noopener noreferrer"
+                 {% endif %}
+                 class="group flex min-h-52 flex-col rounded-3xl border border-stone-200 bg-stone-50 p-5 transition hover:-translate-y-1 hover:border-primary-200 hover:bg-white hover:shadow-xl hover:shadow-stone-200/60">
+                <div class="flex items-center justify-between gap-3">
+                  <span class="rounded-full bg-primary-50 px-3 py-1 text-xs font-black uppercase tracking-[0.14em] text-primary-700">{{ item.label }}</span>
+                  <span class="truncate text-xs font-bold text-stone-500">{{ item.meta }}</span>
+                </div>
+                <div class="mt-4 text-lg/7 font-black tracking-tight text-stone-950 group-hover:text-primary-900">
+                  {{ item.title }}
+                </div>
+                <p class="mt-3 line-clamp-3 text-sm/6 text-stone-600">{{ item.summary }}</p>
+                <div class="mt-auto pt-5 text-sm font-bold text-primary-700">
+                  Open <span aria-hidden="true">&rarr;</span>
+                </div>
+              </a>
+            {% endfor -%}
+          </div>
+        </section>
+      {% endif -%}
+      {# End latest feed -#}
+
       {# Alliances list -#}
       <div>
         <div class="mb-6 flex flex-col gap-3 sm:mb-8 lg:mb-10">

--- a/tests/e2e/site/home/home.spec.js
+++ b/tests/e2e/site/home/home.spec.js
@@ -103,6 +103,19 @@ test.describe("site home page", () => {
       ).toBeVisible();
     });
 
+    test("latest feed makes the homepage feel live", async ({ page }) => {
+      // Verify the homepage surfaces dynamic content from across GOUP.
+      await expect(
+        page.getByText("Latest from GOUP", { exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "What is moving now" }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("link", { name: /Search all/ }),
+      ).toHaveAttribute("href", "/search");
+    });
+
     test("stats strip displays all stat labels with values", async ({
       page,
     }) => {


### PR DESCRIPTION
## Summary
- Add a dynamic `Latest from GOUP` section to the homepage.
- Populate it from upcoming events, jobs, ecosystem entries, and wiki reading links.
- Keep the feed resilient when optional sources are unavailable.

## Test plan
- `cargo check -p ocg-server`
- `cargo fmt --package ocg-server --check`
- `uvx djlint ocg-server/templates/site/home/page.html --check`
- `npx prettier --check tests/e2e/site/home/home.spec.js`
- `cargo test -p ocg-server handlers::site::home::tests`
- Verified locally at `http://127.0.0.1:9000/`


Made with [Cursor](https://cursor.com)