### PR TITLE
Expose group spotlights and store previews

### DIFF
--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -77,6 +77,11 @@ pub(crate) async fn page(
     // Only display featured sponsors on the group page
     group.sponsors.retain(|sponsor| sponsor.featured);
 
+    let (spotlights, store_items) = tokio::try_join!(
+        db.list_group_member_spotlights(group.group_id, false),
+        db.list_group_store_items(group.group_id, false)
+    )?;
+
     // Prepare the page template
     let template = Page {
         base_url: server_cfg.base_url,
@@ -88,6 +93,8 @@ pub(crate) async fn page(
             .collect(),
         path: uri.path().to_string(),
         site_settings,
+        spotlights,
+        store_items,
         upcoming_events: upcoming_events
             .into_iter()
             .map(|event| group::UpcomingEventCard { event })

--- a/ocg-server/src/handlers/group/tests.rs
+++ b/ocg-server/src/handlers/group/tests.rs
@@ -276,14 +276,7 @@ async fn test_page_success() {
                 && *limit == 9
         })
         .returning(move |_, _, _, _| Ok(vec![sample_event_summary(event_id, group_id)]));
-    db.expect_list_group_member_spotlights()
-        .times(1)
-        .withf(move |id, include_unpublished| *id == group_id && !*include_unpublished)
-        .returning(|_, _| Ok(vec![]));
-    db.expect_list_group_store_items()
-        .times(1)
-        .withf(move |id, include_inactive| *id == group_id && !*include_inactive)
-        .returning(|_, _| Ok(vec![]));
+    expect_empty_group_home_previews(&mut db, group_id);
 
     // Setup notifications manager mock
     let nm = MockNotificationsManager::new();
@@ -339,6 +332,17 @@ async fn test_page_success() {
     assert!(body.contains(
         r#"<meta name="twitter:image" content="https://example.test/images/og/group-og.png">"#
     ));
+}
+
+fn expect_empty_group_home_previews(db: &mut MockDB, group_id: Uuid) {
+    db.expect_list_group_member_spotlights()
+        .times(1)
+        .withf(move |id, include_unpublished| *id == group_id && !*include_unpublished)
+        .returning(|_, _| Ok(vec![]));
+    db.expect_list_group_store_items()
+        .times(1)
+        .withf(move |id, include_inactive| *id == group_id && !*include_inactive)
+        .returning(|_, _| Ok(vec![]));
 }
 
 #[tokio::test]

--- a/ocg-server/src/handlers/group/tests.rs
+++ b/ocg-server/src/handlers/group/tests.rs
@@ -276,6 +276,14 @@ async fn test_page_success() {
                 && *limit == 9
         })
         .returning(move |_, _, _, _| Ok(vec![sample_event_summary(event_id, group_id)]));
+    db.expect_list_group_member_spotlights()
+        .times(1)
+        .withf(move |id, include_unpublished| *id == group_id && !*include_unpublished)
+        .returning(|_, _| Ok(vec![]));
+    db.expect_list_group_store_items()
+        .times(1)
+        .withf(move |id, include_inactive| *id == group_id && !*include_inactive)
+        .returning(|_, _| Ok(vec![]));
 
     // Setup notifications manager mock
     let nm = MockNotificationsManager::new();
@@ -306,6 +314,8 @@ async fn test_page_success() {
     );
     let body = String::from_utf8(bytes.to_vec()).unwrap();
     assert!(body.contains("<title>Test Group</title>"));
+    assert!(body.contains("Member spotlights"));
+    assert!(body.contains("Group store"));
     assert!(body.contains(
         r#"<meta name="description" content="Test Alliance alliance in Open Alliance Groups, where Open Source alliances thrive.">"#
     ));

--- a/ocg-server/src/templates/group.rs
+++ b/ocg-server/src/templates/group.rs
@@ -36,6 +36,10 @@ pub(crate) struct Page {
     pub path: String,
     /// Global site settings.
     pub site_settings: SiteSettings,
+    /// Published member spotlights for homepage discovery.
+    pub spotlights: Vec<GroupMemberSpotlight>,
+    /// Active store items for homepage discovery.
+    pub store_items: Vec<GroupStoreItem>,
     /// List of upcoming events for this group.
     pub upcoming_events: Vec<UpcomingEventCard>,
     /// Authenticated user information.

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -286,6 +286,127 @@
       </div>
       {# End next event and location -#}
 
+      {# Spotlights and store previews -#}
+      <div class="grid gap-5 lg:grid-cols-2">
+        <section class="rounded-2xl border border-stone-200 bg-stone-50/70 p-5 sm:p-6">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <div class="inline-flex items-center gap-2 rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700">
+                <div class="svg-icon size-3 icon-star bg-primary-600"></div>
+                Member stories
+              </div>
+              <h2 class="mt-4 text-2xl font-semibold text-stone-950">Member spotlights</h2>
+              <p class="mt-2 text-sm/6 text-stone-600">Wins, stories, and profile cards from {{ group.name|demoji }} members.</p>
+            </div>
+            <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/spotlights"
+               class="btn-secondary-anchor shrink-0"
+               hx-boost="true"
+               hx-target="body">View all</a>
+          </div>
+
+          {% if spotlights.is_empty() -%}
+            <div class="mt-6 rounded-xl border border-dashed border-stone-300 bg-white p-5 text-sm text-stone-600">
+              No member spotlights yet. Check back for stories from this group.
+            </div>
+          {% else -%}
+            <div class="mt-6 grid gap-4">
+              {% for spotlight in spotlights -%}
+                {% if loop.index0 < 2 -%}
+                  <article class="rounded-xl border border-stone-200 bg-white p-4 shadow-sm">
+                    <div class="flex items-start gap-3">
+                      <logo-image
+                      {% if let Some(photo_url) = &spotlight.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+                      size="size-11" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
+                      </logo-image>
+                      <div class="min-w-0 flex-1">
+                        <div class="flex flex-wrap items-center gap-2">
+                          <h3 class="font-semibold text-stone-950">{{ spotlight.title }}</h3>
+                          {% if spotlight.featured -%}
+                            <span class="rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700">Featured</span>
+                          {% endif -%}
+                        </div>
+                        <p class="mt-2 line-clamp-2 text-sm/6 text-stone-600">{{ spotlight.story }}</p>
+                        <div class="mt-3 flex flex-wrap items-center gap-2 text-sm">
+                          <span class="font-medium text-stone-800">{{ spotlight.member_display_name() }}</span>
+                          <a href="{{ spotlight.profile_path() }}"
+                             class="font-semibold text-primary-700 hover:text-primary-900">Profile card</a>
+                        </div>
+                      </div>
+                    </div>
+                  </article>
+                {% endif -%}
+              {% endfor -%}
+            </div>
+          {% endif -%}
+        </section>
+
+        <section class="rounded-2xl border border-stone-200 bg-stone-50/70 p-5 sm:p-6">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <div class="inline-flex items-center gap-2 rounded-full bg-primary-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-primary-700">
+                <div class="svg-icon size-3 icon-shopping-bag bg-primary-600"></div>
+                Group swag
+              </div>
+              <h2 class="mt-4 text-2xl font-semibold text-stone-950">Group store</h2>
+              <p class="mt-2 text-sm/6 text-stone-600">Swag, merch, and community items from {{ group.name|demoji }}.</p>
+            </div>
+            <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/store"
+               class="btn-secondary-anchor shrink-0"
+               hx-boost="true"
+               hx-target="body">View store</a>
+          </div>
+
+          {% if store_items.is_empty() -%}
+            <div class="mt-6 rounded-xl border border-dashed border-stone-300 bg-white p-5 text-sm text-stone-600">
+              The store is empty for now. Check back for group swag and community items.
+            </div>
+          {% else -%}
+            <div class="mt-6 grid gap-4">
+              {% for item in store_items -%}
+                {% if loop.index0 < 2 -%}
+                  <article class="overflow-hidden rounded-xl border border-stone-200 bg-white shadow-sm">
+                    {% if let Some(image_url) = &item.image_url -%}
+                      <img src="{{ image_url }}"
+                           alt=""
+                           class="h-32 w-full object-cover"
+                           loading="lazy">
+                    {% endif -%}
+                    <div class="p-4">
+                      <div class="flex items-start justify-between gap-3">
+                        <h3 class="font-semibold text-stone-950">{{ item.name }}</h3>
+                        {% if item.featured -%}
+                          <span class="rounded-full bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700">Featured</span>
+                        {% endif -%}
+                      </div>
+                      {% if let Some(description) = &item.description -%}
+                        <p class="mt-2 line-clamp-2 text-sm/6 text-stone-600">{{ description }}</p>
+                      {% endif -%}
+                      <div class="mt-4 flex items-center justify-between gap-3">
+                        <div>
+                          <div class="font-semibold text-stone-950">{{ item.display_price() }}</div>
+                          {% if item.is_sold_out() -%}
+                            <div class="mt-1 text-xs text-stone-500">Sold out</div>
+                          {% endif -%}
+                        </div>
+                        <a href="{{ item.checkout_url }}"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="btn-primary-anchor
+                                  {% if item.is_sold_out() %}opacity-50 pointer-events-none{% endif %}"
+                           {% if item.is_sold_out() -%}
+                             aria-disabled="true"
+                           {% endif -%}>Buy</a>
+                      </div>
+                    </div>
+                  </article>
+                {% endif -%}
+              {% endfor -%}
+            </div>
+          {% endif -%}
+        </section>
+      </div>
+      {# End spotlights and store previews -#}
+
       {% if let Some(ad_banner_url) = &group.alliance.ad_banner_url -%}
         {{ ui::floating_advertisement_banner(alt = group.alliance.display_name.clone() + " advertisement",
         image_url = ad_banner_url,

--- a/tests/e2e/site/group/home.spec.js
+++ b/tests/e2e/site/group/home.spec.js
@@ -50,6 +50,28 @@ test.describe("group page", () => {
       page.getByText("Location not provided", { exact: true }),
     ).toBeVisible();
 
+    // Verify member spotlights and store previews are visible on the group page.
+    await expect(
+      page.getByRole("heading", { name: "Member spotlights" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator(
+          `a[href="/${TEST_ALLIANCE_NAME}/group/${TEST_GROUP_SLUGS.alliance1.alpha}/spotlights"]`,
+        )
+        .first(),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Group store" }),
+    ).toBeVisible();
+    await expect(
+      page
+        .locator(
+          `a[href="/${TEST_ALLIANCE_NAME}/group/${TEST_GROUP_SLUGS.alliance1.alpha}/store"]`,
+        )
+        .first(),
+    ).toBeVisible();
+
     // Verify the upcoming events section includes the expected events.
     await expect(
       page.getByText("Upcoming Events", { exact: true }),

--- a/tests/e2e/site/group/home.spec.js
+++ b/tests/e2e/site/group/home.spec.js
@@ -54,23 +54,27 @@ test.describe("group page", () => {
     await expect(
       page.getByRole("heading", { name: "Member spotlights" }),
     ).toBeVisible();
+    const spotlightsPreview = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Member spotlights" }),
+    });
     await expect(
-      page
-        .locator(
-          `a[href="/${TEST_ALLIANCE_NAME}/group/${TEST_GROUP_SLUGS.alliance1.alpha}/spotlights"]`,
-        )
-        .first(),
-    ).toBeVisible();
+      spotlightsPreview.getByRole("link", { name: "View all" }),
+    ).toHaveAttribute(
+      "href",
+      `/${TEST_ALLIANCE_NAME}/group/${TEST_GROUP_SLUGS.alliance1.alpha}/spotlights`,
+    );
     await expect(
       page.getByRole("heading", { name: "Group store" }),
     ).toBeVisible();
+    const storePreview = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Group store" }),
+    });
     await expect(
-      page
-        .locator(
-          `a[href="/${TEST_ALLIANCE_NAME}/group/${TEST_GROUP_SLUGS.alliance1.alpha}/store"]`,
-        )
-        .first(),
-    ).toBeVisible();
+      storePreview.getByRole("link", { name: "View store" }),
+    ).toHaveAttribute(
+      "href",
+      `/${TEST_ALLIANCE_NAME}/group/${TEST_GROUP_SLUGS.alliance1.alpha}/store`,
+    );
 
     // Verify the upcoming events section includes the expected events.
     await expect(


### PR DESCRIPTION
## Summary
- Add public group homepage preview sections for member spotlights and the group store
- Load published spotlights and active store items for the group page
- Add unit/E2E coverage for the new homepage discovery links

## Test plan
- cargo check -p ocg-server
- uvx djlint --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/group/page.html
- npx prettier --check tests/e2e/site/group/home.spec.js
- cargo test -p ocg-server

Made with [Cursor](https://cursor.com)