### PR TITLE
Add member spotlights and profile cards

### DIFF
--- a/database/migrations/schema/0011_group_member_spotlight.sql
+++ b/database/migrations/schema/0011_group_member_spotlight.sql
@@ -1,0 +1,20 @@
+create table if not exists group_member_spotlight (
+    group_member_spotlight_id uuid primary key default uuid_generate_v4(),
+    group_id uuid not null references "group" (group_id) on delete cascade,
+    user_id uuid not null references "user" (user_id) on delete cascade,
+    created_by uuid not null references "user" (user_id),
+    title text not null,
+    story text not null,
+    image_url text,
+    link_url text,
+    featured boolean default false not null,
+    published boolean default true not null,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_member_spotlight_title_check check (btrim(title) <> ''),
+    constraint group_member_spotlight_story_check check (btrim(story) <> ''),
+    constraint group_member_spotlight_user_once_per_group unique (group_id, user_id)
+);
+
+create index if not exists group_member_spotlight_group_id_idx
+on group_member_spotlight (group_id, featured desc, created_at desc);

--- a/database/tests/schema/02_columns.sql
+++ b/database/tests/schema/02_columns.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(70);
+select plan(71);
 
 -- ============================================================================
 -- TESTS
@@ -563,6 +563,22 @@ select columns_are('group_member', array[
     'group_id',
     'user_id',
     'created_at'
+]);
+
+-- Test: group_member_spotlight columns should match expected
+select columns_are('group_member_spotlight', array[
+    'group_member_spotlight_id',
+    'group_id',
+    'user_id',
+    'created_by',
+    'title',
+    'story',
+    'image_url',
+    'link_url',
+    'featured',
+    'published',
+    'created_at',
+    'updated_at'
 ]);
 
 -- Test: group_role columns should match expected

--- a/database/tests/schema/03_keys.sql
+++ b/database/tests/schema/03_keys.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(153);
+select plan(157);
 
 -- ============================================================================
 -- TESTS
@@ -46,6 +46,7 @@ select has_pk('event_waitlist');
 select has_pk('group');
 select has_pk('group_category');
 select has_pk('group_member');
+select has_pk('group_member_spotlight');
 select has_pk('group_permission');
 select has_pk('group_role');
 select has_pk('group_role_group_permission');
@@ -135,6 +136,9 @@ select col_is_fk('group', 'region_id', 'region');
 select col_is_fk('group_category', 'alliance_id', 'alliance');
 select col_is_fk('group_member', 'group_id', 'group');
 select col_is_fk('group_member', 'user_id', 'user');
+select col_is_fk('group_member_spotlight', 'created_by', 'user');
+select col_is_fk('group_member_spotlight', 'group_id', 'group');
+select col_is_fk('group_member_spotlight', 'user_id', 'user');
 select col_is_fk('group_role_group_permission', 'group_permission_id', 'group_permission');
 select col_is_fk('group_role_group_permission', 'group_role_id', 'group_role');
 select col_is_fk('group_sponsor', 'group_id', 'group');

--- a/ocg-server/src/db/auth.rs
+++ b/ocg-server/src/db/auth.rs
@@ -12,7 +12,7 @@ use crate::{
     db::PgExecutor,
     templates::{auth::UserDetails, notifications::EmailVerification},
     types::permissions::{AlliancePermission, GroupPermission},
-    types::user::UserProvider,
+    types::user::{PublicUserProfile, UserProvider},
 };
 
 /// Trait for database operations related to authentication and authorization.
@@ -49,6 +49,12 @@ pub(crate) trait DBAuth {
 
     /// Retrieves a user by their username.
     async fn get_user_by_username(&self, username: &str) -> Result<Option<User>>;
+
+    /// Retrieves public, non-email profile fields by username.
+    async fn get_public_user_profile_by_username(
+        &self,
+        username: &str,
+    ) -> Result<Option<PublicUserProfile>>;
 
     /// Retrieves the password hash for a user.
     async fn get_user_password(&self, user_id: &Uuid) -> Result<Option<String>>;
@@ -230,6 +236,38 @@ where
     async fn get_user_by_username(&self, username: &str) -> Result<Option<User>> {
         self.fetch_json_opt("select get_user_by_username($1::text);", &[&username])
             .await
+    }
+
+    #[instrument(skip(self, username), err)]
+    async fn get_public_user_profile_by_username(
+        &self,
+        username: &str,
+    ) -> Result<Option<PublicUserProfile>> {
+        self.fetch_json_opt(
+            r#"
+            select jsonb_build_object(
+                'user_id', user_id,
+                'username', username,
+                'bio', bio,
+                'bluesky_url', bluesky_url,
+                'company', company,
+                'facebook_url', facebook_url,
+                'github_url', github_url,
+                'linkedin_url', linkedin_url,
+                'name', name,
+                'photo_url', photo_url,
+                'title', title,
+                'twitter_url', twitter_url,
+                'website_url', website_url
+            )
+            from "user"
+            where lower(username) = lower($1::text)
+            and email_verified = true
+            and registration_status = 'registered';
+            "#,
+            &[&username],
+        )
+        .await
     }
 
     #[instrument(skip(self, user_id), err)]

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use cached::proc_macro::cached;
 use tokio_postgres::types::Json;
@@ -24,6 +24,7 @@ use crate::{
             invitation_requests::{InvitationRequestsFilters, InvitationRequestsOutput},
             members::{GroupMembersFilters, GroupMembersOutput},
             sponsors::{GroupSponsorsFilters, GroupSponsorsOutput, Sponsor},
+            spotlights::{GroupMemberSpotlight, SpotlightInput},
             submissions::{
                 CfsSubmissionNotificationData, CfsSubmissionUpdate, CfsSubmissionsFilters,
                 CfsSubmissionsOutput,
@@ -79,6 +80,14 @@ pub(crate) trait DBDashboardGroup {
         actor_user_id: Uuid,
         group_id: Uuid,
         sponsor: &Sponsor,
+    ) -> Result<Uuid>;
+
+    /// Adds a new member spotlight.
+    async fn add_group_member_spotlight(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &SpotlightInput,
     ) -> Result<Uuid>;
 
     /// Adds a user to the group team (pending by default).
@@ -138,6 +147,14 @@ pub(crate) trait DBDashboardGroup {
         actor_user_id: Uuid,
         group_id: Uuid,
         user_id: Uuid,
+    ) -> Result<()>;
+
+    /// Deletes a member spotlight.
+    async fn delete_group_member_spotlight(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        group_member_spotlight_id: Uuid,
     ) -> Result<()>;
 
     /// Deletes event series events atomically.
@@ -264,6 +281,13 @@ pub(crate) trait DBDashboardGroup {
         group_id: Uuid,
         filters: &GroupMembersFilters,
     ) -> Result<GroupMembersOutput>;
+
+    /// Lists member spotlights for one group.
+    async fn list_group_member_spotlights(
+        &self,
+        group_id: Uuid,
+        include_unpublished: bool,
+    ) -> Result<Vec<GroupMemberSpotlight>>;
 
     /// Lists all group member user ids.
     async fn list_group_members_ids(&self, group_id: Uuid) -> Result<Vec<Uuid>>;
@@ -400,6 +424,15 @@ pub(crate) trait DBDashboardGroup {
         sponsor: &Sponsor,
     ) -> Result<()>;
 
+    /// Updates a member spotlight.
+    async fn update_group_member_spotlight(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        group_member_spotlight_id: Uuid,
+        input: &SpotlightInput,
+    ) -> Result<()>;
+
     /// Updates the featured flag for an existing sponsor.
     async fn update_group_sponsor_featured(
         &self,
@@ -438,6 +471,61 @@ where
             &[&actor_user_id, &group_id, &event_id, &user_id],
         )
         .await
+    }
+
+    /// [`DBDashboardGroup::add_group_member_spotlight`]
+    #[instrument(skip(self, input), err)]
+    async fn add_group_member_spotlight(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &SpotlightInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_opt(
+            "
+            insert into group_member_spotlight (
+                group_id,
+                user_id,
+                created_by,
+                title,
+                story,
+                image_url,
+                link_url,
+                featured,
+                published
+            )
+            select
+                $2::uuid,
+                $3::uuid,
+                $1::uuid,
+                $4::text,
+                $5::text,
+                $6::text,
+                $7::text,
+                $8::boolean,
+                $9::boolean
+            where exists (
+                select 1
+                from group_member
+                where group_id = $2::uuid
+                and user_id = $3::uuid
+            )
+            returning group_member_spotlight_id;
+            ",
+            &[
+                &actor_user_id,
+                &group_id,
+                &input.user_id,
+                &input.title,
+                &input.story,
+                &input.image_url,
+                &input.link_url,
+                &input.featured,
+                &input.published,
+            ],
+        )
+        .await?
+        .context("spotlighted user is not a member of this group")
     }
 
     /// [`DBDashboardGroup::add_event`]
@@ -618,6 +706,25 @@ where
         self.execute(
             "select delete_group_member($1::uuid, $2::uuid, $3::uuid)",
             &[&actor_user_id, &group_id, &user_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::delete_group_member_spotlight`]
+    #[instrument(skip(self), err)]
+    async fn delete_group_member_spotlight(
+        &self,
+        _actor_user_id: Uuid,
+        group_id: Uuid,
+        group_member_spotlight_id: Uuid,
+    ) -> Result<()> {
+        self.execute(
+            "
+            delete from group_member_spotlight
+            where group_id = $1::uuid
+            and group_member_spotlight_id = $2::uuid;
+            ",
+            &[&group_id, &group_member_spotlight_id],
         )
         .await
     }
@@ -915,6 +1022,45 @@ where
         self.fetch_json_one(
             "select list_group_members($1::uuid, $2::jsonb)",
             &[&group_id, &Json(filters)],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::list_group_member_spotlights`]
+    #[instrument(skip(self), err)]
+    async fn list_group_member_spotlights(
+        &self,
+        group_id: Uuid,
+        include_unpublished: bool,
+    ) -> Result<Vec<GroupMemberSpotlight>> {
+        self.fetch_json_one(
+            "
+            select coalesce(jsonb_agg(jsonb_build_object(
+                'group_member_spotlight_id', s.group_member_spotlight_id,
+                'group_id', s.group_id,
+                'user_id', s.user_id,
+                'created_by', s.created_by,
+                'title', s.title,
+                'story', s.story,
+                'image_url', s.image_url,
+                'link_url', s.link_url,
+                'featured', s.featured,
+                'published', s.published,
+                'created_at', extract(epoch from s.created_at)::bigint,
+                'updated_at', extract(epoch from s.updated_at)::bigint,
+                'username', u.username,
+                'name', u.name,
+                'photo_url', u.photo_url,
+                'member_title', u.title,
+                'company', u.company,
+                'bio', u.bio
+            ) order by s.featured desc, s.created_at desc), '[]'::jsonb)
+            from group_member_spotlight s
+            join \"user\" u using (user_id)
+            where s.group_id = $1::uuid
+            and ($2::boolean or s.published);
+            ",
+            &[&group_id, &include_unpublished],
         )
         .await
     }
@@ -1234,6 +1380,51 @@ where
         self.execute(
             "select update_group_sponsor($1::uuid, $2::uuid, $3::uuid, $4::jsonb)",
             &[&actor_user_id, &group_id, &group_sponsor_id, &Json(sponsor)],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::update_group_member_spotlight`]
+    #[instrument(skip(self, input), err)]
+    async fn update_group_member_spotlight(
+        &self,
+        _actor_user_id: Uuid,
+        group_id: Uuid,
+        group_member_spotlight_id: Uuid,
+        input: &SpotlightInput,
+    ) -> Result<()> {
+        self.execute(
+            "
+            update group_member_spotlight
+            set
+                user_id = $3::uuid,
+                title = $4::text,
+                story = $5::text,
+                image_url = $6::text,
+                link_url = $7::text,
+                featured = $8::boolean,
+                published = $9::boolean,
+                updated_at = current_timestamp
+            where group_id = $1::uuid
+            and group_member_spotlight_id = $2::uuid
+            and exists (
+                select 1
+                from group_member
+                where group_id = $1::uuid
+                and user_id = $3::uuid
+            );
+            ",
+            &[
+                &group_id,
+                &group_member_spotlight_id,
+                &input.user_id,
+                &input.title,
+                &input.story,
+                &input.image_url,
+                &input.link_url,
+                &input.featured,
+                &input.published,
+            ],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -55,6 +55,10 @@ mock! {
             &self,
             username: &str,
         ) -> Result<Option<crate::auth::User>>;
+        async fn get_public_user_profile_by_username(
+            &self,
+            username: &str,
+        ) -> Result<Option<crate::types::user::PublicUserProfile>>;
         async fn get_user_password(&self, user_id: &Uuid) -> Result<Option<String>>;
         async fn is_linkedin_subject_blocked(&self, linkedin_subject: &str) -> Result<bool>;
         async fn group_belongs_to_alliance(
@@ -348,6 +352,12 @@ mock! {
             group_id: Uuid,
             sponsor: &crate::templates::dashboard::group::sponsors::Sponsor,
         ) -> Result<Uuid>;
+        async fn add_group_member_spotlight(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            input: &crate::templates::dashboard::group::spotlights::SpotlightInput,
+        ) -> Result<Uuid>;
         async fn add_group_team_member(
             &self,
             actor_user_id: Uuid,
@@ -394,6 +404,12 @@ mock! {
             actor_user_id: Uuid,
             group_id: Uuid,
             user_id: Uuid,
+        ) -> Result<()>;
+        async fn delete_group_member_spotlight(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            group_member_spotlight_id: Uuid,
         ) -> Result<()>;
         async fn delete_group_sponsor(
             &self,
@@ -488,6 +504,11 @@ mock! {
             group_id: Uuid,
             filters: &crate::templates::dashboard::group::members::GroupMembersFilters,
         ) -> Result<crate::templates::dashboard::group::members::GroupMembersOutput>;
+        async fn list_group_member_spotlights(
+            &self,
+            group_id: Uuid,
+            include_unpublished: bool,
+        ) -> Result<Vec<crate::templates::dashboard::group::spotlights::GroupMemberSpotlight>>;
         async fn list_group_members_ids(
             &self,
             group_id: Uuid,
@@ -584,6 +605,13 @@ mock! {
             group_id: Uuid,
             group_sponsor_id: Uuid,
             sponsor: &crate::templates::dashboard::group::sponsors::Sponsor,
+        ) -> Result<()>;
+        async fn update_group_member_spotlight(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            group_member_spotlight_id: Uuid,
+            input: &crate::templates::dashboard::group::spotlights::SpotlightInput,
         ) -> Result<()>;
         async fn update_group_sponsor_featured(
             &self,

--- a/ocg-server/src/handlers/dashboard/group.rs
+++ b/ocg-server/src/handlers/dashboard/group.rs
@@ -30,6 +30,7 @@ pub(crate) mod logs;
 pub(crate) mod members;
 pub(crate) mod settings;
 pub(crate) mod sponsors;
+pub(crate) mod spotlights;
 pub(crate) mod submissions;
 pub(crate) mod team;
 pub(crate) mod waitlist;

--- a/ocg-server/src/handlers/dashboard/group/home.rs
+++ b/ocg-server/src/handlers/dashboard/group/home.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_messages::Messages;
 use tracing::instrument;
 
-use super::{events, logs, members, sponsors, team};
+use super::{events, logs, members, sponsors, spotlights, team};
 
 use crate::{
     auth::AuthSession,
@@ -129,6 +129,11 @@ pub(crate) async fn page(
             )
             .await?;
             Content::Sponsors(template)
+        }
+        Tab::Spotlights => {
+            let template =
+                spotlights::prepare_list_page(&db, alliance_id, group_id, user.user_id).await?;
+            Content::Spotlights(template)
         }
         Tab::Team => {
             let (_, template) = team::prepare_list_page(

--- a/ocg-server/src/handlers/dashboard/group/spotlights.rs
+++ b/ocg-server/src/handlers/dashboard/group/spotlights.rs
@@ -1,0 +1,120 @@
+//! HTTP handlers for group member spotlights.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::{HeaderName, StatusCode},
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId, ValidatedForm},
+    },
+    templates::dashboard::group::{
+        members::GroupMembersFilters,
+        spotlights::{self, SpotlightInput},
+    },
+    types::permissions::GroupPermission,
+};
+
+const DASHBOARD_URL: &str = "/dashboard/group?tab=spotlights";
+
+/// Displays group member spotlights.
+#[instrument(skip_all, err)]
+pub(crate) async fn list_page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let template = prepare_list_page(&db, alliance_id, group_id, user.user_id).await?;
+    let headers = [(
+        HeaderName::from_static("hx-push-url"),
+        DASHBOARD_URL.to_string(),
+    )];
+
+    Ok((headers, Html(template.render()?)))
+}
+
+/// Adds a group member spotlight.
+#[instrument(skip_all, err)]
+pub(crate) async fn add(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<SpotlightInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_group_member_spotlight(user.user_id, group_id, &input).await?;
+    Ok((
+        StatusCode::CREATED,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    ))
+}
+
+/// Updates a group member spotlight.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(spotlight_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<SpotlightInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_group_member_spotlight(user.user_id, group_id, spotlight_id, &input)
+        .await?;
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    ))
+}
+
+/// Deletes a group member spotlight.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(spotlight_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_group_member_spotlight(user.user_id, group_id, spotlight_id)
+        .await?;
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    ))
+}
+
+/// Prepares the spotlights list template.
+pub(crate) async fn prepare_list_page(
+    db: &DynDB,
+    alliance_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<spotlights::ListPage, HandlerError> {
+    let member_filters = GroupMembersFilters {
+        limit: Some(500),
+        offset: Some(0),
+        query: None,
+    };
+    let (can_manage_spotlights, spotlights, members) = tokio::try_join!(
+        db.user_has_group_permission(
+            &alliance_id,
+            &group_id,
+            &user_id,
+            GroupPermission::MembersWrite,
+        ),
+        db.list_group_member_spotlights(group_id, true),
+        db.list_group_members(group_id, &member_filters),
+    )?;
+
+    Ok(spotlights::ListPage {
+        can_manage_spotlights,
+        spotlights,
+        members: members.members,
+    })
+}

--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 use crate::{
     activity_tracker::{Activity, DynActivityTracker},
+    auth::AuthSession,
     config::HttpServerConfig,
     db::DynDB,
     handlers::{
@@ -23,7 +24,7 @@ use crate::{
     templates::{
         PageId,
         auth::User,
-        group::{self, Page},
+        group::{self, Page, SpotlightsPage},
         notifications::GroupWelcome,
     },
     types::{event::EventKind, group::GroupFull},
@@ -95,6 +96,43 @@ pub(crate) async fn page(
     };
 
     Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
+}
+
+/// Handler that renders logged-in group member spotlights.
+#[instrument(skip_all)]
+pub(crate) async fn spotlights_page(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((alliance_name, group_slug)): Path<(String, String)>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let Some(mut group) = db.get_group_full_by_slug(alliance_id, &group_slug).await? else {
+        return not_found::render(site_settings);
+    };
+    trim_public_gallery_images(&mut group.photos_urls);
+    group.sponsors.clear();
+
+    let spotlights = db.list_group_member_spotlights(group.group_id, false).await?;
+    let template = SpotlightsPage {
+        base_url: server_cfg.base_url,
+        group,
+        page_id: PageId::Group,
+        path: uri.path().to_string(),
+        site_settings,
+        spotlights,
+        user: User::from_session(auth_session).await?,
+    };
+
+    Ok(Html(template.render()?).into_response())
 }
 
 // Helpers.

--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -6,6 +6,7 @@ pub(crate) mod home;
 pub(crate) mod jobs;
 pub(crate) mod landscape;
 pub(crate) mod not_found;
+pub(crate) mod profile;
 pub(crate) mod search;
 pub(crate) mod stats;
 pub(crate) mod wiki;

--- a/ocg-server/src/handlers/site/profile.rs
+++ b/ocg-server/src/handlers/site/profile.rs
@@ -1,0 +1,45 @@
+//! HTTP handlers for shareable user profile cards.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::Uri,
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+
+use crate::{
+    config::HttpServerConfig,
+    db::DynDB,
+    handlers::{error::HandlerError, site::not_found},
+    router::PUBLIC_SHARED_CACHE_HEADERS,
+    templates::{PageId, auth::User, site::profile::Page},
+};
+
+/// Renders a public profile card by username.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path(username): Path<String>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (site_settings, profile) = tokio::try_join!(
+        db.get_site_settings(),
+        db.get_public_user_profile_by_username(&username)
+    )?;
+    let Some(profile) = profile else {
+        return not_found::render(site_settings);
+    };
+
+    let template = Page {
+        base_url: server_cfg.base_url,
+        path: uri.path().to_string(),
+        page_id: PageId::SiteHome,
+        profile,
+        site_settings,
+        user: User::default(),
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
+}

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -213,6 +213,10 @@ pub(crate) async fn setup(
             "/{alliance}/group/{group_id}/membership",
             get(group::membership_status),
         )
+        .route(
+            "/{alliance}/group/{group_slug}/spotlights",
+            get(group::spotlights_page),
+        )
         .route("/jobs/{job_id}/apply", post(site::jobs::apply))
         // Protected dashboard routes
         .route(
@@ -292,6 +296,7 @@ pub(crate) async fn setup(
         .route("/jobs", get(site::jobs::page))
         .route("/jobs/{slug}", get(site::jobs::details))
         .route("/landscape", get(site::landscape::page))
+        .route("/profiles/{username}", get(site::profile::page))
         .route("/search", get(site::search::page))
         .route("/stats", get(site::stats::page))
         .route("/wiki", get(site::wiki::page))

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -285,6 +285,7 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
         )
         .route("/logs", get(dashboard::group::logs::list_page))
         .route("/members", get(dashboard::group::members::list_page))
+        .route("/spotlights", get(dashboard::group::spotlights::list_page))
         .route(
             "/settings/update",
             get(dashboard::group::settings::update_page),
@@ -380,6 +381,11 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
         .route(
             "/notifications",
             post(dashboard::group::members::send_group_custom_notification),
+        )
+        .route("/spotlights", post(dashboard::group::spotlights::add))
+        .route(
+            "/spotlights/{spotlight_id}",
+            put(dashboard::group::spotlights::update).delete(dashboard::group::spotlights::delete),
         )
         .route_layer(check_selected_group_permission(
             GroupPermission::MembersWrite,

--- a/ocg-server/src/templates/dashboard/group.rs
+++ b/ocg-server/src/templates/dashboard/group.rs
@@ -8,6 +8,7 @@ pub(crate) mod invitation_requests;
 pub(crate) mod members;
 pub(crate) mod settings;
 pub(crate) mod sponsors;
+pub(crate) mod spotlights;
 pub(crate) mod submissions;
 pub(crate) mod team;
 pub(crate) mod waitlist;

--- a/ocg-server/src/templates/dashboard/group/home.rs
+++ b/ocg-server/src/templates/dashboard/group/home.rs
@@ -11,7 +11,7 @@ use crate::{
         auth::User,
         dashboard::{
             audit,
-            group::{analytics, events, members, settings, sponsors, team},
+            group::{analytics, events, members, settings, sponsors, spotlights, team},
         },
         filters,
         helpers::user_initials,
@@ -89,6 +89,8 @@ pub(crate) enum Content {
     Settings(Box<settings::UpdatePage>),
     /// Sponsors management page.
     Sponsors(sponsors::ListPage),
+    /// Member spotlight management page.
+    Spotlights(spotlights::ListPage),
     /// Team management page.
     Team(team::ListPage),
 }
@@ -124,6 +126,11 @@ impl Content {
         matches!(self, Content::Sponsors(_))
     }
 
+    /// Check if the content is the spotlights page.
+    fn is_spotlights(&self) -> bool {
+        matches!(self, Content::Spotlights(_))
+    }
+
     /// Check if the content is the team page.
     fn is_team(&self) -> bool {
         matches!(self, Content::Team(_))
@@ -139,6 +146,7 @@ impl std::fmt::Display for Content {
             Content::Members(template) => write!(f, "{}", template.render()?),
             Content::Settings(template) => write!(f, "{}", template.render()?),
             Content::Sponsors(template) => write!(f, "{}", template.render()?),
+            Content::Spotlights(template) => write!(f, "{}", template.render()?),
             Content::Team(template) => write!(f, "{}", template.render()?),
         }
     }
@@ -164,6 +172,8 @@ pub(crate) enum Tab {
     Settings,
     /// Sponsors management tab.
     Sponsors,
+    /// Member spotlight management tab.
+    Spotlights,
     /// Team management tab.
     Team,
 }

--- a/ocg-server/src/templates/dashboard/group/spotlights.rs
+++ b/ocg-server/src/templates/dashboard/group/spotlights.rs
@@ -1,0 +1,118 @@
+//! Templates and types for group member spotlights.
+
+use askama::Template;
+use chrono::{DateTime, Utc};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use uuid::Uuid;
+
+use crate::{
+    templates::{dashboard::group::members::GroupMember, helpers::user_initials},
+    validation::{
+        MAX_LEN_DESCRIPTION, MAX_LEN_L, MAX_LEN_M, image_url_opt, trimmed_non_empty,
+        trimmed_non_empty_opt,
+    },
+};
+
+/// Group dashboard spotlight management page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/group/spotlights_list.html")]
+pub(crate) struct ListPage {
+    /// Whether the current user can manage spotlights.
+    pub can_manage_spotlights: bool,
+    /// Existing spotlights for the selected group.
+    pub spotlights: Vec<GroupMemberSpotlight>,
+    /// Group members eligible for spotlighting.
+    pub members: Vec<GroupMember>,
+}
+
+/// Dashboard form payload for creating or updating a spotlight.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct SpotlightInput {
+    /// Highlighted group member.
+    #[garde(skip)]
+    pub user_id: Uuid,
+    /// Story title.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub title: String,
+    /// Story body.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION))]
+    pub story: String,
+    /// Optional image URL for the story card.
+    #[garde(custom(image_url_opt))]
+    pub image_url: Option<String>,
+    /// Optional link to a deeper article, demo, video, or profile.
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
+    pub link_url: Option<String>,
+    /// Whether the spotlight should be emphasized.
+    #[serde(default)]
+    #[garde(skip)]
+    pub featured: bool,
+    /// Whether the spotlight is visible.
+    #[serde(default = "default_published")]
+    #[garde(skip)]
+    pub published: bool,
+}
+
+/// Spotlight record with public member profile fields.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GroupMemberSpotlight {
+    /// Spotlight identifier.
+    pub group_member_spotlight_id: Uuid,
+    /// Group identifier.
+    pub group_id: Uuid,
+    /// Highlighted user identifier.
+    pub user_id: Uuid,
+    /// Creating user identifier.
+    pub created_by: Uuid,
+    /// Story title.
+    pub title: String,
+    /// Story body.
+    pub story: String,
+    /// Optional story image.
+    pub image_url: Option<String>,
+    /// Optional external link.
+    pub link_url: Option<String>,
+    /// Whether the story is emphasized.
+    pub featured: bool,
+    /// Whether the story is visible.
+    pub published: bool,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    /// Last update time.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+
+    /// Member username.
+    pub username: String,
+    /// Member display name.
+    pub name: Option<String>,
+    /// Member avatar URL.
+    pub photo_url: Option<String>,
+    /// Member job title.
+    pub member_title: Option<String>,
+    /// Member company.
+    pub company: Option<String>,
+    /// Member biography.
+    pub bio: Option<String>,
+}
+
+impl GroupMemberSpotlight {
+    /// Shareable profile path for the spotlighted member.
+    pub(crate) fn profile_path(&self) -> String {
+        format!("/profiles/{}", self.username)
+    }
+
+    /// Display label for the spotlighted member.
+    pub(crate) fn member_display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.username)
+    }
+}
+
+fn default_published() -> bool {
+    true
+}

--- a/ocg-server/src/templates/group.rs
+++ b/ocg-server/src/templates/group.rs
@@ -4,6 +4,7 @@ use askama::Template;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    templates::dashboard::group::spotlights::GroupMemberSpotlight,
     templates::{
         PageId,
         auth::User,
@@ -41,6 +42,26 @@ pub(crate) struct Page {
     pub user: User,
 }
 
+/// Logged-in group member spotlights page template.
+#[derive(Debug, Clone, Template)]
+#[template(path = "group/spotlights.html")]
+pub(crate) struct SpotlightsPage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Detailed information about the group.
+    pub group: GroupFull,
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Published member spotlights.
+    pub spotlights: Vec<GroupMemberSpotlight>,
+    /// Authenticated user information.
+    pub user: User,
+}
+
 impl Page {
     /// Returns the canonical public URL for the group page.
     pub(crate) fn canonical_url(&self) -> String {
@@ -74,6 +95,39 @@ impl Page {
     /// Returns the preview title for the group page.
     pub(crate) fn preview_title(&self) -> String {
         self.group.name.clone()
+    }
+}
+
+impl SpotlightsPage {
+    /// Returns the canonical URL for the group spotlights page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!(
+                "/{}/group/{}/spotlights",
+                self.group.alliance.name,
+                self.group.public_slug()
+            ),
+        )
+    }
+
+    /// Returns the preview title.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} Member Spotlights", self.group.name)
+    }
+
+    /// Returns the preview description.
+    pub(crate) fn preview_description(&self) -> String {
+        format!("Success stories from members of {}.", self.group.name)
+    }
+
+    /// Returns the Open Graph image URL for the page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.group
+            .og_image_url
+            .as_deref()
+            .or(self.group.alliance.og_image_url.as_deref())
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
     }
 }
 

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -12,6 +12,8 @@ pub(crate) mod jobs;
 pub(crate) mod landscape;
 /// Templates for the not found page.
 pub(crate) mod not_found;
+/// Templates for shareable profile cards.
+pub(crate) mod profile;
 /// Templates for the site search page.
 pub(crate) mod search;
 /// Templates for the stats page.

--- a/ocg-server/src/templates/site/profile.rs
+++ b/ocg-server/src/templates/site/profile.rs
@@ -1,0 +1,77 @@
+//! Templates for shareable public profile cards.
+
+use askama::Template;
+
+use crate::{
+    templates::{
+        PageId,
+        auth::User,
+        filters,
+        helpers::{self, user_initials},
+    },
+    types::{site::SiteSettings, user::PublicUserProfile},
+};
+
+/// Shareable user profile card page.
+#[derive(Debug, Clone, Template)]
+#[template(path = "site/profile.html")]
+pub(crate) struct Page {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Current path.
+    pub path: String,
+    /// Page identifier.
+    pub page_id: PageId,
+    /// Public user profile.
+    pub profile: PublicUserProfile,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+}
+
+impl Page {
+    /// Canonical URL for the profile card.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!("/profiles/{}", self.profile.username),
+        )
+    }
+
+    /// Preview title for social shares.
+    pub(crate) fn preview_title(&self) -> String {
+        format!(
+            "{} on GOUP",
+            self.profile.name.as_deref().unwrap_or(&self.profile.username)
+        )
+    }
+
+    /// Preview description without exposing private email.
+    pub(crate) fn preview_description(&self) -> String {
+        let mut parts = Vec::new();
+        if let Some(title) = self.profile.title.as_deref() {
+            parts.push(title);
+        }
+        if let Some(company) = self.profile.company.as_deref() {
+            parts.push(company);
+        }
+        if parts.is_empty() {
+            return self
+                .profile
+                .bio
+                .clone()
+                .unwrap_or_else(|| "A GOUP community member profile.".to_string());
+        }
+        parts.join(" at ")
+    }
+
+    /// `OpenGraph` image URL for the profile.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.profile
+            .photo_url
+            .as_deref()
+            .or(self.site_settings.og_image_url.as_deref())
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+}

--- a/ocg-server/src/types/user.rs
+++ b/ocg-server/src/types/user.rs
@@ -39,6 +39,39 @@ pub(crate) struct User {
     pub website_url: Option<String>,
 }
 
+/// Public profile data safe to show on shareable profile cards.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct PublicUserProfile {
+    /// User identifier.
+    pub user_id: Uuid,
+    /// Username.
+    pub username: String,
+
+    /// Short biography.
+    pub bio: Option<String>,
+    /// Bluesky profile URL.
+    pub bluesky_url: Option<String>,
+    /// Company the user works for.
+    pub company: Option<String>,
+    /// Facebook profile URL.
+    pub facebook_url: Option<String>,
+    /// GitHub profile URL.
+    pub github_url: Option<String>,
+    /// `LinkedIn` profile URL.
+    pub linkedin_url: Option<String>,
+    /// Full name.
+    pub name: Option<String>,
+    /// URL to user's avatar.
+    pub photo_url: Option<String>,
+    /// User's job title.
+    pub title: Option<String>,
+    /// Twitter profile URL.
+    pub twitter_url: Option<String>,
+    /// Personal website URL.
+    pub website_url: Option<String>,
+}
+
 /// Summary user information.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct UserSummary {

--- a/ocg-server/static/js/common/modals/user-info-modal.js
+++ b/ocg-server/static/js/common/modals/user-info-modal.js
@@ -216,6 +216,26 @@ export class UserInfoModal extends LitWrapper {
     `;
   }
 
+  _renderProfileCardLink() {
+    const username = this._userData?.username?.trim();
+
+    if (!username) {
+      return "";
+    }
+
+    return html`
+      <a
+        href=${`/profiles/${encodeURIComponent(username)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group btn-primary-outline-anchor inline-flex max-w-full items-center justify-center gap-2 h-10 md:h-[30px]"
+      >
+        <span>Share profile card</span>
+        <div class="svg-icon size-3 icon-external-link"></div>
+      </a>
+    `;
+  }
+
   _renderProfilePlaceholder(bio, socialLinks) {
     if (this._hasProfileDetails(bio, socialLinks)) {
       return "";
@@ -266,6 +286,7 @@ export class UserInfoModal extends LitWrapper {
               </h3>
               <div class="flex shrink-0 items-center gap-3 sm:gap-5 sm:pe-2">
                 ${this._renderLinuxFoundationLink()}
+                ${this._renderProfileCardLink()}
                 <button
                   type="button"
                   class="group shrink-0 text-stone-400 bg-transparent hover:bg-stone-200 hover:text-stone-900 transition-colors rounded-lg text-sm w-10 h-10 inline-flex justify-center items-center"

--- a/ocg-server/templates/dashboard/group/home.html
+++ b/ocg-server/templates/dashboard/group/home.html
@@ -96,6 +96,7 @@
     <div class="leading-10 pt-6 border-t border-stone-200 grid gap-y-0.5">
       {{ dashboard::menu_title(text = "Members and sponsors", extra_styles = "py-1.5") -}}
       {{ dashboard::menu_item(name = "Members", icon = "members", is_active = content.is_members() , href = "/dashboard/group?tab=members") -}}
+      {{ dashboard::menu_item(name = "Spotlights", icon = "star", is_active = content.is_spotlights() , href = "/dashboard/group?tab=spotlights") -}}
       {{ dashboard::menu_item(name = "Sponsors", icon = "handshake", is_active = content.is_sponsors() , href = "/dashboard/group?tab=sponsors") -}}
     </div>
     {# End members and sponsors -#}
@@ -120,7 +121,7 @@
        data-alliance-banner-mobile-url="{{ current_selection.0.banner_mobile_url }}"
        data-group-name="{{ current_selection.1.name }}"
        data-group-slug="{{ current_selection.1.public_slug() }}"
-       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else -%}events{%- endif -%}"
+       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_spotlights() -%}spotlights{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else -%}events{%- endif -%}"
        hx-trigger="refresh-group-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/dashboard/group/spotlights_list.html
+++ b/ocg-server/templates/dashboard/group/spotlights_list.html
@@ -1,0 +1,212 @@
+{% import "macros/ui.html" as ui -%}
+{% import "macros/dashboard.html" as dashboard -%}
+
+{{ dashboard::page_title(title = "Member Spotlights") -}}
+
+<div class="my-5 grid gap-6">
+  <section class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-stone-950">Add a success story</h2>
+        <p class="mt-1 text-sm text-stone-600">Highlight a member story with an optional image and link. Only group admins can manage these cards.</p>
+      </div>
+      {% if !can_manage_spotlights -%}
+        <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600">Read only</span>
+      {% endif -%}
+    </div>
+
+    <form class="mt-5 grid gap-4"
+          hx-post="/dashboard/group/spotlights"
+          hx-target="#dashboard-content"
+          hx-indicator="#dashboard-spinner"
+          {% if !can_manage_spotlights || members.is_empty() -%}
+            inert
+          {% endif -%}>
+      <div class="grid gap-4 lg:grid-cols-2">
+        <label class="block">
+          <span class="label-primary">Member</span>
+          <select name="user_id" class="input-primary mt-1" required>
+            {% for member in members -%}
+              <option value="{{ member.user_id }}">{{ member.name.as_deref().unwrap_or(&member.username) }} (@{{ member.username }})</option>
+            {% endfor -%}
+          </select>
+        </label>
+        <label class="block">
+          <span class="label-primary">Title</span>
+          <input name="title"
+                 class="input-primary mt-1"
+                 maxlength="{{ crate::validation::MAX_LEN_M }}"
+                 placeholder="How this member moved the community forward"
+                 required>
+        </label>
+      </div>
+      <label class="block">
+        <span class="label-primary">Story</span>
+        <textarea name="story"
+                  class="input-primary mt-1 min-h-32"
+                  maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION }}"
+                  placeholder="Tell the member story, result, or lesson."
+                  required></textarea>
+      </label>
+      <div class="grid gap-4 lg:grid-cols-2">
+        <label class="block">
+          <span class="label-primary">Image URL</span>
+          <input name="image_url" class="input-primary mt-1" placeholder="https://...">
+        </label>
+        <label class="block">
+          <span class="label-primary">Link URL</span>
+          <input name="link_url" class="input-primary mt-1" placeholder="https://...">
+        </label>
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <label class="block">
+          <span class="label-primary">Featured</span>
+          <select name="featured" class="input-primary mt-1">
+            <option value="false">No</option>
+            <option value="true">Yes</option>
+          </select>
+        </label>
+        <label class="block">
+          <span class="label-primary">Published</span>
+          <select name="published" class="input-primary mt-1">
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <button type="submit"
+                class="btn-primary"
+                {% if !can_manage_spotlights || members.is_empty() -%}
+                  disabled
+                {% endif -%}>Add spotlight</button>
+      </div>
+    </form>
+  </section>
+
+  {% if spotlights.is_empty() -%}
+    <section class="rounded-2xl border border-dashed border-stone-300 bg-white px-8 py-12 text-center">
+      <div class="mx-auto flex size-12 items-center justify-center rounded-full bg-primary-50">
+        <div class="svg-icon size-6 icon-star bg-primary-500"></div>
+      </div>
+      <h2 class="mt-4 text-lg font-semibold text-stone-950">No member spotlights yet</h2>
+      <p class="mt-2 text-sm text-stone-600">Add a story to celebrate members, projects, launches, and community wins.</p>
+    </section>
+  {% else -%}
+    <section class="grid gap-5 xl:grid-cols-2">
+      {% for spotlight in spotlights -%}
+        <article class="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
+          {% if let Some(image_url) = &spotlight.image_url -%}
+            <img src="{{ image_url }}"
+                 alt=""
+                 class="h-44 w-full object-cover"
+                 loading="lazy">
+          {% else -%}
+            <div class="h-2 bg-gradient-to-r from-primary-500 via-primary-300 to-stone-100"></div>
+          {% endif -%}
+          <form class="grid gap-4 p-5"
+                hx-put="/dashboard/group/spotlights/{{ spotlight.group_member_spotlight_id }}"
+                hx-target="#dashboard-content"
+                hx-indicator="#dashboard-spinner"
+                {% if !can_manage_spotlights -%}
+                  inert
+                {% endif -%}>
+            <div class="flex items-start gap-3">
+              <logo-image
+              {% if let Some(photo_url) = &spotlight.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+              size="size-12" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
+              </logo-image>
+              <div class="min-w-0 flex-1">
+                <div class="font-semibold text-stone-950">{{ spotlight.member_display_name() }}</div>
+                <div class="text-sm text-stone-500">
+                  @{{ spotlight.username }}
+                  {% if let Some(member_title) = &spotlight.member_title -%}
+                    · {{ member_title }}
+                  {% endif -%}
+                  {% if let Some(company) = &spotlight.company -%}
+                    at {{ company }}
+                  {% endif -%}
+                </div>
+              </div>
+              <a href="{{ spotlight.profile_path() }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="btn-secondary-anchor btn-mini">Profile</a>
+            </div>
+
+            <input type="hidden" name="user_id" value="{{ spotlight.user_id }}">
+
+            <label class="block">
+              <span class="label-primary">Title</span>
+              <input name="title"
+                     class="input-primary mt-1"
+                     value="{{ spotlight.title }}"
+                     maxlength="{{ crate::validation::MAX_LEN_M }}"
+                     required>
+            </label>
+            <label class="block">
+              <span class="label-primary">Story</span>
+              <textarea name="story"
+                        class="input-primary mt-1 min-h-32"
+                        maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION }}"
+                        required>{{ spotlight.story }}</textarea>
+            </label>
+            <div class="grid gap-4 lg:grid-cols-2">
+              <label class="block">
+                <span class="label-primary">Image URL</span>
+                <input name="image_url"
+                       class="input-primary mt-1"
+                       value="{{ spotlight.image_url.as_deref().unwrap_or("") }}">
+              </label>
+              <label class="block">
+                <span class="label-primary">Link URL</span>
+                <input name="link_url"
+                       class="input-primary mt-1"
+                       value="{{ spotlight.link_url.as_deref().unwrap_or("") }}">
+              </label>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <label class="block">
+                <span class="label-primary">Featured</span>
+                <select name="featured" class="input-primary mt-1">
+                  <option value="false" {% if !spotlight.featured %}selected{% endif %}>No</option>
+                  <option value="true" {% if spotlight.featured %}selected{% endif %}>Yes</option>
+                </select>
+              </label>
+              <label class="block">
+                <span class="label-primary">Published</span>
+                <select name="published" class="input-primary mt-1">
+                  <option value="true" {% if spotlight.published %}selected{% endif %}>Yes</option>
+                  <option value="false" {% if !spotlight.published %}selected{% endif %}>No</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <button type="submit"
+                      class="btn-primary"
+                      {% if !can_manage_spotlights -%}
+                        disabled
+                      {% endif -%}>Save</button>
+              <button type="button"
+                      class="btn-tertiary"
+                      hx-delete="/dashboard/group/spotlights/{{ spotlight.group_member_spotlight_id }}"
+                      hx-target="#dashboard-content"
+                      hx-indicator="#dashboard-spinner"
+                      hx-confirm="Delete this spotlight?"
+                      {% if !can_manage_spotlights -%}
+                        disabled
+                      {% endif -%}>Delete</button>
+              {% if let Some(link_url) = &spotlight.link_url -%}
+                <a href="{{ link_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="btn-secondary-anchor">Open link</a>
+              {% endif -%}
+            </div>
+          </form>
+        </article>
+      {% endfor -%}
+    </section>
+  {% endif -%}
+</div>

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -139,6 +139,11 @@
                   <div class="svg-icon size-4 icon-vertical-dots"></div>
                 </summary>
                 <div class="absolute left-4 z-20 mt-2 w-56 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-stone-200 bg-white py-1 shadow-lg sm:left-auto sm:right-0 sm:w-max sm:min-w-48">
+                  <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/spotlights"
+                     class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
+                    <div class="svg-icon size-4 icon-star bg-stone-600"></div>
+                    Member spotlights
+                  </a>
                   <share-modal trigger-variant="menu-item" title="{{ group.name }}" url="/{{ group.alliance.name }}/group/{{ group.public_slug() }}">
                   </share-modal>
                 </div>

--- a/ocg-server/templates/group/spotlights.html
+++ b/ocg-server/templates/group/spotlights.html
@@ -1,0 +1,110 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+{% import "macros/ui.html" as ui -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() |demoji }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &group.name) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block scripts -%}
+  <script type="module" src="/static/js/common/modals/share-modal.js"></script>
+{% endblock scripts -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl p-4 sm:p-6 lg:p-8">
+    <div class="rounded-3xl border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+      <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}"
+             class="text-sm font-medium text-primary-700 hover:text-primary-900">← Back to {{ group.name|demoji }}</a>
+          <h1 class="mt-4 text-3xl font-semibold text-stone-950 sm:text-4xl">Member spotlights</h1>
+          <p class="mt-3 max-w-2xl text-base leading-7 text-stone-600">Success stories from {{ group.name|demoji }} members.</p>
+        </div>
+        <share-modal trigger-variant="button" title="{{ self.preview_title() }}" url="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/spotlights">
+        </share-modal>
+      </div>
+
+      {% if spotlights.is_empty() -%}
+        <div class="mt-10 rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-8 py-12 text-center">
+          <div class="mx-auto flex size-12 items-center justify-center rounded-full bg-primary-50">
+            <div class="svg-icon size-6 icon-star bg-primary-500"></div>
+          </div>
+          <h2 class="mt-4 text-lg font-semibold text-stone-950">No spotlights published yet</h2>
+          <p class="mt-2 text-sm text-stone-600">Check back for member stories and community wins.</p>
+        </div>
+      {% else -%}
+        <div class="mt-10 grid gap-6 lg:grid-cols-2">
+          {% for spotlight in spotlights -%}
+            <article class="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
+              {% if let Some(image_url) = &spotlight.image_url -%}
+                <img src="{{ image_url }}"
+                     alt=""
+                     class="h-56 w-full object-cover"
+                     loading="lazy">
+              {% else -%}
+                <div class="h-2 bg-gradient-to-r from-primary-500 via-primary-300 to-stone-100"></div>
+              {% endif -%}
+              <div class="p-6">
+                {% if spotlight.featured -%}
+                  <span class="inline-flex items-center gap-1.5 rounded-full bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700">
+                    <div class="svg-icon size-3 icon-star bg-primary-600"></div>
+                    Featured
+                  </span>
+                {% endif -%}
+                <h2 class="mt-4 text-2xl font-semibold text-stone-950">{{ spotlight.title }}</h2>
+                <p class="mt-4 whitespace-pre-line text-base leading-7 text-stone-700">{{ spotlight.story }}</p>
+                <div class="mt-6 flex items-center gap-3 border-t border-stone-100 pt-5">
+                  <logo-image
+                  {% if let Some(photo_url) = &spotlight.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+                  size="size-12" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
+                  </logo-image>
+                  <div class="min-w-0 flex-1">
+                    <div class="font-semibold text-stone-950">{{ spotlight.member_display_name() }}</div>
+                    <div class="text-sm text-stone-500">
+                      @{{ spotlight.username }}
+                      {% if let Some(member_title) = &spotlight.member_title -%}
+                        · {{ member_title }}
+                      {% endif -%}
+                    </div>
+                  </div>
+                </div>
+                <div class="mt-5 flex flex-wrap gap-2">
+                  <a href="{{ spotlight.profile_path() }}"
+                     class="btn-primary-outline-anchor">View profile card</a>
+                  {% if let Some(link_url) = &spotlight.link_url -%}
+                    <a href="{{ link_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="btn-secondary-anchor">Read more</a>
+                  {% endif -%}
+                </div>
+              </div>
+            </article>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    </div>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/profile.html
+++ b/ocg-server/templates/site/profile.html
@@ -1,0 +1,113 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+{% import "macros/ui.html" as ui -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() |demoji }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = self.profile.name.as_deref().unwrap_or(&self.profile.username)) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block scripts -%}
+  <script type="module" src="/static/js/common/modals/share-modal.js"></script>
+{% endblock scripts -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-4xl p-4 sm:p-6 lg:p-10">
+    <article class="overflow-hidden rounded-3xl border border-stone-200 bg-white shadow-sm">
+      <div class="h-36 bg-gradient-to-br from-primary-100 via-white to-stone-100"></div>
+      <div class="-mt-16 px-6 pb-8 sm:px-10 sm:pb-10">
+        <div class="flex flex-col gap-6 sm:flex-row sm:items-end sm:justify-between">
+          <div class="flex flex-col gap-5 sm:flex-row sm:items-end">
+            <div class="rounded-3xl bg-white p-2 shadow-sm ring-1 ring-stone-200">
+              <logo-image
+              {% if let Some(photo_url) = &profile.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+              size="size-28" placeholder="{{ crate::templates::helpers::user_initials(profile.name.as_deref() , profile.username.as_str()) }}">
+              </logo-image>
+            </div>
+            <div class="min-w-0 pb-1">
+              <div class="text-sm font-semibold uppercase tracking-wide text-primary-600">@{{ profile.username }}</div>
+              <h1 class="mt-1 text-3xl font-semibold text-stone-950 sm:text-4xl">
+                {{ profile.name.as_deref().unwrap_or(&profile.username) }}
+              </h1>
+              {% if profile.title.is_some() || profile.company.is_some() -%}
+                <p class="mt-3 text-lg text-stone-600">
+                  {% if let Some(title) = &profile.title -%}
+                    {{ title }}
+                  {% endif -%}
+                  {% if profile.title.is_some() && profile.company.is_some() -%}
+                    <span class="text-stone-400">at</span>
+                  {% endif -%}
+                  {% if let Some(company) = &profile.company -%}
+                    {{ company }}
+                  {% endif -%}
+                </p>
+              {% endif -%}
+            </div>
+          </div>
+          <share-modal trigger-variant="button" title="{{ self.preview_title() }}" url="/profiles/{{ profile.username }}">
+          </share-modal>
+        </div>
+
+        {% if let Some(bio) = &profile.bio -%}
+          <p class="mt-8 max-w-3xl text-base leading-7 text-stone-700">{{ bio }}</p>
+        {% endif -%}
+
+        <div class="mt-8 border-t border-stone-200 pt-6">
+          <div class="text-sm font-semibold uppercase tracking-wide text-stone-500">Connect</div>
+          <div class="mt-4 flex flex-wrap gap-3">
+            {% if let Some(website_url) = &profile.website_url -%}
+              {{ social_link(url = website_url, icon = "website", label = "Website") }}
+            {% endif -%}
+            {% if let Some(linkedin_url) = &profile.linkedin_url -%}
+              {{ social_link(url = linkedin_url, icon = "linkedin", label = "LinkedIn") }}
+            {% endif -%}
+            {% if let Some(github_url) = &profile.github_url -%}
+              {{ social_link(url = github_url, icon = "github", label = "GitHub") }}
+            {% endif -%}
+            {% if let Some(bluesky_url) = &profile.bluesky_url -%}
+              {{ social_link(url = bluesky_url, icon = "bluesky", label = "Bluesky") }}
+            {% endif -%}
+            {% if let Some(twitter_url) = &profile.twitter_url -%}
+              {{ social_link(url = twitter_url, icon = "twitter", label = "X") }}
+            {% endif -%}
+            {% if let Some(facebook_url) = &profile.facebook_url -%}
+              {{ social_link(url = facebook_url, icon = "facebook", label = "Facebook") }}
+            {% endif -%}
+          </div>
+        </div>
+      </div>
+    </article>
+  </div>
+{% endblock content -%}
+
+{% macro social_link(url, icon, label) -%}
+  <a href="{{ url }}"
+     target="_blank"
+     rel="noopener noreferrer"
+     class="group btn-secondary-anchor p-3 flex items-center justify-center"
+     title="{{ label }}"
+     aria-label="{{ label }}">
+    <div class="svg-icon size-6 bg-primary-500 group-hover:bg-white transition-colors icon-{{ icon }}"></div>
+  </a>
+{% endmacro social_link -%}


### PR DESCRIPTION
## Summary
- Add group member spotlight storage plus dashboard CRUD for group admins with optional images, links, featured, and published states.
- Add a login-protected group spotlights page for published member success stories.
- Add public shareable profile cards at `/profiles/{username}` with social metadata and no email exposure, plus a profile-card link in the user info modal.

## Test plan
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `just db-tests` (blocked locally: PostgreSQL role `postgres` does not exist)


Made with [Cursor](https://cursor.com)