### PR TITLE
Add group swag store

### DIFF
--- a/database/migrations/schema/0011_group_store.sql
+++ b/database/migrations/schema/0011_group_store.sql
@@ -1,0 +1,26 @@
+create table if not exists group_store_item (
+    group_store_item_id uuid primary key default uuid_generate_v4(),
+    group_id uuid not null references "group" (group_id) on delete cascade,
+    created_by uuid not null references "user" (user_id),
+    name text not null,
+    description text,
+    image_url text,
+    price_minor bigint not null,
+    currency_code text not null default 'USD',
+    inventory_count integer,
+    checkout_url text not null,
+    featured boolean default false not null,
+    active boolean default true not null,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_store_item_name_check check (btrim(name) <> ''),
+    constraint group_store_item_description_check check (description is null or btrim(description) <> ''),
+    constraint group_store_item_image_url_check check (image_url is null or btrim(image_url) <> ''),
+    constraint group_store_item_price_minor_check check (price_minor >= 0),
+    constraint group_store_item_currency_code_check check (currency_code ~ '^[A-Z]{3}$'),
+    constraint group_store_item_inventory_count_check check (inventory_count is null or inventory_count >= 0),
+    constraint group_store_item_checkout_url_check check (btrim(checkout_url) <> '')
+);
+
+create index if not exists group_store_item_group_id_idx
+on group_store_item (group_id, active, featured desc, created_at desc);

--- a/database/tests/schema/01_extensions_and_tables.sql
+++ b/database/tests/schema/01_extensions_and_tables.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(68);
+select plan(69);
 
 -- ============================================================================
 -- TESTS
@@ -58,6 +58,7 @@ select has_table('group_role');
 select has_table('group_role_group_permission');
 select has_table('group_site_layout');
 select has_table('group_sponsor');
+select has_table('group_store_item');
 select has_table('group_team');
 select has_table('group_views');
 select has_table('images');

--- a/database/tests/schema/02_columns.sql
+++ b/database/tests/schema/02_columns.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(70);
+select plan(71);
 
 -- ============================================================================
 -- TESTS
@@ -598,6 +598,24 @@ select columns_are('group_sponsor', array[
     'name',
 
     'website_url'
+]);
+
+-- Test: group_store_item columns should match expected
+select columns_are('group_store_item', array[
+    'group_store_item_id',
+    'group_id',
+    'created_by',
+    'name',
+    'description',
+    'image_url',
+    'price_minor',
+    'currency_code',
+    'inventory_count',
+    'checkout_url',
+    'featured',
+    'active',
+    'created_at',
+    'updated_at'
 ]);
 
 -- Test: group_team columns should match expected

--- a/database/tests/schema/03_keys.sql
+++ b/database/tests/schema/03_keys.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(153);
+select plan(156);
 
 -- ============================================================================
 -- TESTS
@@ -51,6 +51,7 @@ select has_pk('group_role');
 select has_pk('group_role_group_permission');
 select has_pk('group_site_layout');
 select has_pk('group_sponsor');
+select has_pk('group_store_item');
 select has_pk('group_team');
 select hasnt_pk('group_views');
 select has_pk('images');
@@ -138,6 +139,8 @@ select col_is_fk('group_member', 'user_id', 'user');
 select col_is_fk('group_role_group_permission', 'group_permission_id', 'group_permission');
 select col_is_fk('group_role_group_permission', 'group_role_id', 'group_role');
 select col_is_fk('group_sponsor', 'group_id', 'group');
+select col_is_fk('group_store_item', 'created_by', 'user');
+select col_is_fk('group_store_item', 'group_id', 'group');
 select col_is_fk('group_team', 'group_id', 'group');
 select col_is_fk('group_team', 'role', 'group_role');
 select col_is_fk('group_team', 'user_id', 'user');

--- a/database/tests/schema/04_indexes.sql
+++ b/database/tests/schema/04_indexes.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(68);
+select plan(69);
 
 -- ============================================================================
 -- TESTS
@@ -302,6 +302,12 @@ select indexes_are('group_site_layout', array[
 select indexes_are('group_sponsor', array[
     'group_sponsor_pkey',
     'group_sponsor_group_id_idx'
+]);
+
+-- Test: group_store_item indexes should match expected
+select indexes_are('group_store_item', array[
+    'group_store_item_pkey',
+    'group_store_item_group_id_idx'
 ]);
 
 -- Test: event_speaker indexes should match expected

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -24,6 +24,7 @@ use crate::{
             invitation_requests::{InvitationRequestsFilters, InvitationRequestsOutput},
             members::{GroupMembersFilters, GroupMembersOutput},
             sponsors::{GroupSponsorsFilters, GroupSponsorsOutput, Sponsor},
+            store::{GroupStoreItem, StoreItemInput},
             submissions::{
                 CfsSubmissionNotificationData, CfsSubmissionUpdate, CfsSubmissionsFilters,
                 CfsSubmissionsOutput,
@@ -79,6 +80,14 @@ pub(crate) trait DBDashboardGroup {
         actor_user_id: Uuid,
         group_id: Uuid,
         sponsor: &Sponsor,
+    ) -> Result<Uuid>;
+
+    /// Adds a group store item.
+    async fn add_group_store_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &StoreItemInput,
     ) -> Result<Uuid>;
 
     /// Adds a user to the group team (pending by default).
@@ -154,6 +163,14 @@ pub(crate) trait DBDashboardGroup {
         actor_user_id: Uuid,
         group_id: Uuid,
         group_sponsor_id: Uuid,
+    ) -> Result<()>;
+
+    /// Deletes a group store item.
+    async fn delete_group_store_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        group_store_item_id: Uuid,
     ) -> Result<()>;
 
     /// Deletes a user from the group team.
@@ -280,6 +297,13 @@ pub(crate) trait DBDashboardGroup {
         full_list: bool,
     ) -> Result<GroupSponsorsOutput>;
 
+    /// Lists group store items.
+    async fn list_group_store_items(
+        &self,
+        group_id: Uuid,
+        include_inactive: bool,
+    ) -> Result<Vec<GroupStoreItem>>;
+
     /// Lists all group team members.
     async fn list_group_team_members(
         &self,
@@ -400,6 +424,15 @@ pub(crate) trait DBDashboardGroup {
         sponsor: &Sponsor,
     ) -> Result<()>;
 
+    /// Updates a group store item.
+    async fn update_group_store_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        group_store_item_id: Uuid,
+        input: &StoreItemInput,
+    ) -> Result<()>;
+
     /// Updates the featured flag for an existing sponsor.
     async fn update_group_sponsor_featured(
         &self,
@@ -436,6 +469,60 @@ where
         self.execute(
             "select accept_event_invitation_request($1::uuid, $2::uuid, $3::uuid, $4::uuid)",
             &[&actor_user_id, &group_id, &event_id, &user_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::add_group_store_item`]
+    #[instrument(skip(self, input), err)]
+    async fn add_group_store_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &StoreItemInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            "
+            insert into group_store_item (
+                group_id,
+                created_by,
+                name,
+                description,
+                image_url,
+                price_minor,
+                currency_code,
+                inventory_count,
+                checkout_url,
+                featured,
+                active
+            ) values (
+                $1::uuid,
+                $2::uuid,
+                $3::text,
+                $4::text,
+                $5::text,
+                $6::bigint,
+                upper($7::text),
+                $8::integer,
+                $9::text,
+                $10::boolean,
+                $11::boolean
+            )
+            returning group_store_item_id;
+            ",
+            &[
+                &group_id,
+                &actor_user_id,
+                &input.name,
+                &input.description,
+                &input.image_url,
+                &input.price_minor,
+                &input.currency_code,
+                &input.inventory_count,
+                &input.checkout_url,
+                &input.featured,
+                &input.active,
+            ],
         )
         .await
     }
@@ -648,6 +735,25 @@ where
         self.execute(
             "select delete_group_sponsor($1::uuid, $2::uuid, $3::uuid)",
             &[&actor_user_id, &group_id, &group_sponsor_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::delete_group_store_item`]
+    #[instrument(skip(self), err)]
+    async fn delete_group_store_item(
+        &self,
+        _actor_user_id: Uuid,
+        group_id: Uuid,
+        group_store_item_id: Uuid,
+    ) -> Result<()> {
+        self.execute(
+            "
+            delete from group_store_item
+            where group_id = $1::uuid
+            and group_store_item_id = $2::uuid;
+            ",
+            &[&group_id, &group_store_item_id],
         )
         .await
     }
@@ -962,6 +1068,40 @@ where
         .await
     }
 
+    /// [`DBDashboardGroup::list_group_store_items`]
+    #[instrument(skip(self), err)]
+    async fn list_group_store_items(
+        &self,
+        group_id: Uuid,
+        include_inactive: bool,
+    ) -> Result<Vec<GroupStoreItem>> {
+        self.fetch_json_one(
+            "
+            select coalesce(jsonb_agg(jsonb_build_object(
+                'group_store_item_id', group_store_item_id,
+                'group_id', group_id,
+                'created_by', created_by,
+                'name', name,
+                'description', description,
+                'image_url', image_url,
+                'price_minor', price_minor,
+                'currency_code', currency_code,
+                'inventory_count', inventory_count,
+                'checkout_url', checkout_url,
+                'featured', featured,
+                'active', active,
+                'created_at', extract(epoch from created_at)::bigint,
+                'updated_at', extract(epoch from updated_at)::bigint
+            ) order by featured desc, created_at desc), '[]'::jsonb)
+            from group_store_item
+            where group_id = $1::uuid
+            and ($2::boolean or active);
+            ",
+            &[&group_id, &include_inactive],
+        )
+        .await
+    }
+
     /// [`DBDashboardGroup::list_group_team_members`]
     #[instrument(skip(self), err)]
     async fn list_group_team_members(
@@ -1234,6 +1374,49 @@ where
         self.execute(
             "select update_group_sponsor($1::uuid, $2::uuid, $3::uuid, $4::jsonb)",
             &[&actor_user_id, &group_id, &group_sponsor_id, &Json(sponsor)],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::update_group_store_item`]
+    #[instrument(skip(self, input), err)]
+    async fn update_group_store_item(
+        &self,
+        _actor_user_id: Uuid,
+        group_id: Uuid,
+        group_store_item_id: Uuid,
+        input: &StoreItemInput,
+    ) -> Result<()> {
+        self.execute(
+            "
+            update group_store_item
+            set
+                name = $3::text,
+                description = $4::text,
+                image_url = $5::text,
+                price_minor = $6::bigint,
+                currency_code = upper($7::text),
+                inventory_count = $8::integer,
+                checkout_url = $9::text,
+                featured = $10::boolean,
+                active = $11::boolean,
+                updated_at = current_timestamp
+            where group_id = $1::uuid
+            and group_store_item_id = $2::uuid;
+            ",
+            &[
+                &group_id,
+                &group_store_item_id,
+                &input.name,
+                &input.description,
+                &input.image_url,
+                &input.price_minor,
+                &input.currency_code,
+                &input.inventory_count,
+                &input.checkout_url,
+                &input.featured,
+                &input.active,
+            ],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -348,6 +348,12 @@ mock! {
             group_id: Uuid,
             sponsor: &crate::templates::dashboard::group::sponsors::Sponsor,
         ) -> Result<Uuid>;
+        async fn add_group_store_item(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            input: &crate::templates::dashboard::group::store::StoreItemInput,
+        ) -> Result<Uuid>;
         async fn add_group_team_member(
             &self,
             actor_user_id: Uuid,
@@ -400,6 +406,12 @@ mock! {
             actor_user_id: Uuid,
             group_id: Uuid,
             group_sponsor_id: Uuid,
+        ) -> Result<()>;
+        async fn delete_group_store_item(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            group_store_item_id: Uuid,
         ) -> Result<()>;
         async fn delete_group_team_member(
             &self,
@@ -500,6 +512,11 @@ mock! {
             filters: &crate::templates::dashboard::group::sponsors::GroupSponsorsFilters,
             full_list: bool,
         ) -> Result<crate::templates::dashboard::group::sponsors::GroupSponsorsOutput>;
+        async fn list_group_store_items(
+            &self,
+            group_id: Uuid,
+            include_inactive: bool,
+        ) -> Result<Vec<crate::templates::dashboard::group::store::GroupStoreItem>>;
         async fn list_group_team_members(
             &self,
             group_id: Uuid,
@@ -584,6 +601,13 @@ mock! {
             group_id: Uuid,
             group_sponsor_id: Uuid,
             sponsor: &crate::templates::dashboard::group::sponsors::Sponsor,
+        ) -> Result<()>;
+        async fn update_group_store_item(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            group_store_item_id: Uuid,
+            input: &crate::templates::dashboard::group::store::StoreItemInput,
         ) -> Result<()>;
         async fn update_group_sponsor_featured(
             &self,

--- a/ocg-server/src/handlers/dashboard/group.rs
+++ b/ocg-server/src/handlers/dashboard/group.rs
@@ -30,6 +30,7 @@ pub(crate) mod logs;
 pub(crate) mod members;
 pub(crate) mod settings;
 pub(crate) mod sponsors;
+pub(crate) mod store;
 pub(crate) mod submissions;
 pub(crate) mod team;
 pub(crate) mod waitlist;

--- a/ocg-server/src/handlers/dashboard/group/home.rs
+++ b/ocg-server/src/handlers/dashboard/group/home.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_messages::Messages;
 use tracing::instrument;
 
-use super::{events, logs, members, sponsors, team};
+use super::{events, logs, members, sponsors, store, team};
 
 use crate::{
     auth::AuthSession,
@@ -129,6 +129,11 @@ pub(crate) async fn page(
             )
             .await?;
             Content::Sponsors(template)
+        }
+        Tab::Store => {
+            let template =
+                store::prepare_list_page(&db, alliance_id, group_id, user.user_id).await?;
+            Content::Store(template)
         }
         Tab::Team => {
             let (_, template) = team::prepare_list_page(

--- a/ocg-server/src/handlers/dashboard/group/store.rs
+++ b/ocg-server/src/handlers/dashboard/group/store.rs
@@ -1,0 +1,113 @@
+//! HTTP handlers for the group store dashboard.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::{HeaderName, StatusCode},
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId, ValidatedForm},
+    },
+    templates::dashboard::group::store::{self, StoreItemInput},
+    types::permissions::GroupPermission,
+};
+
+const DASHBOARD_URL: &str = "/dashboard/group?tab=store";
+
+/// Displays the group store dashboard.
+#[instrument(skip_all, err)]
+pub(crate) async fn list_page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let template = prepare_list_page(&db, alliance_id, group_id, user.user_id).await?;
+    let headers = [(
+        HeaderName::from_static("hx-push-url"),
+        DASHBOARD_URL.to_string(),
+    )];
+
+    Ok((headers, Html(template.render()?)))
+}
+
+/// Adds a store item.
+#[instrument(skip_all, err)]
+pub(crate) async fn add(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<StoreItemInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_group_store_item(user.user_id, group_id, &input).await?;
+
+    Ok((
+        StatusCode::CREATED,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    ))
+}
+
+/// Updates a store item.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(group_store_item_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<StoreItemInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_group_store_item(user.user_id, group_id, group_store_item_id, &input)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    ))
+}
+
+/// Deletes a store item.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(group_store_item_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_group_store_item(user.user_id, group_id, group_store_item_id)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    ))
+}
+
+/// Prepares the store list template.
+pub(crate) async fn prepare_list_page(
+    db: &DynDB,
+    alliance_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<store::ListPage, HandlerError> {
+    let (can_manage_store, items) = tokio::try_join!(
+        db.user_has_group_permission(
+            &alliance_id,
+            &group_id,
+            &user_id,
+            GroupPermission::SponsorsWrite,
+        ),
+        db.list_group_store_items(group_id, true),
+    )?;
+
+    Ok(store::ListPage {
+        can_manage_store,
+        items,
+    })
+}

--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -23,7 +23,7 @@ use crate::{
     templates::{
         PageId,
         auth::User,
-        group::{self, Page},
+        group::{self, Page, StorePage},
         notifications::GroupWelcome,
     },
     types::{event::EventKind, group::GroupFull},
@@ -91,6 +91,42 @@ pub(crate) async fn page(
             .into_iter()
             .map(|event| group::UpcomingEventCard { event })
             .collect(),
+        user: User::default(),
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
+}
+
+/// Handler that renders the public group store page.
+#[instrument(skip_all)]
+pub(crate) async fn store_page(
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((alliance_name, group_slug)): Path<(String, String)>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let Some(mut group) = db.get_group_full_by_slug(alliance_id, &group_slug).await? else {
+        return not_found::render(site_settings);
+    };
+    trim_public_gallery_images(&mut group.photos_urls);
+    group.sponsors.retain(|sponsor| sponsor.featured);
+
+    let store_items = db.list_group_store_items(group.group_id, false).await?;
+    let template = StorePage {
+        base_url: server_cfg.base_url,
+        group,
+        page_id: PageId::Group,
+        path: uri.path().to_string(),
+        site_settings,
+        store_items,
         user: User::default(),
     };
 

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -297,6 +297,10 @@ pub(crate) async fn setup(
         .route("/wiki", get(site::wiki::page))
         // Alliance-prefixed public routes
         .route("/{alliance}", get(alliance::page))
+        .route(
+            "/{alliance}/group/{group_slug}/store",
+            get(group::store_page),
+        )
         .route("/{alliance}/group/{group_slug}", get(group::page))
         .route(
             "/{alliance}/event/{event_id}/cfs-modal",

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -295,6 +295,7 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             "/sponsors/{group_sponsor_id}/update",
             get(dashboard::group::sponsors::update_page),
         )
+        .route("/store", get(dashboard::group::store::list_page))
         .route("/team", get(dashboard::group::team::list_page))
         .route_layer(check_selected_group_permission(GroupPermission::Read));
 
@@ -406,6 +407,11 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
         .route(
             "/sponsors/{group_sponsor_id}/update",
             put(dashboard::group::sponsors::update),
+        )
+        .route("/store", post(dashboard::group::store::add))
+        .route(
+            "/store/{group_store_item_id}",
+            put(dashboard::group::store::update).delete(dashboard::group::store::delete),
         )
         .route_layer(check_selected_group_permission(
             GroupPermission::SponsorsWrite,

--- a/ocg-server/src/templates/dashboard/group.rs
+++ b/ocg-server/src/templates/dashboard/group.rs
@@ -8,6 +8,7 @@ pub(crate) mod invitation_requests;
 pub(crate) mod members;
 pub(crate) mod settings;
 pub(crate) mod sponsors;
+pub(crate) mod store;
 pub(crate) mod submissions;
 pub(crate) mod team;
 pub(crate) mod waitlist;

--- a/ocg-server/src/templates/dashboard/group/home.rs
+++ b/ocg-server/src/templates/dashboard/group/home.rs
@@ -11,7 +11,7 @@ use crate::{
         auth::User,
         dashboard::{
             audit,
-            group::{analytics, events, members, settings, sponsors, team},
+            group::{analytics, events, members, settings, sponsors, store, team},
         },
         filters,
         helpers::user_initials,
@@ -89,6 +89,8 @@ pub(crate) enum Content {
     Settings(Box<settings::UpdatePage>),
     /// Sponsors management page.
     Sponsors(sponsors::ListPage),
+    /// Group store management page.
+    Store(store::ListPage),
     /// Team management page.
     Team(team::ListPage),
 }
@@ -124,6 +126,11 @@ impl Content {
         matches!(self, Content::Sponsors(_))
     }
 
+    /// Check if the content is the store page.
+    fn is_store(&self) -> bool {
+        matches!(self, Content::Store(_))
+    }
+
     /// Check if the content is the team page.
     fn is_team(&self) -> bool {
         matches!(self, Content::Team(_))
@@ -139,6 +146,7 @@ impl std::fmt::Display for Content {
             Content::Members(template) => write!(f, "{}", template.render()?),
             Content::Settings(template) => write!(f, "{}", template.render()?),
             Content::Sponsors(template) => write!(f, "{}", template.render()?),
+            Content::Store(template) => write!(f, "{}", template.render()?),
             Content::Team(template) => write!(f, "{}", template.render()?),
         }
     }
@@ -164,6 +172,8 @@ pub(crate) enum Tab {
     Settings,
     /// Sponsors management tab.
     Sponsors,
+    /// Group store management tab.
+    Store,
     /// Team management tab.
     Team,
 }

--- a/ocg-server/src/templates/dashboard/group/store.rs
+++ b/ocg-server/src/templates/dashboard/group/store.rs
@@ -1,0 +1,119 @@
+//! Templates and types for group store management.
+
+use askama::Template;
+use chrono::{DateTime, Utc};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use uuid::Uuid;
+
+use crate::validation::{
+    MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_L, MAX_LEN_M, image_url_opt, trimmed_non_empty,
+    trimmed_non_empty_opt,
+};
+
+/// Group dashboard store management page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/group/store_list.html")]
+pub(crate) struct ListPage {
+    /// Whether the current user can manage store items.
+    pub can_manage_store: bool,
+    /// Store items for the selected group.
+    pub items: Vec<GroupStoreItem>,
+}
+
+/// Dashboard form payload for creating or updating a store item.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct StoreItemInput {
+    /// Item name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub name: String,
+    /// Short item description.
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub description: Option<String>,
+    /// Optional product image URL.
+    #[garde(custom(image_url_opt))]
+    pub image_url: Option<String>,
+    /// Price in minor units, for example cents.
+    #[garde(range(min = 0))]
+    pub price_minor: i64,
+    /// ISO currency code.
+    #[garde(pattern(r"^[A-Z]{3}$"))]
+    pub currency_code: String,
+    /// Optional available inventory count.
+    #[garde(range(min = 0))]
+    pub inventory_count: Option<i32>,
+    /// External checkout URL where buyers purchase the item.
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty))]
+    pub checkout_url: String,
+    /// Whether the item should be emphasized.
+    #[serde(default)]
+    #[garde(skip)]
+    pub featured: bool,
+    /// Whether the item is visible in the group store.
+    #[serde(default = "default_active")]
+    #[garde(skip)]
+    pub active: bool,
+}
+
+/// Store item shown in dashboards and public group stores.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct GroupStoreItem {
+    /// Store item identifier.
+    pub group_store_item_id: Uuid,
+    /// Group identifier.
+    pub group_id: Uuid,
+    /// Creating user identifier.
+    pub created_by: Uuid,
+    /// Item name.
+    pub name: String,
+    /// Item description.
+    pub description: Option<String>,
+    /// Item image URL.
+    pub image_url: Option<String>,
+    /// Price in minor units.
+    pub price_minor: i64,
+    /// Currency code.
+    pub currency_code: String,
+    /// Optional available inventory count.
+    pub inventory_count: Option<i32>,
+    /// External checkout URL.
+    pub checkout_url: String,
+    /// Whether the item is emphasized.
+    pub featured: bool,
+    /// Whether the item is visible.
+    pub active: bool,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    /// Last update time.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+impl GroupStoreItem {
+    /// Returns the display price using a simple minor-unit formatter.
+    pub(crate) fn display_price(&self) -> String {
+        let major = self.price_minor / 100;
+        let minor = self.price_minor % 100;
+        format!("{major}.{minor:02} {}", self.currency_code)
+    }
+
+    /// Returns whether the item should be treated as sold out.
+    pub(crate) fn is_sold_out(&self) -> bool {
+        self.inventory_count == Some(0)
+    }
+
+    /// Returns the inventory value for dashboard form inputs.
+    pub(crate) fn inventory_input_value(&self) -> String {
+        self.inventory_count
+            .map(|count| count.to_string())
+            .unwrap_or_default()
+    }
+}
+
+fn default_active() -> bool {
+    true
+}

--- a/ocg-server/src/templates/group.rs
+++ b/ocg-server/src/templates/group.rs
@@ -4,6 +4,7 @@ use askama::Template;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    templates::dashboard::group::store::GroupStoreItem,
     templates::{
         PageId,
         auth::User,
@@ -41,6 +42,26 @@ pub(crate) struct Page {
     pub user: User,
 }
 
+/// Public group store page.
+#[derive(Debug, Clone, Template)]
+#[template(path = "group/store.html")]
+pub(crate) struct StorePage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Detailed information about the group.
+    pub group: GroupFull,
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Active store items.
+    pub store_items: Vec<GroupStoreItem>,
+    /// Authenticated user information.
+    pub user: User,
+}
+
 impl Page {
     /// Returns the canonical public URL for the group page.
     pub(crate) fn canonical_url(&self) -> String {
@@ -74,6 +95,39 @@ impl Page {
     /// Returns the preview title for the group page.
     pub(crate) fn preview_title(&self) -> String {
         self.group.name.clone()
+    }
+}
+
+impl StorePage {
+    /// Returns the canonical URL for the group store page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!(
+                "/{}/group/{}/store",
+                self.group.alliance.name,
+                self.group.public_slug()
+            ),
+        )
+    }
+
+    /// Returns the `OpenGraph` image URL for the group store page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.group
+            .og_image_url
+            .as_deref()
+            .or(self.group.alliance.og_image_url.as_deref())
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+
+    /// Returns the preview description for the group store page.
+    pub(crate) fn preview_description(&self) -> String {
+        format!("Swag and merch from {}.", self.group.name)
+    }
+
+    /// Returns the preview title for the group store page.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} Store", self.group.name)
     }
 }
 

--- a/ocg-server/templates/dashboard/group/home.html
+++ b/ocg-server/templates/dashboard/group/home.html
@@ -97,6 +97,7 @@
       {{ dashboard::menu_title(text = "Members and sponsors", extra_styles = "py-1.5") -}}
       {{ dashboard::menu_item(name = "Members", icon = "members", is_active = content.is_members() , href = "/dashboard/group?tab=members") -}}
       {{ dashboard::menu_item(name = "Sponsors", icon = "handshake", is_active = content.is_sponsors() , href = "/dashboard/group?tab=sponsors") -}}
+      {{ dashboard::menu_item(name = "Store", icon = "shopping-bag", is_active = content.is_store() , href = "/dashboard/group?tab=store") -}}
     </div>
     {# End members and sponsors -#}
 
@@ -120,7 +121,7 @@
        data-alliance-banner-mobile-url="{{ current_selection.0.banner_mobile_url }}"
        data-group-name="{{ current_selection.1.name }}"
        data-group-slug="{{ current_selection.1.public_slug() }}"
-       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else -%}events{%- endif -%}"
+       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_store() -%}store{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else -%}events{%- endif -%}"
        hx-trigger="refresh-group-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/dashboard/group/store_list.html
+++ b/ocg-server/templates/dashboard/group/store_list.html
@@ -1,0 +1,250 @@
+{% import "macros/dashboard.html" as dashboard -%}
+
+{{ dashboard::page_title(title = "Store") -}}
+
+<div class="my-5 grid gap-6">
+  <section class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h2 class="text-lg font-semibold text-stone-950">Add swag item</h2>
+        <p class="mt-1 text-sm text-stone-600">List group swag with a price, product image, inventory, and checkout link.</p>
+      </div>
+      {% if !can_manage_store -%}
+        <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600">Read only</span>
+      {% endif -%}
+    </div>
+
+    <form class="mt-5 grid gap-4"
+          hx-post="/dashboard/group/store"
+          hx-target="#dashboard-content"
+          hx-indicator="#dashboard-spinner"
+          {% if !can_manage_store -%}
+            inert
+          {% endif -%}>
+      <div class="grid gap-4 lg:grid-cols-2">
+        <label class="block">
+          <span class="label-primary">Name</span>
+          <input name="name"
+                 class="input-primary mt-1"
+                 maxlength="{{ crate::validation::MAX_LEN_M }}"
+                 placeholder="Community hoodie"
+                 required>
+        </label>
+        <label class="block">
+          <span class="label-primary">Checkout URL</span>
+          <input name="checkout_url"
+                 class="input-primary mt-1"
+                 placeholder="https://..."
+                 required>
+        </label>
+      </div>
+      <label class="block">
+        <span class="label-primary">Description</span>
+        <textarea name="description"
+                  class="input-primary mt-1 min-h-24"
+                  maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION_SHORT }}"
+                  placeholder="Describe the item, sizes, shipping, or pickup details."></textarea>
+      </label>
+      <div class="grid gap-4 lg:grid-cols-2">
+        <label class="block">
+          <span class="label-primary">Image URL</span>
+          <input name="image_url" class="input-primary mt-1" placeholder="https://...">
+        </label>
+        <label class="block">
+          <span class="label-primary">Price in cents</span>
+          <input name="price_minor"
+                 class="input-primary mt-1"
+                 type="number"
+                 min="0"
+                 value="0"
+                 required>
+        </label>
+      </div>
+      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <label class="block">
+          <span class="label-primary">Currency</span>
+          <input name="currency_code"
+                 class="input-primary mt-1 uppercase"
+                 maxlength="3"
+                 value="USD"
+                 required>
+        </label>
+        <label class="block">
+          <span class="label-primary">Inventory</span>
+          <input name="inventory_count"
+                 class="input-primary mt-1"
+                 type="number"
+                 min="0"
+                 placeholder="Unlimited">
+        </label>
+        <label class="block">
+          <span class="label-primary">Featured</span>
+          <select name="featured" class="input-primary mt-1">
+            <option value="false">No</option>
+            <option value="true">Yes</option>
+          </select>
+        </label>
+        <label class="block">
+          <span class="label-primary">Active</span>
+          <select name="active" class="input-primary mt-1">
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </label>
+      </div>
+      <div>
+        <button type="submit"
+                class="btn-primary"
+                {% if !can_manage_store -%}
+                  disabled
+                {% endif -%}>Add item</button>
+      </div>
+    </form>
+  </section>
+
+  {% if items.is_empty() -%}
+    <section class="rounded-2xl border border-dashed border-stone-300 bg-white px-8 py-12 text-center">
+      <div class="mx-auto flex size-12 items-center justify-center rounded-full bg-primary-50">
+        <div class="svg-icon size-6 icon-shopping-bag bg-primary-500"></div>
+      </div>
+      <h2 class="mt-4 text-lg font-semibold text-stone-950">No store items yet</h2>
+      <p class="mt-2 text-sm text-stone-600">Add swag, merch, stickers, books, or sponsor kits to open the group store.</p>
+    </section>
+  {% else -%}
+    <section class="grid gap-5 xl:grid-cols-2">
+      {% for item in items -%}
+        <article class="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
+          {% if let Some(image_url) = &item.image_url -%}
+            <img src="{{ image_url }}"
+                 alt=""
+                 class="h-44 w-full object-cover"
+                 loading="lazy">
+          {% else -%}
+            <div class="h-2 bg-gradient-to-r from-primary-500 via-primary-300 to-stone-100"></div>
+          {% endif -%}
+          <form class="grid gap-4 p-5"
+                hx-put="/dashboard/group/store/{{ item.group_store_item_id }}"
+                hx-target="#dashboard-content"
+                hx-indicator="#dashboard-spinner"
+                {% if !can_manage_store -%}
+                  inert
+                {% endif -%}>
+            <div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <div class="font-semibold text-stone-950">{{ item.name }}</div>
+                <div class="text-sm text-stone-500">
+                  {{ item.display_price() }}
+                  {% if let Some(inventory_count) = item.inventory_count -%}
+                    · {{ inventory_count }} in stock
+                  {% endif -%}
+                </div>
+              </div>
+              <div class="flex flex-wrap gap-2">
+                {% if item.featured -%}
+                  <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">Featured</span>
+                {% endif -%}
+                {% if !item.active -%}
+                  <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-600">Inactive</span>
+                {% endif -%}
+              </div>
+            </div>
+
+            <div class="grid gap-4 lg:grid-cols-2">
+              <label class="block">
+                <span class="label-primary">Name</span>
+                <input name="name"
+                       class="input-primary mt-1"
+                       value="{{ item.name }}"
+                       maxlength="{{ crate::validation::MAX_LEN_M }}"
+                       required>
+              </label>
+              <label class="block">
+                <span class="label-primary">Checkout URL</span>
+                <input name="checkout_url"
+                       class="input-primary mt-1"
+                       value="{{ item.checkout_url }}"
+                       required>
+              </label>
+            </div>
+            <label class="block">
+              <span class="label-primary">Description</span>
+              <textarea name="description"
+                        class="input-primary mt-1 min-h-24"
+                        maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION_SHORT }}">{{ item.description.as_deref().unwrap_or("") }}</textarea>
+            </label>
+            <div class="grid gap-4 lg:grid-cols-2">
+              <label class="block">
+                <span class="label-primary">Image URL</span>
+                <input name="image_url"
+                       class="input-primary mt-1"
+                       value="{{ item.image_url.as_deref().unwrap_or("") }}">
+              </label>
+              <label class="block">
+                <span class="label-primary">Price in cents</span>
+                <input name="price_minor"
+                       class="input-primary mt-1"
+                       type="number"
+                       min="0"
+                       value="{{ item.price_minor }}"
+                       required>
+              </label>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <label class="block">
+                <span class="label-primary">Currency</span>
+                <input name="currency_code"
+                       class="input-primary mt-1 uppercase"
+                       maxlength="3"
+                       value="{{ item.currency_code }}"
+                       required>
+              </label>
+              <label class="block">
+                <span class="label-primary">Inventory</span>
+                <input name="inventory_count"
+                       class="input-primary mt-1"
+                       type="number"
+                       min="0"
+                       value="{{ item.inventory_input_value() }}">
+              </label>
+              <label class="block">
+                <span class="label-primary">Featured</span>
+                <select name="featured" class="input-primary mt-1">
+                  <option value="false" {% if !item.featured %}selected{% endif %}>No</option>
+                  <option value="true" {% if item.featured %}selected{% endif %}>Yes</option>
+                </select>
+              </label>
+              <label class="block">
+                <span class="label-primary">Active</span>
+                <select name="active" class="input-primary mt-1">
+                  <option value="true" {% if item.active %}selected{% endif %}>Yes</option>
+                  <option value="false" {% if !item.active %}selected{% endif %}>No</option>
+                </select>
+              </label>
+            </div>
+
+            <div class="flex flex-wrap gap-2">
+              <button type="submit"
+                      class="btn-primary"
+                      {% if !can_manage_store -%}
+                        disabled
+                      {% endif -%}>Save</button>
+              <button type="button"
+                      class="btn-tertiary"
+                      hx-delete="/dashboard/group/store/{{ item.group_store_item_id }}"
+                      hx-target="#dashboard-content"
+                      hx-indicator="#dashboard-spinner"
+                      hx-confirm="Delete this store item?"
+                      {% if !can_manage_store -%}
+                        disabled
+                      {% endif -%}>Delete</button>
+              <a href="{{ item.checkout_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="btn-secondary-anchor">Open checkout</a>
+            </div>
+          </form>
+        </article>
+      {% endfor -%}
+    </section>
+  {% endif -%}
+</div>

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -139,6 +139,11 @@
                   <div class="svg-icon size-4 icon-vertical-dots"></div>
                 </summary>
                 <div class="absolute left-4 z-20 mt-2 w-56 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-stone-200 bg-white py-1 shadow-lg sm:left-auto sm:right-0 sm:w-max sm:min-w-48">
+                  <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/store"
+                     class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
+                    <div class="svg-icon size-4 icon-shopping-bag bg-stone-600"></div>
+                    Store
+                  </a>
                   <share-modal trigger-variant="menu-item" title="{{ group.name }}" url="/{{ group.alliance.name }}/group/{{ group.public_slug() }}">
                   </share-modal>
                 </div>

--- a/ocg-server/templates/group/store.html
+++ b/ocg-server/templates/group/store.html
@@ -1,0 +1,103 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() |demoji }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &group.name) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl p-4 sm:p-6 lg:p-8">
+    <div class="rounded-3xl border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+      <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}"
+             class="text-sm font-medium text-primary-700 hover:text-primary-900">← Back to {{ group.name|demoji }}</a>
+          <h1 class="mt-4 text-3xl font-semibold text-stone-950 sm:text-4xl">Group store</h1>
+          <p class="mt-3 max-w-2xl text-base leading-7 text-stone-600">Swag, merch, and community items from {{ group.name|demoji }}.</p>
+        </div>
+      </div>
+
+      {% if store_items.is_empty() -%}
+        <div class="mt-10 rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-8 py-12 text-center">
+          <div class="mx-auto flex size-12 items-center justify-center rounded-full bg-primary-50">
+            <div class="svg-icon size-6 icon-shopping-bag bg-primary-500"></div>
+          </div>
+          <h2 class="mt-4 text-lg font-semibold text-stone-950">The store is empty</h2>
+          <p class="mt-2 text-sm text-stone-600">Check back for group swag and community merch.</p>
+        </div>
+      {% else -%}
+        <div class="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {% for item in store_items -%}
+            <article class="flex overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
+              <div class="flex w-full flex-col">
+                {% if let Some(image_url) = &item.image_url -%}
+                  <img src="{{ image_url }}"
+                       alt=""
+                       class="h-56 w-full object-cover"
+                       loading="lazy">
+                {% else -%}
+                  <div class="h-2 bg-gradient-to-r from-primary-500 via-primary-300 to-stone-100"></div>
+                {% endif -%}
+                <div class="flex grow flex-col p-5">
+                  <div class="flex items-start justify-between gap-3">
+                    <h2 class="text-xl font-semibold text-stone-950">{{ item.name }}</h2>
+                    {% if item.featured -%}
+                      <span class="shrink-0 rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">Featured</span>
+                    {% endif -%}
+                  </div>
+                  {% if let Some(description) = &item.description -%}
+                    <p class="mt-3 text-sm leading-6 text-stone-600">{{ description }}</p>
+                  {% endif -%}
+                  <div class="mt-5 flex items-center justify-between gap-4 border-t border-stone-100 pt-5">
+                    <div>
+                      <div class="text-lg font-semibold text-stone-950">{{ item.display_price() }}</div>
+                      {% if let Some(inventory_count) = item.inventory_count -%}
+                        <div class="mt-1 text-xs text-stone-500">
+                          {% if item.is_sold_out() -%}
+                            Sold out
+                          {% else -%}
+                            {{ inventory_count }} available
+                          {% endif -%}
+                        </div>
+                      {% endif -%}
+                    </div>
+                    <a href="{{ item.checkout_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="btn-primary-anchor
+                              {% if item.is_sold_out() %}opacity-50 pointer-events-none{% endif %}"
+                       {% if item.is_sold_out() -%}
+                         aria-disabled="true"
+                       {% endif -%}>Buy</a>
+                  </div>
+                </div>
+              </div>
+            </article>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    </div>
+  </div>
+{% endblock content -%}


### PR DESCRIPTION
## Summary
- Add a group-scoped swag store catalog with migration, schema tests, and dashboard CRUD for group leads using existing group sponsor-write permissions.
- Add a public `/GROUP/store` page showing active swag items with price, inventory state, images, and external checkout links.
- Add Store navigation in the group dashboard and public group actions menu.

## Test plan
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`
- `just db-tests` (blocked locally: PostgreSQL role `postgres` does not exist)


Made with [Cursor](https://cursor.com)