### PR TITLE
Align group spotlight and store forms

### DIFF
--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -58,7 +58,7 @@
             </div>
           </div>
         </div>
-        {{ header::link(content = "Ecosystem", href = "/landscape", current_path = path, path = "/landscape") -}}
+        {{ header::link(content = "Landscape", href = "/landscape", current_path = path, path = "/landscape") -}}
         {{ header::link(content = "Resources", href = "/wiki", current_path = path, path = "/wiki") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
       </div>
@@ -222,7 +222,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-map bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Ecosystem</div>
+                <div class="ms-2 text-xs/6">Landscape</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -472,7 +472,7 @@
                role="menuitem">
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-map bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Ecosystem</div>
+                <div class="ms-2 text-xs/6">Landscape</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/ocg-server/templates/dashboard/group/spotlights_list.html
+++ b/ocg-server/templates/dashboard/group/spotlights_list.html
@@ -4,18 +4,36 @@
 {{ dashboard::page_title(title = "Member Spotlights") -}}
 
 <div class="my-5 grid gap-6">
-  <section class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
-    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-      <div>
-        <h2 class="text-lg font-semibold text-stone-950">Add a success story</h2>
-        <p class="mt-1 text-sm text-stone-600">Highlight a member story with an optional image and link. Only group admins can manage these cards.</p>
+  <section class="overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
+    <div class="border-b border-stone-100 bg-linear-to-br from-primary-50/80 via-white to-stone-50 px-5 py-5 sm:px-6">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div class="inline-flex rounded-full border border-primary-200 bg-white/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700">
+            New member story
+          </div>
+          <h2 class="mt-3 text-xl font-black tracking-tight text-stone-950">Add member spotlight</h2>
+          <p class="mt-2 max-w-2xl text-sm/6 text-stone-600">
+            Highlight a group member with a story, optional image, and a link to a deeper profile,
+            demo, article, or launch.
+          </p>
+        </div>
+        {% if can_manage_spotlights && !members.is_empty() -%}
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+            Use Published to control visibility.
+          </div>
+        {% else -%}
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+            {% if members.is_empty() -%}
+              Add group members first.
+            {% else -%}
+              Read only.
+            {% endif -%}
+          </div>
+        {% endif -%}
       </div>
-      {% if !can_manage_spotlights -%}
-        <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600">Read only</span>
-      {% endif -%}
     </div>
 
-    <form class="mt-5 grid gap-4"
+    <form class="grid gap-5 p-5 sm:p-6"
           hx-post="/dashboard/group/spotlights"
           hx-target="#dashboard-content"
           hx-indicator="#dashboard-spinner"
@@ -24,57 +42,57 @@
           {% endif -%}>
       <div class="grid gap-4 lg:grid-cols-2">
         <label class="block">
-          <span class="label-primary">Member</span>
-          <select name="user_id" class="input-primary mt-1" required>
+          <span class="label">Member</span>
+          <select name="user_id" class="input" required>
             {% for member in members -%}
               <option value="{{ member.user_id }}">{{ member.name.as_deref().unwrap_or(&member.username) }} (@{{ member.username }})</option>
             {% endfor -%}
           </select>
         </label>
         <label class="block">
-          <span class="label-primary">Title</span>
+          <span class="label">Title</span>
           <input name="title"
-                 class="input-primary mt-1"
+                 class="input"
                  maxlength="{{ crate::validation::MAX_LEN_M }}"
                  placeholder="How this member moved the community forward"
                  required>
         </label>
       </div>
       <label class="block">
-        <span class="label-primary">Story</span>
+        <span class="label">Story</span>
         <textarea name="story"
-                  class="input-primary mt-1 min-h-32"
+                  class="input min-h-32"
                   maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION }}"
                   placeholder="Tell the member story, result, or lesson."
                   required></textarea>
       </label>
       <div class="grid gap-4 lg:grid-cols-2">
         <label class="block">
-          <span class="label-primary">Image URL</span>
-          <input name="image_url" class="input-primary mt-1" placeholder="https://...">
+          <span class="label">Image URL</span>
+          <input name="image_url" class="input" placeholder="https://...">
         </label>
         <label class="block">
-          <span class="label-primary">Link URL</span>
-          <input name="link_url" class="input-primary mt-1" placeholder="https://...">
+          <span class="label">Link URL</span>
+          <input name="link_url" class="input" placeholder="https://...">
         </label>
       </div>
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <label class="block">
-          <span class="label-primary">Featured</span>
-          <select name="featured" class="input-primary mt-1">
+          <span class="label">Featured</span>
+          <select name="featured" class="input">
             <option value="false">No</option>
             <option value="true">Yes</option>
           </select>
         </label>
         <label class="block">
-          <span class="label-primary">Published</span>
-          <select name="published" class="input-primary mt-1">
+          <span class="label">Published</span>
+          <select name="published" class="input">
             <option value="true">Yes</option>
             <option value="false">No</option>
           </select>
         </label>
       </div>
-      <div>
+      <div class="flex justify-end border-t border-stone-100 pt-5">
         <button type="submit"
                 class="btn-primary"
                 {% if !can_manage_spotlights || members.is_empty() -%}
@@ -137,45 +155,45 @@
             <input type="hidden" name="user_id" value="{{ spotlight.user_id }}">
 
             <label class="block">
-              <span class="label-primary">Title</span>
+              <span class="label">Title</span>
               <input name="title"
-                     class="input-primary mt-1"
+                     class="input"
                      value="{{ spotlight.title }}"
                      maxlength="{{ crate::validation::MAX_LEN_M }}"
                      required>
             </label>
             <label class="block">
-              <span class="label-primary">Story</span>
+              <span class="label">Story</span>
               <textarea name="story"
-                        class="input-primary mt-1 min-h-32"
+                        class="input min-h-32"
                         maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION }}"
                         required>{{ spotlight.story }}</textarea>
             </label>
             <div class="grid gap-4 lg:grid-cols-2">
               <label class="block">
-                <span class="label-primary">Image URL</span>
+                <span class="label">Image URL</span>
                 <input name="image_url"
-                       class="input-primary mt-1"
+                       class="input"
                        value="{{ spotlight.image_url.as_deref().unwrap_or("") }}">
               </label>
               <label class="block">
-                <span class="label-primary">Link URL</span>
+                <span class="label">Link URL</span>
                 <input name="link_url"
-                       class="input-primary mt-1"
+                       class="input"
                        value="{{ spotlight.link_url.as_deref().unwrap_or("") }}">
               </label>
             </div>
             <div class="grid gap-4 sm:grid-cols-2">
               <label class="block">
-                <span class="label-primary">Featured</span>
-                <select name="featured" class="input-primary mt-1">
+                <span class="label">Featured</span>
+                <select name="featured" class="input">
                   <option value="false" {% if !spotlight.featured %}selected{% endif %}>No</option>
                   <option value="true" {% if spotlight.featured %}selected{% endif %}>Yes</option>
                 </select>
               </label>
               <label class="block">
-                <span class="label-primary">Published</span>
-                <select name="published" class="input-primary mt-1">
+                <span class="label">Published</span>
+                <select name="published" class="input">
                   <option value="true" {% if spotlight.published %}selected{% endif %}>Yes</option>
                   <option value="false" {% if !spotlight.published %}selected{% endif %}>No</option>
                 </select>

--- a/ocg-server/templates/dashboard/group/store_list.html
+++ b/ocg-server/templates/dashboard/group/store_list.html
@@ -3,18 +3,32 @@
 {{ dashboard::page_title(title = "Store") -}}
 
 <div class="my-5 grid gap-6">
-  <section class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
-    <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-      <div>
-        <h2 class="text-lg font-semibold text-stone-950">Add swag item</h2>
-        <p class="mt-1 text-sm text-stone-600">List group swag with a price, product image, inventory, and checkout link.</p>
+  <section class="overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
+    <div class="border-b border-stone-100 bg-linear-to-br from-primary-50/80 via-white to-stone-50 px-5 py-5 sm:px-6">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div class="inline-flex rounded-full border border-primary-200 bg-white/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700">
+            New store item
+          </div>
+          <h2 class="mt-3 text-xl font-black tracking-tight text-stone-950">Add swag item</h2>
+          <p class="mt-2 max-w-2xl text-sm/6 text-stone-600">
+            List group swag, merch, stickers, books, or sponsor kits with a price, image,
+            inventory, and checkout link.
+          </p>
+        </div>
+        {% if can_manage_store -%}
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+            Use Active to control visibility.
+          </div>
+        {% else -%}
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+            Read only.
+          </div>
+        {% endif -%}
       </div>
-      {% if !can_manage_store -%}
-        <span class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600">Read only</span>
-      {% endif -%}
     </div>
 
-    <form class="mt-5 grid gap-4"
+    <form class="grid gap-5 p-5 sm:p-6"
           hx-post="/dashboard/group/store"
           hx-target="#dashboard-content"
           hx-indicator="#dashboard-spinner"
@@ -23,37 +37,34 @@
           {% endif -%}>
       <div class="grid gap-4 lg:grid-cols-2">
         <label class="block">
-          <span class="label-primary">Name</span>
+          <span class="label">Name</span>
           <input name="name"
-                 class="input-primary mt-1"
+                 class="input"
                  maxlength="{{ crate::validation::MAX_LEN_M }}"
                  placeholder="Community hoodie"
                  required>
         </label>
         <label class="block">
-          <span class="label-primary">Checkout URL</span>
-          <input name="checkout_url"
-                 class="input-primary mt-1"
-                 placeholder="https://..."
-                 required>
+          <span class="label">Checkout URL</span>
+          <input name="checkout_url" class="input" placeholder="https://..." required>
         </label>
       </div>
       <label class="block">
-        <span class="label-primary">Description</span>
+        <span class="label">Description</span>
         <textarea name="description"
-                  class="input-primary mt-1 min-h-24"
+                  class="input min-h-24"
                   maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION_SHORT }}"
                   placeholder="Describe the item, sizes, shipping, or pickup details."></textarea>
       </label>
       <div class="grid gap-4 lg:grid-cols-2">
         <label class="block">
-          <span class="label-primary">Image URL</span>
-          <input name="image_url" class="input-primary mt-1" placeholder="https://...">
+          <span class="label">Image URL</span>
+          <input name="image_url" class="input" placeholder="https://...">
         </label>
         <label class="block">
-          <span class="label-primary">Price in cents</span>
+          <span class="label">Price in cents</span>
           <input name="price_minor"
-                 class="input-primary mt-1"
+                 class="input"
                  type="number"
                  min="0"
                  value="0"
@@ -62,37 +73,37 @@
       </div>
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <label class="block">
-          <span class="label-primary">Currency</span>
+          <span class="label">Currency</span>
           <input name="currency_code"
-                 class="input-primary mt-1 uppercase"
+                 class="input uppercase"
                  maxlength="3"
                  value="USD"
                  required>
         </label>
         <label class="block">
-          <span class="label-primary">Inventory</span>
+          <span class="label">Inventory</span>
           <input name="inventory_count"
-                 class="input-primary mt-1"
+                 class="input"
                  type="number"
                  min="0"
                  placeholder="Unlimited">
         </label>
         <label class="block">
-          <span class="label-primary">Featured</span>
-          <select name="featured" class="input-primary mt-1">
+          <span class="label">Featured</span>
+          <select name="featured" class="input">
             <option value="false">No</option>
             <option value="true">Yes</option>
           </select>
         </label>
         <label class="block">
-          <span class="label-primary">Active</span>
-          <select name="active" class="input-primary mt-1">
+          <span class="label">Active</span>
+          <select name="active" class="input">
             <option value="true">Yes</option>
             <option value="false">No</option>
           </select>
         </label>
       </div>
-      <div>
+      <div class="flex justify-end border-t border-stone-100 pt-5">
         <button type="submit"
                 class="btn-primary"
                 {% if !can_manage_store -%}
@@ -151,38 +162,38 @@
 
             <div class="grid gap-4 lg:grid-cols-2">
               <label class="block">
-                <span class="label-primary">Name</span>
+                <span class="label">Name</span>
                 <input name="name"
-                       class="input-primary mt-1"
+                       class="input"
                        value="{{ item.name }}"
                        maxlength="{{ crate::validation::MAX_LEN_M }}"
                        required>
               </label>
               <label class="block">
-                <span class="label-primary">Checkout URL</span>
+                <span class="label">Checkout URL</span>
                 <input name="checkout_url"
-                       class="input-primary mt-1"
+                       class="input"
                        value="{{ item.checkout_url }}"
                        required>
               </label>
             </div>
             <label class="block">
-              <span class="label-primary">Description</span>
+              <span class="label">Description</span>
               <textarea name="description"
-                        class="input-primary mt-1 min-h-24"
+                        class="input min-h-24"
                         maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION_SHORT }}">{{ item.description.as_deref().unwrap_or("") }}</textarea>
             </label>
             <div class="grid gap-4 lg:grid-cols-2">
               <label class="block">
-                <span class="label-primary">Image URL</span>
+                <span class="label">Image URL</span>
                 <input name="image_url"
-                       class="input-primary mt-1"
+                       class="input"
                        value="{{ item.image_url.as_deref().unwrap_or("") }}">
               </label>
               <label class="block">
-                <span class="label-primary">Price in cents</span>
+                <span class="label">Price in cents</span>
                 <input name="price_minor"
-                       class="input-primary mt-1"
+                       class="input"
                        type="number"
                        min="0"
                        value="{{ item.price_minor }}"
@@ -191,31 +202,31 @@
             </div>
             <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <label class="block">
-                <span class="label-primary">Currency</span>
+                <span class="label">Currency</span>
                 <input name="currency_code"
-                       class="input-primary mt-1 uppercase"
+                       class="input uppercase"
                        maxlength="3"
                        value="{{ item.currency_code }}"
                        required>
               </label>
               <label class="block">
-                <span class="label-primary">Inventory</span>
+                <span class="label">Inventory</span>
                 <input name="inventory_count"
-                       class="input-primary mt-1"
+                       class="input"
                        type="number"
                        min="0"
                        value="{{ item.inventory_input_value() }}">
               </label>
               <label class="block">
-                <span class="label-primary">Featured</span>
-                <select name="featured" class="input-primary mt-1">
+                <span class="label">Featured</span>
+                <select name="featured" class="input">
                   <option value="false" {% if !item.featured %}selected{% endif %}>No</option>
                   <option value="true" {% if item.featured %}selected{% endif %}>Yes</option>
                 </select>
               </label>
               <label class="block">
-                <span class="label-primary">Active</span>
-                <select name="active" class="input-primary mt-1">
+                <span class="label">Active</span>
+                <select name="active" class="input">
                   <option value="true" {% if item.active %}selected{% endif %}>Yes</option>
                   <option value="false" {% if !item.active %}selected{% endif %}>No</option>
                 </select>

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -47,7 +47,7 @@ test.describe("site header", () => {
       "/log-in?next_url=/dashboard/jobs",
     );
     await expect(
-      navigation.getByRole("link", { name: "Ecosystem" }),
+      navigation.getByRole("link", { name: "Landscape" }),
     ).toHaveAttribute("href", "/landscape");
     await expect(
       navigation.getByRole("link", { name: "Resources" }),
@@ -95,7 +95,7 @@ test.describe("site header", () => {
       0,
     );
     await expect(
-      userMenu.getByRole("menuitem", { name: "Ecosystem" }),
+      userMenu.getByRole("menuitem", { name: "Landscape" }),
     ).toHaveCount(0);
     await expect(
       userMenu.getByRole("menuitem", { name: "Resources" }),


### PR DESCRIPTION
## Summary
- Restyle group spotlight and store dashboard add forms to match the alliance landscape form treatment
- Normalize spotlight/store edit fields to use the shared dashboard `label` and `input` styling
- Preserve existing HTMX routes and permission behavior

## Test plan
- uvx djlint --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/dashboard/group/spotlights_list.html ocg-server/templates/dashboard/group/store_list.html
- cargo check -p ocg-server

Made with [Cursor](https://cursor.com)