### PR TITLE
Fix jobs search typing behavior

### DIFF
--- a/ocg-server/templates/site/jobs/page.html
+++ b/ocg-server/templates/site/jobs/page.html
@@ -22,11 +22,12 @@
           hx-get="/jobs"
           hx-target="body"
           hx-push-url="true"
-          hx-trigger="input changed delay:300ms from:#jobs-query, input changed delay:300ms from:#jobs-location, change from:#jobs-remote"
+          hx-trigger="submit, search from:#jobs-query, change from:#jobs-location, change from:#jobs-remote"
           class="mb-8 grid gap-3 rounded-2xl border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_240px_auto_auto]">
       <label class="sr-only" for="jobs-query">Search jobs</label>
       <input id="jobs-query"
              name="query"
+             type="search"
              value="{{ filters.query.as_deref().unwrap_or("") }}"
              class="input"
              placeholder="Search title, company, summary, or tags" />


### PR DESCRIPTION
## Summary
- Stop the public jobs page from re-rendering on every query keystroke so trailing spaces are not immediately removed while typing.
- Keep HTMX search behavior on form submit, search events, location changes, and remote filter changes.

## Test plan
- `uvx djlint --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/site/jobs/page.html`
- `cargo check -p ocg-server`

Made with [Cursor](https://cursor.com)