### PR TITLE
Make global search instant

### DIFF
--- a/ocg-server/templates/site/search/page.html
+++ b/ocg-server/templates/site/search/page.html
@@ -12,6 +12,11 @@
       </p>
       <form action="/search"
             method="get"
+            hx-get="/search"
+            hx-target="#site-search-results"
+            hx-select="#site-search-results"
+            hx-push-url="true"
+            hx-trigger="input changed delay:300ms from:#site-search-query"
             class="mt-7 flex flex-col gap-3 sm:flex-row">
         <label class="sr-only" for="site-search-query">Search GOUP</label>
         <input id="site-search-query"
@@ -32,65 +37,67 @@
 
 {% block content -%}
   <div class="container mx-auto max-w-5xl px-4 pb-14 sm:px-6 lg:px-8 lg:pb-20">
-    {% if query.is_empty() -%}
-      <div class="rounded-[2rem] border border-dashed border-stone-300 bg-stone-50 p-6 text-center">
-        <h2 class="text-xl font-black text-stone-950">Start with a keyword</h2>
-        <p class="mt-2 text-sm/6 text-stone-600">Try a topic, city, company, role, technology, or community name.</p>
-      </div>
-    {% else -%}
-      <div class="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <div class="text-xs font-bold uppercase tracking-[0.2em] text-primary-700">Search results</div>
-          <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950">Search for "{{ query }}"</h2>
-        </div>
-        <div class="text-sm font-medium text-stone-500">{{ total }} total matches</div>
-      </div>
-
-      {% if total == 0 -%}
+    <div id="site-search-results">
+      {% if query.is_empty() -%}
         <div class="rounded-[2rem] border border-dashed border-stone-300 bg-stone-50 p-6 text-center">
-          <h2 class="text-xl font-black text-stone-950">No matches yet</h2>
-          <p class="mt-2 text-sm/6 text-stone-600">Try a broader term, a city, a technology, or a company name.</p>
+          <h2 class="text-xl font-black text-stone-950">Start with a keyword</h2>
+          <p class="mt-2 text-sm/6 text-stone-600">Try a topic, city, company, role, technology, or community name.</p>
         </div>
       {% else -%}
-        <div class="grid gap-5">
-          {% for section in sections -%}
-            <section class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm">
-              <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <h3 class="text-xl font-black text-stone-950">{{ section.title }}</h3>
-                  <p class="mt-1 text-sm font-medium text-stone-500">{{ section.total }} matches</p>
-                </div>
-                <a href="{{ section.href }}"
-                   hx-boost="true"
-                   hx-target="body"
-                   class="text-sm font-bold text-primary-700 transition hover:text-primary-900">View all</a>
-              </div>
-
-              {% if section.results.is_empty() -%}
-                <div class="rounded-2xl border border-dashed border-stone-200 bg-stone-50 p-4 text-sm/6 text-stone-600">
-                  No results in {{ section.title|lower }} for this query.
-                </div>
-              {% else -%}
-                <div class="grid gap-3 sm:grid-cols-2">
-                  {% for result in section.results -%}
-                    <a href="{{ result.href }}"
-                       {% if result.hx_boost %}
-                         hx-boost="true" hx-target="body"
-                       {% else %}
-                         hx-boost="false" target="_blank" rel="noopener noreferrer"
-                       {% endif %}
-                       class="group rounded-3xl border border-stone-200 bg-stone-50 p-4 transition hover:border-primary-200 hover:bg-white hover:shadow-lg hover:shadow-stone-200/50">
-                      <div class="text-xs font-bold uppercase tracking-[0.14em] text-primary-700">{{ result.eyebrow }}</div>
-                      <div class="mt-2 text-base/7 font-black text-stone-950 group-hover:text-primary-900">{{ result.title }}</div>
-                      <p class="mt-2 line-clamp-3 text-sm/6 text-stone-600">{{ result.summary }}</p>
-                    </a>
-                  {% endfor -%}
-                </div>
-              {% endif -%}
-            </section>
-          {% endfor -%}
+        <div class="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div class="text-xs font-bold uppercase tracking-[0.2em] text-primary-700">Search results</div>
+            <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950">Search for "{{ query }}"</h2>
+          </div>
+          <div class="text-sm font-medium text-stone-500">{{ total }} total matches</div>
         </div>
+
+        {% if total == 0 -%}
+          <div class="rounded-[2rem] border border-dashed border-stone-300 bg-stone-50 p-6 text-center">
+            <h2 class="text-xl font-black text-stone-950">No matches yet</h2>
+            <p class="mt-2 text-sm/6 text-stone-600">Try a broader term, a city, a technology, or a company name.</p>
+          </div>
+        {% else -%}
+          <div class="grid gap-5">
+            {% for section in sections -%}
+              <section class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm">
+                <div class="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div>
+                    <h3 class="text-xl font-black text-stone-950">{{ section.title }}</h3>
+                    <p class="mt-1 text-sm font-medium text-stone-500">{{ section.total }} matches</p>
+                  </div>
+                  <a href="{{ section.href }}"
+                     hx-boost="true"
+                     hx-target="body"
+                     class="text-sm font-bold text-primary-700 transition hover:text-primary-900">View all</a>
+                </div>
+
+                {% if section.results.is_empty() -%}
+                  <div class="rounded-2xl border border-dashed border-stone-200 bg-stone-50 p-4 text-sm/6 text-stone-600">
+                    No results in {{ section.title|lower }} for this query.
+                  </div>
+                {% else -%}
+                  <div class="grid gap-3 sm:grid-cols-2">
+                    {% for result in section.results -%}
+                      <a href="{{ result.href }}"
+                         {% if result.hx_boost %}
+                           hx-boost="true" hx-target="body"
+                         {% else %}
+                           hx-boost="false" target="_blank" rel="noopener noreferrer"
+                         {% endif %}
+                         class="group rounded-3xl border border-stone-200 bg-stone-50 p-4 transition hover:border-primary-200 hover:bg-white hover:shadow-lg hover:shadow-stone-200/50">
+                        <div class="text-xs font-bold uppercase tracking-[0.14em] text-primary-700">{{ result.eyebrow }}</div>
+                        <div class="mt-2 text-base/7 font-black text-stone-950 group-hover:text-primary-900">{{ result.title }}</div>
+                        <p class="mt-2 line-clamp-3 text-sm/6 text-stone-600">{{ result.summary }}</p>
+                      </a>
+                    {% endfor -%}
+                  </div>
+                {% endif -%}
+              </section>
+            {% endfor -%}
+          </div>
+        {% endif -%}
       {% endif -%}
-    {% endif -%}
+    </div>
   </div>
 {% endblock content -%}

--- a/tests/e2e/site/search/search.spec.js
+++ b/tests/e2e/site/search/search.spec.js
@@ -17,7 +17,14 @@ test.describe("site search page", () => {
     await expect(
       page.getByRole("heading", { level: 1, name: "Find what you need" }),
     ).toBeVisible();
-    await expect(page.getByDisplayValue("AI")).toBeVisible();
+    const searchInput = page.getByDisplayValue("AI");
+    await expect(searchInput).toBeVisible();
+    const searchForm = page.locator('form[action="/search"]').first();
+    await expect(searchForm).toHaveAttribute("hx-get", "/search");
+    await expect(searchForm).toHaveAttribute(
+      "hx-trigger",
+      /input changed delay:300ms/,
+    );
     await expect(
       page.getByRole("heading", { name: /Search for/ }),
     ).toContainText('Search for "AI"');


### PR DESCRIPTION
## Summary
- Add HTMX type-ahead behavior to the global `/search` form.
- Swap only the results container and push the query URL for shareable searches.
- Update E2E coverage for the instant search attributes.

## Test plan
- `cargo check -p ocg-server`
- `uvx djlint ocg-server/templates/site/search/page.html --check`
- `npx prettier --check tests/e2e/site/search/search.spec.js`
- Verified locally at `http://127.0.0.1:9000/search?query=AI`


Made with [Cursor](https://cursor.com)