### PR TITLE
Add full API support

### DIFF
--- a/database/migrations/schema/0010_api_token.sql
+++ b/database/migrations/schema/0010_api_token.sql
@@ -1,0 +1,18 @@
+create table if not exists api_token (
+    api_token_id uuid primary key default uuid_generate_v4(),
+    user_id uuid not null references "user" (user_id) on delete cascade,
+    token_hash text not null unique,
+    token_prefix text not null,
+    name text,
+    scopes text[] not null default array['read:public']::text[],
+    created_at timestamptz not null default now(),
+    last_used_at timestamptz,
+    revoked_at timestamptz
+);
+
+create index if not exists api_token_user_id_idx
+on api_token (user_id);
+
+create index if not exists api_token_active_hash_idx
+on api_token (token_hash)
+where revoked_at is null;

--- a/database/tests/schema/02_columns.sql
+++ b/database/tests/schema/02_columns.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(70);
+select plan(71);
 
 -- ============================================================================
 -- TESTS
@@ -40,6 +40,19 @@ select columns_are('auth_session', array[
     'auth_session_id',
     'data',
     'expires_at'
+]);
+
+-- Test: api_token columns should match expected
+select columns_are('api_token', array[
+    'api_token_id',
+    'created_at',
+    'last_used_at',
+    'name',
+    'revoked_at',
+    'scopes',
+    'token_hash',
+    'token_prefix',
+    'user_id'
 ]);
 
 -- Test: cfs_submission columns should match expected

--- a/database/tests/schema/03_keys.sql
+++ b/database/tests/schema/03_keys.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(153);
+select plan(155);
 
 -- ============================================================================
 -- TESTS
@@ -25,6 +25,7 @@ select has_pk('alliance_role_group_permission');
 select has_pk('alliance_site_layout');
 select has_pk('alliance_team');
 select hasnt_pk('alliance_views');
+select has_pk('api_token');
 select has_pk('custom_notification');
 select has_pk('email_verification_code');
 select has_pk('event');
@@ -84,6 +85,7 @@ select col_is_fk('alliance_role_group_permission', 'group_permission_id', 'group
 select col_is_fk('alliance_team', 'alliance_id', 'alliance');
 select col_is_fk('alliance_team', 'user_id', 'user');
 select col_is_fk('alliance_views', 'alliance_id', 'alliance');
+select col_is_fk('api_token', 'user_id', 'user');
 select col_is_fk('custom_notification', 'created_by', 'user');
 select col_is_fk('custom_notification', 'event_id', 'event');
 select col_is_fk('custom_notification', 'group_id', 'group');

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,325 @@
+openapi: 3.1.0
+info:
+  title: GOUP API
+  version: 1.0.0
+  description: Versioned JSON API for public GOUP data, authenticated user actions, and scoped admin mutations.
+servers:
+  - url: /api/v1
+security:
+  - bearerAuth: []
+paths:
+  /health:
+    get:
+      security: []
+      summary: Health check
+      responses:
+        "200":
+          description: API is available.
+  /meta/filters:
+    get:
+      security: []
+      summary: List public filter options.
+      parameters:
+        - $ref: "#/components/parameters/AllianceQuery"
+        - name: entity
+          in: query
+          schema:
+            type: string
+            enum: [events, groups]
+      responses:
+        "200":
+          description: Filter options envelope.
+  /alliances:
+    get:
+      security: []
+      summary: List active alliances.
+      responses:
+        "200":
+          description: Alliance summaries.
+    post:
+      summary: Create an alliance.
+      description: Requires `admin:platform` and a platform-admin user.
+      responses:
+        "200":
+          description: Created alliance id.
+  /alliances/{alliance}:
+    get:
+      security: []
+      summary: Get an alliance.
+      parameters:
+        - $ref: "#/components/parameters/AlliancePath"
+      responses:
+        "200":
+          description: Full alliance.
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      summary: Update an alliance.
+      description: Requires `admin:alliance`.
+      parameters:
+        - $ref: "#/components/parameters/AlliancePath"
+      responses:
+        "200":
+          description: Updated.
+  /alliances/{alliance}/groups:
+    get:
+      security: []
+      summary: List/search groups in an alliance.
+      parameters:
+        - $ref: "#/components/parameters/AlliancePath"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Group summaries with total metadata.
+    post:
+      summary: Create a group.
+      description: Requires `admin:alliance`.
+      parameters:
+        - $ref: "#/components/parameters/AlliancePath"
+      responses:
+        "200":
+          description: Created group id.
+  /alliances/{alliance}/events:
+    get:
+      security: []
+      summary: List/search events in an alliance.
+      parameters:
+        - $ref: "#/components/parameters/AlliancePath"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Offset"
+      responses:
+        "200":
+          description: Event summaries with total metadata.
+  /groups/{alliance}/{group_slug}:
+    get:
+      security: []
+      summary: Get a group by slug.
+      parameters:
+        - $ref: "#/components/parameters/AlliancePath"
+        - name: group_slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Full group.
+  /groups/{alliance}/{group_id}/join:
+    post:
+      summary: Join a group.
+      description: Requires `write:events`.
+      responses:
+        "200":
+          description: Joined.
+    delete:
+      summary: Leave a group.
+      description: Requires `write:events`.
+      responses:
+        "200":
+          description: Left.
+  /events/{alliance}/{group_slug}/{event_slug}:
+    get:
+      security: []
+      summary: Get an event by slug.
+      responses:
+        "200":
+          description: Full event.
+  /events/{alliance}/{event_id}/attendance:
+    get:
+      summary: Get current user's event attendance.
+      description: Requires `write:events`.
+      responses:
+        "200":
+          description: Attendance details.
+  /events/{alliance}/{event_id}/attend:
+    post:
+      summary: Attend an event.
+      description: Requires `write:events`.
+      responses:
+        "200":
+          description: Attendance status.
+    delete:
+      summary: Leave an event.
+      description: Requires `write:events`.
+      responses:
+        "200":
+          description: Leave outcome.
+  /jobs:
+    get:
+      security: []
+      summary: List/search jobs.
+      responses:
+        "200":
+          description: Job summaries with total metadata.
+    post:
+      summary: Create a job.
+      description: Requires `write:jobs`.
+      responses:
+        "200":
+          description: Created job id.
+  /jobs/{slug}:
+    get:
+      security: []
+      summary: Get a job by slug.
+      responses:
+        "200":
+          description: Full job.
+  /jobs/{job_id}:
+    patch:
+      summary: Update a job.
+      description: Requires `write:jobs`.
+      responses:
+        "200":
+          description: Updated.
+    delete:
+      summary: Delete a job.
+      description: Requires `write:jobs`.
+      responses:
+        "200":
+          description: Deleted.
+  /jobs/{job_id}/applications:
+    post:
+      summary: Apply to a job.
+      description: Requires `write:jobs`.
+      responses:
+        "200":
+          description: Application saved.
+  /landscape:
+    get:
+      security: []
+      summary: List/search ecosystem entries.
+      responses:
+        "200":
+          description: Landscape entries with total metadata.
+    post:
+      summary: Create an ecosystem entry.
+      description: Requires `admin:alliance`; body includes `alliance` plus the landscape entry fields.
+      responses:
+        "200":
+          description: Created entry id.
+  /landscape/{entry_id}:
+    patch:
+      summary: Update an ecosystem entry.
+      description: Requires `admin:alliance`; body includes `alliance` plus the landscape entry fields.
+      responses:
+        "200":
+          description: Updated.
+  /search:
+    get:
+      security: []
+      summary: Search events, groups, jobs, and ecosystem entries.
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/AllianceQuery"
+        - $ref: "#/components/parameters/Limit"
+      responses:
+        "200":
+          description: Aggregated search results.
+  /me:
+    get:
+      summary: Get current API user.
+      responses:
+        "200":
+          description: Current user.
+    patch:
+      summary: Update current user's profile.
+      description: Requires `write:profile`.
+      responses:
+        "200":
+          description: Updated.
+  /me/tokens:
+    get:
+      summary: List current user's API tokens.
+      description: Uses the browser session to bootstrap token management.
+      responses:
+        "200":
+          description: Token metadata.
+    post:
+      summary: Create an API token.
+      description: Uses the browser session; plaintext token is returned only once.
+      responses:
+        "200":
+          description: Created token and metadata.
+  /me/tokens/{token_id}:
+    delete:
+      summary: Revoke an API token.
+      description: Uses the browser session.
+      responses:
+        "200":
+          description: Revoked.
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  parameters:
+    AlliancePath:
+      name: alliance
+      in: path
+      required: true
+      schema:
+        type: string
+    AllianceQuery:
+      name: alliance
+      in: query
+      schema:
+        type: string
+    Limit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+    Offset:
+      name: offset
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+  responses:
+    NotFound:
+      description: Resource not found.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorEnvelope"
+  schemas:
+    ResponseEnvelope:
+      type: object
+      required: [data]
+      properties:
+        data: true
+        meta:
+          type: object
+        links:
+          type: object
+    ErrorEnvelope:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: object
+          required: [code, message]
+          properties:
+            code:
+              type: string
+              enum:
+                - invalid_request
+                - unauthenticated
+                - forbidden
+                - not_found
+                - conflict
+                - validation_failed
+                - internal_error
+            message:
+              type: string
+            details:
+              type: array
+              items:
+                type: string

--- a/ocg-server/src/db/auth.rs
+++ b/ocg-server/src/db/auth.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::{
     auth::{User, UserSummary},
     db::PgExecutor,
+    handlers::api::auth::{ApiScope, ApiToken, ApiUser},
     templates::{auth::UserDetails, notifications::EmailVerification},
     types::permissions::{AlliancePermission, GroupPermission},
     types::user::UserProvider,
@@ -35,6 +36,16 @@ pub(crate) trait DBAuth {
     /// Creates a new session in the database.
     async fn create_session(&self, record: &session::Record) -> Result<()>;
 
+    /// Creates a new API token.
+    async fn create_api_token(
+        &self,
+        user_id: Uuid,
+        token_hash: &str,
+        token_prefix: &str,
+        name: Option<String>,
+        scopes: &[ApiScope],
+    ) -> Result<ApiToken>;
+
     /// Deletes a session from the database.
     async fn delete_session(&self, session_id: &session::Id) -> Result<()>;
 
@@ -43,6 +54,12 @@ pub(crate) trait DBAuth {
 
     /// Retrieves a registered or pre-registered user by email for external auth.
     async fn get_user_by_email_for_external_auth(&self, email: &str) -> Result<Option<User>>;
+
+    /// Resolves a non-revoked API token to an authenticated API user.
+    async fn get_api_token_auth(&self, token_hash: &str) -> Result<Option<ApiUser>>;
+
+    /// Lists a user's API tokens.
+    async fn list_api_tokens(&self, user_id: Uuid) -> Result<Vec<ApiToken>>;
 
     /// Retrieves a user by their unique ID.
     async fn get_user_by_id(&self, user_id: &Uuid) -> Result<Option<User>>;
@@ -66,6 +83,9 @@ pub(crate) trait DBAuth {
         email_verified: bool,
         verification: Option<EmailVerificationNotification>,
     ) -> Result<(User, Option<Uuid>)>;
+
+    /// Revokes one API token owned by a user.
+    async fn revoke_api_token(&self, user_id: Uuid, api_token_id: Uuid) -> Result<()>;
 
     /// Updates an existing session in the database.
     async fn update_session(&self, record: &session::Record) -> Result<()>;
@@ -180,6 +200,47 @@ where
         .await
     }
 
+    #[instrument(skip(self, token_hash), err)]
+    async fn create_api_token(
+        &self,
+        user_id: Uuid,
+        token_hash: &str,
+        token_prefix: &str,
+        name: Option<String>,
+        scopes: &[ApiScope],
+    ) -> Result<ApiToken> {
+        let scope_texts = scopes.iter().map(|scope| scope.as_str()).collect::<Vec<_>>();
+        self.fetch_json_one(
+            "
+            insert into api_token (
+                user_id,
+                token_hash,
+                token_prefix,
+                name,
+                scopes
+            ) values (
+                $1::uuid,
+                $2::text,
+                $3::text,
+                $4::text,
+                $5::text[]
+            )
+            returning jsonb_build_object(
+                'api_token_id', api_token_id,
+                'user_id', user_id,
+                'name', name,
+                'token_prefix', token_prefix,
+                'scopes', scopes,
+                'created_at', extract(epoch from created_at)::bigint,
+                'last_used_at', null,
+                'revoked_at', null
+            );
+            ",
+            &[&user_id, &token_hash, &token_prefix, &name, &scope_texts],
+        )
+        .await
+    }
+
     #[instrument(skip(self, session_id), err)]
     async fn delete_session(&self, session_id: &session::Id) -> Result<()> {
         self.execute(
@@ -216,6 +277,57 @@ where
         self.fetch_json_opt(
             "select get_user_by_email_for_external_auth($1::text);",
             &[&email],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, token_hash), err)]
+    async fn get_api_token_auth(&self, token_hash: &str) -> Result<Option<ApiUser>> {
+        let db = self.client().await?;
+        let Some(row) = db
+            .query_opt(
+                "
+                update api_token
+                set last_used_at = now()
+                where token_hash = $1::text
+                and revoked_at is null
+                returning get_user_by_id(user_id), scopes;
+                ",
+                &[&token_hash],
+            )
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let user = row.try_get::<_, Json<User>>(0)?.0;
+        let scopes = row
+            .get::<_, Vec<String>>(1)
+            .into_iter()
+            .filter_map(|scope| scope.parse().ok())
+            .collect();
+
+        Ok(Some(ApiUser { user, scopes }))
+    }
+
+    #[instrument(skip(self), err)]
+    async fn list_api_tokens(&self, user_id: Uuid) -> Result<Vec<ApiToken>> {
+        self.fetch_json_one(
+            "
+            select coalesce(jsonb_agg(jsonb_build_object(
+                'api_token_id', api_token_id,
+                'user_id', user_id,
+                'name', name,
+                'token_prefix', token_prefix,
+                'scopes', scopes,
+                'created_at', extract(epoch from created_at)::bigint,
+                'last_used_at', extract(epoch from last_used_at)::bigint,
+                'revoked_at', extract(epoch from revoked_at)::bigint
+            ) order by created_at desc), '[]'::jsonb)
+            from api_token
+            where user_id = $1::uuid;
+            ",
+            &[&user_id],
         )
         .await
     }
@@ -305,6 +417,20 @@ where
         let verification_code: Option<Uuid> = row.get(1);
 
         Ok((user, verification_code))
+    }
+
+    #[instrument(skip(self), err)]
+    async fn revoke_api_token(&self, user_id: Uuid, api_token_id: Uuid) -> Result<()> {
+        self.execute(
+            "
+            update api_token
+            set revoked_at = coalesce(revoked_at, now())
+            where user_id = $1::uuid
+            and api_token_id = $2::uuid;
+            ",
+            &[&user_id, &api_token_id],
+        )
+        .await
     }
 
     #[instrument(skip(self, record), err)]

--- a/ocg-server/src/db/event.rs
+++ b/ocg-server/src/db/event.rs
@@ -59,6 +59,9 @@ pub(crate) trait DBEvent {
         user_id: Uuid,
     ) -> Result<EventAttendanceInfo>;
 
+    /// Resolves an event's group identifier.
+    async fn get_event_group_id(&self, event_id: Uuid) -> Result<Option<Uuid>>;
+
     /// Retrieves detailed event information.
     async fn get_event_full_by_slug(
         &self,
@@ -195,6 +198,16 @@ where
         self.fetch_json_one(
             "select get_event_attendance($1::uuid, $2::uuid, $3::uuid)",
             &[&alliance_id, &event_id, &user_id],
+        )
+        .await
+    }
+
+    /// [`DBEvent::get_event_group_id`]
+    #[instrument(skip(self), err)]
+    async fn get_event_group_id(&self, event_id: Uuid) -> Result<Option<Uuid>> {
+        self.fetch_scalar_opt(
+            "select group_id from event where event_id = $1::uuid",
+            &[&event_id],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -38,6 +38,14 @@ mock! {
             &self,
             record: &axum_login::tower_sessions::session::Record,
         ) -> Result<()>;
+        async fn create_api_token(
+            &self,
+            user_id: Uuid,
+            token_hash: &str,
+            token_prefix: &str,
+            name: Option<String>,
+            scopes: &[crate::handlers::api::auth::ApiScope],
+        ) -> Result<crate::handlers::api::auth::ApiToken>;
         async fn delete_session(
             &self,
             session_id: &axum_login::tower_sessions::session::Id,
@@ -50,6 +58,14 @@ mock! {
             &self,
             email: &str,
         ) -> Result<Option<crate::auth::User>>;
+        async fn get_api_token_auth(
+            &self,
+            token_hash: &str,
+        ) -> Result<Option<crate::handlers::api::auth::ApiUser>>;
+        async fn list_api_tokens(
+            &self,
+            user_id: Uuid,
+        ) -> Result<Vec<crate::handlers::api::auth::ApiToken>>;
         async fn get_user_by_id(&self, user_id: &Uuid) -> Result<Option<crate::auth::User>>;
         async fn get_user_by_username(
             &self,
@@ -68,6 +84,11 @@ mock! {
             email_verified: bool,
             verification: Option<crate::db::auth::EmailVerificationNotification>,
         ) -> Result<(crate::auth::User, Option<Uuid>)>;
+        async fn revoke_api_token(
+            &self,
+            user_id: Uuid,
+            api_token_id: Uuid,
+        ) -> Result<()>;
         async fn update_session(
             &self,
             record: &axum_login::tower_sessions::session::Record,
@@ -781,6 +802,7 @@ mock! {
             event_id: Uuid,
             user_id: Uuid,
         ) -> Result<crate::types::event::EventAttendanceInfo>;
+        async fn get_event_group_id(&self, event_id: Uuid) -> Result<Option<Uuid>>;
         async fn is_event_check_in_window_open(
             &self,
             alliance_id: Uuid,

--- a/ocg-server/src/handlers.rs
+++ b/ocg-server/src/handlers.rs
@@ -12,6 +12,8 @@ use crate::{config::HttpServerConfig, router::PUBLIC_SHARED_CACHE_HEADERS};
 
 /// Alliance site handlers.
 pub(crate) mod alliance;
+/// JSON API handlers.
+pub(crate) mod api;
 /// Authentication handlers.
 pub(crate) mod auth;
 /// Dashboards handlers.

--- a/ocg-server/src/handlers/api/admin.rs
+++ b/ocg-server/src/handlers/api/admin.rs
@@ -1,0 +1,265 @@
+//! Admin API mutation handlers.
+
+use std::collections::HashMap;
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    response::IntoResponse,
+};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    config::MeetingsConfig,
+    handlers::extractors::ValidatedJson,
+    router,
+    services::meetings::MeetingProvider,
+    templates::dashboard::{
+        alliance::{create::AllianceCreate, groups::Group, settings::AllianceUpdate},
+        group::events::Event,
+    },
+    types::{jobs::JobInput, landscape::LandscapeEntryInput},
+};
+
+use super::auth::{ApiScope, ApiUser};
+use super::{
+    error::ApiError,
+    types::{ApiResponse, EmptyData},
+};
+
+pub(crate) async fn create_alliance(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    ValidatedJson(input): ValidatedJson<AllianceCreate>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_platform_admin(&api_user)?;
+    let id = state.db.add_alliance(api_user.user_id(), &input).await?;
+    Ok(Json(ApiResponse::data(IdOutput { id })))
+}
+
+pub(crate) async fn update_alliance(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<AlliancePath>,
+    ValidatedJson(input): ValidatedJson<AllianceUpdate>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::AdminAlliance)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    state
+        .db
+        .update_alliance(api_user.user_id(), alliance_id, &input)
+        .await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn create_group(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<AlliancePath>,
+    ValidatedJson(input): ValidatedJson<Group>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::AdminAlliance)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    let id = state.db.add_group(api_user.user_id(), alliance_id, &input).await?;
+    Ok(Json(ApiResponse::data(IdOutput { id })))
+}
+
+pub(crate) async fn update_group(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<GroupPath>,
+    ValidatedJson(input): ValidatedJson<Group>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::AdminAlliance)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    state
+        .db
+        .update_group(api_user.user_id(), alliance_id, path.group_id, &input)
+        .await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn create_event(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<CreateEventPath>,
+    ValidatedJson(input): ValidatedJson<Event>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let payload = input.to_db_payload()?;
+    let id = state
+        .db
+        .add_event(
+            api_user.user_id(),
+            path.group_id,
+            &payload,
+            &build_meetings_max_participants(state.meetings_cfg.as_ref()),
+        )
+        .await?;
+    Ok(Json(ApiResponse::data(IdOutput { id })))
+}
+
+pub(crate) async fn update_event(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<EventPath>,
+    ValidatedJson(input): ValidatedJson<Event>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let group_id = state
+        .db
+        .get_event_group_id(path.event_id)
+        .await?
+        .ok_or_else(ApiError::not_found)?;
+    let payload = input.to_db_payload()?;
+    let promoted_user_ids = state
+        .db
+        .update_event(
+            api_user.user_id(),
+            group_id,
+            path.event_id,
+            &payload,
+            &build_meetings_max_participants(state.meetings_cfg.as_ref()),
+        )
+        .await?;
+    Ok(Json(ApiResponse::data(promoted_user_ids)))
+}
+
+pub(crate) async fn create_job(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    ValidatedJson(input): ValidatedJson<JobInput>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteJobs)?;
+    let id = state.db.add_job(api_user.user_id(), &input).await?;
+    Ok(Json(ApiResponse::data(IdOutput { id })))
+}
+
+pub(crate) async fn update_job(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<JobPath>,
+    ValidatedJson(input): ValidatedJson<JobInput>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteJobs)?;
+    state.db.update_job(api_user.user_id(), path.job_id, &input).await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn delete_job(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<JobPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteJobs)?;
+    state.db.delete_job(api_user.user_id(), path.job_id).await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn create_landscape_entry(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    ValidatedJson(input): ValidatedJson<LandscapeEntryApiInput>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::AdminAlliance)?;
+    let alliance_id = alliance_id(&state, &input.alliance).await?;
+    let id = state
+        .db
+        .add_landscape_entry(api_user.user_id(), alliance_id, &input.entry)
+        .await?;
+    Ok(Json(ApiResponse::data(IdOutput { id })))
+}
+
+pub(crate) async fn update_landscape_entry(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<LandscapePath>,
+    ValidatedJson(input): ValidatedJson<LandscapeEntryApiInput>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::AdminAlliance)?;
+    let alliance_id = alliance_id(&state, &input.alliance).await?;
+    state
+        .db
+        .update_landscape_entry(api_user.user_id(), alliance_id, path.entry_id, &input.entry)
+        .await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+fn require_platform_admin(api_user: &ApiUser) -> Result<(), ApiError> {
+    api_user.require_scope(ApiScope::AdminPlatform)?;
+    if api_user.user.platform_admin {
+        return Ok(());
+    }
+    Err(ApiError::forbidden())
+}
+
+async fn alliance_id(state: &router::State, alliance: &str) -> Result<Uuid, ApiError> {
+    state
+        .db
+        .get_alliance_id_by_name(alliance)
+        .await?
+        .ok_or_else(ApiError::not_found)
+}
+
+fn build_meetings_max_participants(
+    meetings_cfg: Option<&MeetingsConfig>,
+) -> HashMap<MeetingProvider, i32> {
+    let mut map = HashMap::new();
+    if let Some(cfg) = meetings_cfg
+        && let Some(google_meet) = &cfg.google_meet
+    {
+        map.insert(MeetingProvider::GoogleMeet, google_meet.max_participants);
+    }
+    if let Some(cfg) = meetings_cfg
+        && let Some(zoom) = &cfg.zoom
+    {
+        map.insert(MeetingProvider::Zoom, zoom.max_participants);
+    }
+    map
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct IdOutput {
+    id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AlliancePath {
+    alliance: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GroupPath {
+    alliance: String,
+    group_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct CreateEventPath {
+    group_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct EventPath {
+    event_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JobPath {
+    job_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LandscapePath {
+    entry_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize, garde::Validate)]
+pub(crate) struct LandscapeEntryApiInput {
+    #[garde(length(min = 1, max = 200))]
+    alliance: String,
+    #[serde(flatten)]
+    #[garde(dive)]
+    entry: LandscapeEntryInput,
+}

--- a/ocg-server/src/handlers/api/auth.rs
+++ b/ocg-server/src/handlers/api/auth.rs
@@ -1,0 +1,169 @@
+//! API bearer-token authentication helpers.
+
+use axum::{
+    extract::FromRequestParts,
+    http::{header::AUTHORIZATION, request::Parts},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::{auth::User, handlers::api::error::ApiError, router};
+
+/// Parsed and authenticated API caller.
+#[derive(Debug, Clone)]
+pub(crate) struct ApiUser {
+    /// Authenticated user.
+    pub user: User,
+    /// Token scopes granted to the caller.
+    pub scopes: Vec<ApiScope>,
+}
+
+impl ApiUser {
+    /// Require a specific API scope.
+    pub(crate) fn require_scope(&self, scope: ApiScope) -> Result<(), ApiError> {
+        if self.scopes.contains(&scope) || self.scopes.contains(&ApiScope::AdminPlatform) {
+            return Ok(());
+        }
+        Err(ApiError::forbidden())
+    }
+
+    /// Current user id.
+    pub(crate) fn user_id(&self) -> Uuid {
+        self.user.user_id
+    }
+}
+
+impl FromRequestParts<router::State> for ApiUser {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &router::State,
+    ) -> Result<Self, Self::Rejection> {
+        let Some(header) = parts.headers.get(AUTHORIZATION) else {
+            return Err(ApiError::unauthenticated());
+        };
+        let header = header.to_str().map_err(|_| ApiError::unauthenticated())?;
+        let Some(token) = header.strip_prefix("Bearer ") else {
+            return Err(ApiError::unauthenticated());
+        };
+        let token_hash = hash_token(token);
+
+        state
+            .db
+            .get_api_token_auth(&token_hash)
+            .await?
+            .ok_or_else(ApiError::unauthenticated)
+    }
+}
+
+/// API token scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum ApiScope {
+    /// Public read endpoints.
+    #[serde(rename = "read:public")]
+    ReadPublic,
+    /// User profile writes.
+    #[serde(rename = "write:profile")]
+    WriteProfile,
+    /// Event actions and writes.
+    #[serde(rename = "write:events")]
+    WriteEvents,
+    /// Job actions and writes.
+    #[serde(rename = "write:jobs")]
+    WriteJobs,
+    /// Alliance scoped admin actions.
+    #[serde(rename = "admin:alliance")]
+    AdminAlliance,
+    /// Platform admin actions.
+    #[serde(rename = "admin:platform")]
+    AdminPlatform,
+}
+
+impl ApiScope {
+    /// Scope as persisted text.
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadPublic => "read:public",
+            Self::WriteProfile => "write:profile",
+            Self::WriteEvents => "write:events",
+            Self::WriteJobs => "write:jobs",
+            Self::AdminAlliance => "admin:alliance",
+            Self::AdminPlatform => "admin:platform",
+        }
+    }
+}
+
+impl std::str::FromStr for ApiScope {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "read:public" => Ok(Self::ReadPublic),
+            "write:profile" => Ok(Self::WriteProfile),
+            "write:events" => Ok(Self::WriteEvents),
+            "write:jobs" => Ok(Self::WriteJobs),
+            "admin:alliance" => Ok(Self::AdminAlliance),
+            "admin:platform" => Ok(Self::AdminPlatform),
+            _ => Err(()),
+        }
+    }
+}
+
+/// Hash a bearer token for storage and lookup.
+pub(crate) fn hash_token(token: &str) -> String {
+    hex::encode(Sha256::digest(token.as_bytes()))
+}
+
+/// Non-secret token metadata returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ApiToken {
+    /// Token identifier.
+    pub api_token_id: Uuid,
+    /// Token owner.
+    pub user_id: Uuid,
+    /// Human-readable name.
+    pub name: Option<String>,
+    /// Non-secret token prefix.
+    pub token_prefix: String,
+    /// Token scopes.
+    pub scopes: Vec<ApiScope>,
+    /// Creation timestamp.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Last-used timestamp.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub last_used_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Revocation timestamp.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub revoked_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::{ApiScope, hash_token};
+
+    #[test]
+    fn hash_token_is_stable_and_not_plaintext() {
+        let hash = hash_token("goup_test_token");
+
+        assert_eq!(
+            hash,
+            "8a097b2bf9772e4086101d9ebb6791be85bb23d639bdc9915174f5bdd97f920c"
+        );
+        assert_ne!(hash, "goup_test_token");
+    }
+
+    #[test]
+    fn api_scope_parses_persisted_scope_strings() {
+        assert_eq!(
+            ApiScope::from_str("admin:alliance").expect("valid scope"),
+            ApiScope::AdminAlliance
+        );
+        assert!(ApiScope::from_str("admin:unknown").is_err());
+    }
+}

--- a/ocg-server/src/handlers/api/error.rs
+++ b/ocg-server/src/handlers/api/error.rs
@@ -1,0 +1,147 @@
+//! JSON API error responses.
+
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+
+use crate::{handlers::error::HandlerError, types::search::FilterError};
+
+/// Error type returned by API routes.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+pub(crate) struct ApiError {
+    /// HTTP status.
+    pub status: StatusCode,
+    /// Machine-readable error code.
+    pub code: &'static str,
+    /// Human-readable error message.
+    pub message: String,
+    /// Optional error details.
+    pub details: Vec<String>,
+}
+
+impl ApiError {
+    /// Build a new API error.
+    pub(crate) fn new(status: StatusCode, code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            code,
+            message: message.into(),
+            details: Vec::new(),
+        }
+    }
+
+    /// Add details to an API error.
+    pub(crate) fn with_details(mut self, details: Vec<String>) -> Self {
+        self.details = details;
+        self
+    }
+
+    /// 401 helper.
+    pub(crate) fn unauthenticated() -> Self {
+        Self::new(
+            StatusCode::UNAUTHORIZED,
+            "unauthenticated",
+            "Authentication is required.",
+        )
+    }
+
+    /// 403 helper.
+    pub(crate) fn forbidden() -> Self {
+        Self::new(
+            StatusCode::FORBIDDEN,
+            "forbidden",
+            "You do not have permission to perform this action.",
+        )
+    }
+
+    /// 404 helper.
+    pub(crate) fn not_found() -> Self {
+        Self::new(StatusCode::NOT_FOUND, "not_found", "Resource not found.")
+    }
+}
+
+impl From<HandlerError> for ApiError {
+    fn from(error: HandlerError) -> Self {
+        match error {
+            HandlerError::Auth(message) => {
+                Self::new(StatusCode::UNAUTHORIZED, "unauthenticated", message)
+            }
+            HandlerError::Database(message) | HandlerError::Deserialization(message) => Self::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "validation_failed",
+                message,
+            ),
+            HandlerError::Forbidden => Self::forbidden(),
+            HandlerError::NotFound => Self::not_found(),
+            HandlerError::Validation(report) => Self::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "validation_failed",
+                "Request is invalid.",
+            )
+            .with_details(vec![report.to_string()]),
+            _ => Self::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal_error",
+                "An internal error occurred.",
+            ),
+        }
+    }
+}
+
+impl From<FilterError> for ApiError {
+    fn from(error: FilterError) -> Self {
+        HandlerError::from(error).into()
+    }
+}
+
+impl From<anyhow::Error> for ApiError {
+    fn from(error: anyhow::Error) -> Self {
+        HandlerError::from(error).into()
+    }
+}
+
+impl From<tower_sessions::session::Error> for ApiError {
+    fn from(_error: tower_sessions::session::Error) -> Self {
+        Self::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "internal_error",
+            "An internal error occurred.",
+        )
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let status = self.status;
+        (status, Json(ApiErrorEnvelope::from(self))).into_response()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ApiErrorEnvelope {
+    error: ApiErrorBody,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct ApiErrorBody {
+    code: &'static str,
+    message: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    details: Vec<String>,
+}
+
+impl From<ApiError> for ApiErrorEnvelope {
+    fn from(error: ApiError) -> Self {
+        Self {
+            error: ApiErrorBody {
+                code: error.code,
+                message: error.message,
+                details: error.details,
+            },
+        }
+    }
+}

--- a/ocg-server/src/handlers/api/mod.rs
+++ b/ocg-server/src/handlers/api/mod.rs
@@ -1,0 +1,9 @@
+//! Versioned JSON API handlers.
+
+pub(crate) mod admin;
+pub(crate) mod auth;
+pub(crate) mod error;
+pub(crate) mod public;
+pub(crate) mod tokens;
+pub(crate) mod types;
+pub(crate) mod user;

--- a/ocg-server/src/handlers/api/public.rs
+++ b/ocg-server/src/handlers/api/public.rs
@@ -1,0 +1,296 @@
+//! Public API read handlers.
+
+use axum::{
+    Json,
+    extract::{Path, Query, RawQuery, State},
+    http::{HeaderMap, StatusCode, header::AUTHORIZATION},
+    response::IntoResponse,
+};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    db::common::SearchEventsOutput,
+    router,
+    templates::site::explore::Entity,
+    types::{
+        jobs::{JobsFilters, JobsOutput},
+        landscape::{LandscapeFilters, LandscapeOutput},
+        search::{SearchEventsFilters, SearchGroupsFilters},
+    },
+};
+
+use super::auth::hash_token;
+use super::{error::ApiError, types::ApiResponse};
+
+/// Public API health check.
+pub(crate) async fn health() -> impl IntoResponse {
+    Json(ApiResponse::data(serde_json::json!({ "status": "ok" })))
+}
+
+pub(crate) async fn filters(
+    State(state): State<router::State>,
+    Query(query): Query<FiltersQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let filters = state.db.get_filters_options(query.alliance, query.entity).await?;
+    Ok(Json(ApiResponse::data(filters)))
+}
+
+pub(crate) async fn alliances(
+    State(state): State<router::State>,
+) -> Result<impl IntoResponse, ApiError> {
+    Ok(Json(ApiResponse::data(state.db.list_alliances().await?)))
+}
+
+pub(crate) async fn alliance(
+    State(state): State<router::State>,
+    Path(path): Path<AlliancePath>,
+) -> Result<impl IntoResponse, ApiError> {
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    Ok(Json(ApiResponse::data(
+        state.db.get_alliance_full(alliance_id).await?,
+    )))
+}
+
+pub(crate) async fn alliance_groups(
+    State(state): State<router::State>,
+    headers: HeaderMap,
+    Path(path): Path<AlliancePath>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, ApiError> {
+    let mut filters = SearchGroupsFilters::new(&headers, raw_query.as_deref().unwrap_or(""))?;
+    filters.alliance = vec![path.alliance];
+    let output = state.db.search_groups(&filters).await?;
+    Ok(Json(
+        ApiResponse::data(output.groups).with_meta("total", output.total),
+    ))
+}
+
+pub(crate) async fn alliance_events(
+    State(state): State<router::State>,
+    headers: HeaderMap,
+    Path(path): Path<AlliancePath>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, ApiError> {
+    let mut filters = SearchEventsFilters::new(&headers, raw_query.as_deref().unwrap_or(""))?;
+    filters.alliance = vec![path.alliance];
+    let output = state.db.search_events(&filters).await?;
+    Ok(Json(
+        ApiResponse::data(output.events).with_meta("total", output.total),
+    ))
+}
+
+pub(crate) async fn group(
+    State(state): State<router::State>,
+    Path(path): Path<GroupPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    let group = state
+        .db
+        .get_group_full_by_slug(alliance_id, &path.group_slug)
+        .await?
+        .ok_or_else(ApiError::not_found)?;
+    Ok(Json(ApiResponse::data(group)))
+}
+
+pub(crate) async fn event(
+    State(state): State<router::State>,
+    Path(path): Path<EventPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    let event = state
+        .db
+        .get_event_full_by_slug(alliance_id, &path.group_slug, &path.event_slug)
+        .await?
+        .ok_or_else(ApiError::not_found)?;
+    Ok(Json(ApiResponse::data(event)))
+}
+
+pub(crate) async fn jobs(
+    State(state): State<router::State>,
+    Query(filters): Query<JobsFilters>,
+) -> Result<impl IntoResponse, ApiError> {
+    filters.validate().map_err(|error| validation_error(&error))?;
+    let output = state.db.search_jobs(&filters).await?;
+    Ok(Json(jobs_response(output)))
+}
+
+pub(crate) async fn job(
+    State(state): State<router::State>,
+    headers: HeaderMap,
+    Path(path): Path<JobPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    let viewer_user_id = optional_api_user_id(&state, &headers).await?;
+    let job = state.db.get_job_by_slug(&path.slug, viewer_user_id).await?;
+    Ok(Json(ApiResponse::data(job)))
+}
+
+pub(crate) async fn landscape(
+    State(state): State<router::State>,
+    Query(filters): Query<LandscapeFilters>,
+) -> Result<impl IntoResponse, ApiError> {
+    filters.validate().map_err(|error| validation_error(&error))?;
+    let output = state.db.search_landscape_entries(&filters).await?;
+    Ok(Json(landscape_response(output)))
+}
+
+pub(crate) async fn search(
+    State(state): State<router::State>,
+    headers: HeaderMap,
+    Query(query): Query<SearchQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    query.validate().map_err(|error| validation_error(&error))?;
+    let raw_query = format!("ts_query={}&limit={}", query.q, query.limit.unwrap_or(5));
+    let mut events_filters = SearchEventsFilters::new(&headers, &raw_query)?;
+    let mut groups_filters = SearchGroupsFilters::new(&headers, &raw_query)?;
+    if let Some(alliance) = query.alliance.clone() {
+        events_filters.alliance = vec![alliance.clone()];
+        groups_filters.alliance = vec![alliance];
+    }
+
+    let jobs_filters = JobsFilters {
+        query: Some(query.q.clone()),
+        limit: query.limit,
+        ..Default::default()
+    };
+    let landscape_filters = LandscapeFilters {
+        query: Some(query.q),
+        alliance: query.alliance,
+        limit: query.limit,
+        ..Default::default()
+    };
+
+    let (events, groups, jobs, landscape) = tokio::try_join!(
+        state.db.search_events(&events_filters),
+        state.db.search_groups(&groups_filters),
+        state.db.search_jobs(&jobs_filters),
+        state.db.search_landscape_entries(&landscape_filters),
+    )?;
+
+    Ok(Json(ApiResponse::data(SearchOutput {
+        events: events_response(events),
+        groups: groups.groups,
+        jobs: jobs.jobs,
+        landscape: landscape.entries,
+    })))
+}
+
+async fn alliance_id(state: &router::State, alliance: &str) -> Result<uuid::Uuid, ApiError> {
+    state
+        .db
+        .get_alliance_id_by_name(alliance)
+        .await?
+        .ok_or_else(ApiError::not_found)
+}
+
+fn validation_error(error: &garde::Report) -> ApiError {
+    ApiError::new(
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "validation_failed",
+        "Request parameters failed validation.",
+    )
+    .with_details(vec![error.to_string()])
+}
+
+fn jobs_response(output: JobsOutput) -> ApiResponse<Vec<crate::types::jobs::JobSummary>> {
+    ApiResponse::data(output.jobs).with_meta("total", output.total)
+}
+
+fn landscape_response(
+    output: LandscapeOutput,
+) -> ApiResponse<Vec<crate::types::landscape::LandscapeEntry>> {
+    ApiResponse::data(output.entries).with_meta("total", output.total)
+}
+
+fn events_response(output: SearchEventsOutput) -> Vec<crate::types::event::EventSummary> {
+    output.events
+}
+
+async fn optional_api_user_id(
+    state: &router::State,
+    headers: &HeaderMap,
+) -> Result<Option<uuid::Uuid>, ApiError> {
+    let Some(header) = headers.get(AUTHORIZATION) else {
+        return Ok(None);
+    };
+    let Ok(header) = header.to_str() else {
+        return Ok(None);
+    };
+    let Some(token) = header.strip_prefix("Bearer ") else {
+        return Ok(None);
+    };
+    Ok(state
+        .db
+        .get_api_token_auth(&hash_token(token))
+        .await?
+        .map(|api_user| api_user.user_id()))
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FiltersQuery {
+    alliance: Option<String>,
+    entity: Option<Entity>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AlliancePath {
+    alliance: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GroupPath {
+    alliance: String,
+    group_slug: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct EventPath {
+    alliance: String,
+    group_slug: String,
+    event_slug: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JobPath {
+    slug: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Validate)]
+pub(crate) struct SearchQuery {
+    #[garde(length(min = 1, max = 200))]
+    q: String,
+    #[garde(length(max = 200))]
+    alliance: Option<String>,
+    #[serde(default)]
+    #[garde(range(max = 50))]
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SearchOutput {
+    events: Vec<crate::types::event::EventSummary>,
+    groups: Vec<crate::types::group::GroupSummary>,
+    jobs: Vec<crate::types::jobs::JobSummary>,
+    landscape: Vec<crate::types::landscape::LandscapeEntry>,
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body, response::IntoResponse};
+
+    use super::health;
+
+    #[tokio::test]
+    async fn health_returns_ok_json_envelope() {
+        let response = health().await.into_response();
+
+        assert!(response.status().is_success());
+
+        let body = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body bytes");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("valid json");
+
+        assert_eq!(body["data"]["status"], "ok");
+    }
+}

--- a/ocg-server/src/handlers/api/tokens.rs
+++ b/ocg-server/src/handlers/api/tokens.rs
@@ -1,0 +1,119 @@
+//! API token management handlers.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    response::IntoResponse,
+};
+use axum_login::AuthSession;
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{auth::AuthnBackend, handlers::extractors::ValidatedJson, router};
+
+use super::auth::{ApiScope, hash_token};
+use super::{
+    error::ApiError,
+    types::{ApiResponse, EmptyData},
+};
+
+pub(crate) async fn list(
+    State(state): State<router::State>,
+    auth_session: AuthSession<AuthnBackend>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = auth_session.user.ok_or_else(ApiError::unauthenticated)?;
+    Ok(Json(ApiResponse::data(
+        state.db.list_api_tokens(user.user_id).await?,
+    )))
+}
+
+pub(crate) async fn create(
+    State(state): State<router::State>,
+    auth_session: AuthSession<AuthnBackend>,
+    ValidatedJson(input): ValidatedJson<CreateApiTokenInput>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = auth_session.user.ok_or_else(ApiError::unauthenticated)?;
+    let token = new_token_secret();
+    let token_prefix = token.chars().take(17).collect::<String>();
+    let scopes = input.scopes.unwrap_or_else(|| vec![ApiScope::ReadPublic]);
+    let record = state
+        .db
+        .create_api_token(
+            user.user_id,
+            &hash_token(&token),
+            &token_prefix,
+            input.name,
+            &scopes,
+        )
+        .await?;
+
+    Ok(Json(ApiResponse::data(CreateApiTokenOutput {
+        token,
+        record,
+    })))
+}
+
+pub(crate) async fn revoke(
+    State(state): State<router::State>,
+    auth_session: AuthSession<AuthnBackend>,
+    Path(path): Path<TokenPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    let user = auth_session.user.ok_or_else(ApiError::unauthenticated)?;
+    state.db.revoke_api_token(user.user_id, path.token_id).await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+fn new_token_secret() -> String {
+    format!(
+        "goup_{}{}",
+        Uuid::new_v4().simple(),
+        Uuid::new_v4().simple()
+    )
+}
+
+#[derive(Debug, Clone, Deserialize, Validate)]
+pub(crate) struct CreateApiTokenInput {
+    #[garde(length(max = 120))]
+    name: Option<String>,
+    #[garde(length(min = 1, max = 16))]
+    scopes: Option<Vec<ApiScope>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct CreateApiTokenOutput {
+    token: String,
+    record: super::auth::ApiToken,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct TokenPath {
+    token_id: Uuid,
+}
+
+#[cfg(test)]
+mod tests {
+    use garde::Validate;
+
+    use super::{ApiScope, CreateApiTokenInput};
+
+    #[test]
+    fn create_token_input_requires_at_least_one_scope_when_scopes_are_present() {
+        let input = CreateApiTokenInput {
+            name: Some("Integration".to_string()),
+            scopes: Some(Vec::new()),
+        };
+
+        assert!(input.validate().is_err());
+    }
+
+    #[test]
+    fn create_token_input_accepts_named_scoped_tokens() {
+        let input = CreateApiTokenInput {
+            name: Some("Integration".to_string()),
+            scopes: Some(vec![ApiScope::ReadPublic]),
+        };
+
+        assert!(input.validate().is_ok());
+    }
+}

--- a/ocg-server/src/handlers/api/types.rs
+++ b/ocg-server/src/handlers/api/types.rs
@@ -1,0 +1,48 @@
+//! Shared API response types.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+/// Standard successful API response envelope.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ApiResponse<T>
+where
+    T: Serialize,
+{
+    /// Response payload.
+    pub data: T,
+    /// Optional response metadata.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub meta: BTreeMap<String, serde_json::Value>,
+    /// Optional related links.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub links: BTreeMap<String, String>,
+}
+
+impl<T> ApiResponse<T>
+where
+    T: Serialize,
+{
+    /// Wrap data in the standard response envelope.
+    pub(crate) fn data(data: T) -> Self {
+        Self {
+            data,
+            meta: BTreeMap::new(),
+            links: BTreeMap::new(),
+        }
+    }
+
+    /// Add one metadata field to the response.
+    pub(crate) fn with_meta(mut self, key: impl Into<String>, value: impl Serialize) -> Self {
+        self.meta.insert(
+            key.into(),
+            serde_json::to_value(value).unwrap_or(serde_json::Value::Null),
+        );
+        self
+    }
+}
+
+/// Empty object used for mutation responses with no additional payload.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct EmptyData {}

--- a/ocg-server/src/handlers/api/user.rs
+++ b/ocg-server/src/handlers/api/user.rs
@@ -1,0 +1,152 @@
+//! Authenticated user API handlers.
+
+use axum::{
+    Json,
+    extract::{Path, State},
+    response::IntoResponse,
+};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::{
+    handlers::extractors::ValidatedJson,
+    router,
+    templates::auth::UserDetails,
+    types::{jobs::JobApplicationInput, questionnaire::QuestionnaireAnswers},
+};
+
+use super::auth::{ApiScope, ApiUser};
+use super::{
+    error::ApiError,
+    types::{ApiResponse, EmptyData},
+};
+
+pub(crate) async fn me(api_user: ApiUser) -> Result<impl IntoResponse, ApiError> {
+    Ok(Json(ApiResponse::data(api_user.user)))
+}
+
+pub(crate) async fn update_me(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    ValidatedJson(input): ValidatedJson<UserDetails>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteProfile)?;
+    state.db.update_user_details(&api_user.user_id(), &input).await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn join_group(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<GroupActionPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    state
+        .db
+        .join_group(alliance_id, path.group_id, api_user.user_id())
+        .await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn leave_group(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<GroupActionPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    state
+        .db
+        .leave_group(alliance_id, path.group_id, api_user.user_id())
+        .await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+pub(crate) async fn event_attendance(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<EventActionPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    let attendance = state
+        .db
+        .get_event_attendance(alliance_id, path.event_id, api_user.user_id())
+        .await?;
+    Ok(Json(ApiResponse::data(attendance)))
+}
+
+pub(crate) async fn attend_event(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<EventActionPath>,
+    body: Option<Json<AttendEventInput>>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    let answers = body.and_then(|Json(input)| input.registration_answers);
+    let status = state
+        .db
+        .attend_event(alliance_id, path.event_id, api_user.user_id(), answers)
+        .await?;
+    Ok(Json(ApiResponse::data(status)))
+}
+
+pub(crate) async fn leave_event(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<EventActionPath>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteEvents)?;
+    let alliance_id = alliance_id(&state, &path.alliance).await?;
+    let outcome = state
+        .db
+        .leave_event(alliance_id, path.event_id, api_user.user_id())
+        .await?;
+    Ok(Json(ApiResponse::data(outcome)))
+}
+
+pub(crate) async fn apply_to_job(
+    State(state): State<router::State>,
+    api_user: ApiUser,
+    Path(path): Path<JobActionPath>,
+    ValidatedJson(input): ValidatedJson<JobApplicationInput>,
+) -> Result<impl IntoResponse, ApiError> {
+    api_user.require_scope(ApiScope::WriteJobs)?;
+    state
+        .db
+        .add_job_application(api_user.user_id(), path.job_id, &input)
+        .await?;
+    Ok(Json(ApiResponse::data(EmptyData {})))
+}
+
+async fn alliance_id(state: &router::State, alliance: &str) -> Result<Uuid, ApiError> {
+    state
+        .db
+        .get_alliance_id_by_name(alliance)
+        .await?
+        .ok_or_else(ApiError::not_found)
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct GroupActionPath {
+    alliance: String,
+    group_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct EventActionPath {
+    alliance: String,
+    event_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct JobActionPath {
+    job_id: Uuid,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct AttendEventInput {
+    registration_answers: Option<QuestionnaireAnswers>,
+}

--- a/ocg-server/src/handlers/extractors.rs
+++ b/ocg-server/src/handlers/extractors.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use axum::{
-    Form,
+    Form, Json,
     extract::{FromRequest, FromRequestParts, Path, Request},
     http::{StatusCode, request::Parts},
 };
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::{
     auth::{AuthSession, OAuth2ProviderDetails, OidcProviderDetails, User as AuthUser},
     config::{OAuth2Provider, OidcProvider},
+    handlers::api::error::ApiError,
     router,
 };
 
@@ -192,6 +193,39 @@ where
             .map_err(|e| (StatusCode::UNPROCESSABLE_ENTITY, e.to_string()))?;
 
         Ok(ValidatedForm(value))
+    }
+}
+
+/// Extractor that deserializes and validates JSON request bodies.
+pub(crate) struct ValidatedJson<T>(pub T);
+
+impl<T> FromRequest<router::State> for ValidatedJson<T>
+where
+    T: DeserializeOwned + Validate,
+    T::Context: Default,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(req: Request, state: &router::State) -> Result<Self, Self::Rejection> {
+        let Json(value) = Json::<T>::from_request(req, state).await.map_err(|error| {
+            ApiError::new(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "Request JSON body is invalid.",
+            )
+            .with_details(vec![error.to_string()])
+        })?;
+
+        value.validate().map_err(|error| {
+            ApiError::new(
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "validation_failed",
+                "Request JSON body failed validation.",
+            )
+            .with_details(vec![error.to_string()])
+        })?;
+
+        Ok(ValidatedJson(value))
     }
 }
 

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -3,6 +3,7 @@
 //! This module sets up the Axum router with all application routes, middleware layers,
 //! and static file handling.
 
+mod api;
 mod dashboard;
 
 #[cfg(test)]
@@ -168,6 +169,7 @@ pub(crate) async fn setup(
     let auth_layer = crate::auth::setup_layer(server_cfg, db)?;
 
     // Setup sub-routers
+    let api_router = api::setup_api_router();
     let alliance_dashboard_router = dashboard::setup_alliance_dashboard_router(&state);
     let group_dashboard_router = dashboard::setup_group_dashboard_router(&state);
     let user_dashboard_router = dashboard::setup_user_dashboard_router();
@@ -254,6 +256,7 @@ pub(crate) async fn setup(
             login_url = LOG_IN_URL,
             redirect_field = "next_url"
         ))
+        .nest("/api/v1", api_router)
         // Global site routes (no alliance prefix)
         .route("/", get(site::home::page))
         .route(

--- a/ocg-server/src/router/api.rs
+++ b/ocg-server/src/router/api.rs
@@ -1,0 +1,72 @@
+//! Versioned JSON API router.
+
+use axum::{
+    Router,
+    routing::{delete, get, patch, post},
+};
+
+use crate::handlers::api::{admin, public, tokens, user};
+
+use super::State;
+
+/// Sets up `/api/v1` routes.
+pub(super) fn setup_api_router() -> Router<State> {
+    Router::new()
+        .route("/health", get(public::health))
+        .route("/meta/filters", get(public::filters))
+        .route(
+            "/alliances",
+            get(public::alliances).post(admin::create_alliance),
+        )
+        .route(
+            "/alliances/{alliance}",
+            get(public::alliance).patch(admin::update_alliance),
+        )
+        .route(
+            "/alliances/{alliance}/groups",
+            get(public::alliance_groups).post(admin::create_group),
+        )
+        .route(
+            "/alliances/{alliance}/groups/{group_id}",
+            patch(admin::update_group),
+        )
+        .route("/alliances/{alliance}/events", get(public::alliance_events))
+        .route("/groups/{alliance}/{group_slug}", get(public::group))
+        .route(
+            "/groups/{alliance}/{group_id}/join",
+            post(user::join_group).delete(user::leave_group),
+        )
+        .route("/groups/{group_id}/events", post(admin::create_event))
+        .route(
+            "/events/{alliance}/{group_slug}/{event_slug}",
+            get(public::event),
+        )
+        .route(
+            "/events/{alliance}/{event_id}/attendance",
+            get(user::event_attendance),
+        )
+        .route(
+            "/events/{alliance}/{event_id}/attend",
+            post(user::attend_event).delete(user::leave_event),
+        )
+        .route("/events/{event_id}", patch(admin::update_event))
+        .route("/jobs", get(public::jobs).post(admin::create_job))
+        .route("/jobs/{slug}", get(public::job))
+        .route(
+            "/jobs/{job_id}",
+            patch(admin::update_job).delete(admin::delete_job),
+        )
+        .route("/jobs/{job_id}/applications", post(user::apply_to_job))
+        .route(
+            "/landscape",
+            get(public::landscape).post(admin::create_landscape_entry),
+        )
+        .route(
+            "/landscape/{entry_id}",
+            patch(admin::update_landscape_entry),
+        )
+        .route("/search", get(public::search))
+        .route("/me", get(user::me).patch(user::update_me))
+        .route("/me/tokens", get(tokens::list).post(tokens::create))
+        .route("/me/tokens/{token_id}", delete(tokens::revoke))
+}


### PR DESCRIPTION
## Summary
- Add `/api/v1` JSON routing with response/error envelopes and validated JSON bodies.
- Add API token storage, bearer-token resolution, scoped user/admin endpoints, and public read/search endpoints.
- Add checked-in OpenAPI documentation plus schema expectations for the new `api_token` table.

## Test plan
- `cargo clippy -p ocg-server --all-targets -- -D warnings`
- `cargo test -p ocg-server handlers::api`
- Attempted `just db-tests` locally, but local Postgres lacks the `postgres` role; schema expectations were updated for CI.


Made with [Cursor](https://cursor.com)