### PR TITLE
Add signup onboarding email

### DIFF
--- a/database/migrations/schema/0015_site_onboarding_notification.sql
+++ b/database/migrations/schema/0015_site_onboarding_notification.sql
@@ -1,0 +1,4 @@
+insert into notification_kind (notification_kind_id, name, optional_notification)
+values ('6bc2dc91-ccff-49f5-8b73-3a70af0387a6', 'site-onboarding', false)
+on conflict (name) do update
+set optional_notification = excluded.optional_notification;

--- a/database/tests/schema/06_constraints_and_reference_data.sql
+++ b/database/tests/schema/06_constraints_and_reference_data.sql
@@ -325,6 +325,7 @@ select results_eq(
         ('group-team-invitation', false),
         ('group-welcome', false),
         ('session-proposal-co-speaker-invitation', false),
+        ('site-onboarding', false),
         ('speaker-series-welcome', false),
         ('speaker-welcome', false)
     $$,

--- a/ocg-server/src/handlers/auth.rs
+++ b/ocg-server/src/handlers/auth.rs
@@ -34,10 +34,11 @@ use crate::{
             ValidatedFormQs,
         },
     },
+    services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
     templates::{
         self, PageId,
         auth::{User, UserDetails},
-        notifications::EmailVerification,
+        notifications::{EmailVerification, SiteOnboarding},
     },
     types::permissions::{AlliancePermission, GroupPermission},
     validation::{MAX_LEN_S, trimmed_non_empty},
@@ -343,6 +344,7 @@ pub(crate) async fn oidc_redirect(
 pub(crate) async fn sign_up(
     messages: Messages,
     State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
     State(server_cfg): State<HttpServerConfig>,
     Query(query): Query<HashMap<String, String>>,
     Form(mut user_summary): Form<auth::UserSummary>,
@@ -379,11 +381,13 @@ pub(crate) async fn sign_up(
         Ok(None) => db.sign_up_user(&user_summary, false, Some(verification)).await,
         Err(err) => Err(err),
     };
-    let Ok((_user, email_verification_code)) = sign_up_result else {
+    let Ok((user, email_verification_code)) = sign_up_result else {
         // Redirect to the sign up page on error
         messages.error("Something went wrong while signing up. Please try again later.");
         return Ok(Redirect::to(SIGN_UP_URL).into_response());
     };
+
+    enqueue_site_onboarding_notification(&db, &notifications_manager, &server_cfg, &user).await;
 
     // Notify the user that database-side verification email enqueue was requested
     if email_verification_code.is_some() {
@@ -991,6 +995,53 @@ async fn build_email_verification_notification(
         code,
         template_data,
     })
+}
+
+/// Enqueues first-step guidance for a newly created account.
+async fn enqueue_site_onboarding_notification(
+    db: &DynDB,
+    notifications_manager: &DynNotificationsManager,
+    server_cfg: &HttpServerConfig,
+    user: &auth::User,
+) {
+    if let Err(err) =
+        try_enqueue_site_onboarding_notification(db, notifications_manager, server_cfg, user).await
+    {
+        warn!(
+            error = %err,
+            user_id = %user.user_id,
+            "failed to enqueue site onboarding notification"
+        );
+    }
+}
+
+/// Builds and enqueues the new-user onboarding email.
+async fn try_enqueue_site_onboarding_notification(
+    db: &DynDB,
+    notifications_manager: &DynNotificationsManager,
+    server_cfg: &HttpServerConfig,
+    user: &auth::User,
+) -> Result<(), HandlerError> {
+    let site_settings = db.get_site_settings().await?;
+    let base_url = server_cfg.base_url.trim_end_matches('/');
+    let template_data = SiteOnboarding {
+        explore_link: format!("{base_url}/explore"),
+        jobs_link: format!("{base_url}/jobs"),
+        landscape_link: format!("{base_url}/landscape"),
+        search_link: format!("{base_url}/search"),
+        theme: site_settings.theme,
+        user_dashboard_link: format!("{base_url}/dashboard/user"),
+        user_name: user.name.clone(),
+    };
+    let notification = NewNotification {
+        attachments: vec![],
+        kind: NotificationKind::SiteOnboarding,
+        recipients: vec![user.user_id],
+        template_data: Some(serde_json::to_value(&template_data)?),
+    };
+
+    notifications_manager.enqueue(&notification).await?;
+    Ok(())
 }
 
 /// Percent-encode a `next_url` so it can be safely embedded in a query string.

--- a/ocg-server/src/handlers/auth/tests.rs
+++ b/ocg-server/src/handlers/auth/tests.rs
@@ -1430,9 +1430,11 @@ async fn test_sign_up_success() {
     let session_id = session::Id::default();
     let session_record = sample_empty_session_record(session_id);
     let user_for_db = sample_auth_user(Uuid::new_v4(), "hash");
+    let user_id = user_for_db.user_id;
     let site_settings = sample_site_settings();
     let activation_primary_color = site_settings.theme.primary_color.clone();
     let sign_up_primary_color = site_settings.theme.primary_color.clone();
+    let onboarding_primary_color = site_settings.theme.primary_color.clone();
 
     // Setup database mock
     let mut db = MockDB::new();
@@ -1441,7 +1443,7 @@ async fn test_sign_up_success() {
         .withf(move |id| *id == session_id)
         .returning(move |_| Ok(Some(session_record.clone())));
     db.expect_get_site_settings()
-        .times(1)
+        .times(2)
         .returning(move || Ok(site_settings.clone()));
     db.expect_activate_pre_registered_user_email_password()
         .times(1)
@@ -1480,7 +1482,25 @@ async fn test_sign_up_success() {
 
     // Setup notifications manager mock
     let mut nm = MockNotificationsManager::new();
-    nm.expect_enqueue().times(0);
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::SiteOnboarding)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref().is_some_and(|data| {
+                    serde_json::from_value::<SiteOnboarding>(data.clone()).is_ok_and(|onboarding| {
+                        onboarding.explore_link == "https://app.example/explore"
+                            && onboarding.jobs_link == "https://app.example/jobs"
+                            && onboarding.landscape_link == "https://app.example/landscape"
+                            && onboarding.search_link == "https://app.example/search"
+                            && onboarding.user_dashboard_link
+                                == "https://app.example/dashboard/user"
+                            && onboarding.user_name == "Test User"
+                            && onboarding.theme.primary_color == onboarding_primary_color
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
 
     // Setup router
     let server_cfg = HttpServerConfig {
@@ -1525,8 +1545,10 @@ async fn test_sign_up_activates_pre_registered_user() {
     let session_id = session::Id::default();
     let session_record = sample_empty_session_record(session_id);
     let user_for_db = sample_auth_user(Uuid::new_v4(), "hash");
+    let user_id = user_for_db.user_id;
     let site_settings = sample_site_settings();
     let activation_primary_color = site_settings.theme.primary_color.clone();
+    let onboarding_primary_color = site_settings.theme.primary_color.clone();
 
     // Setup database mock
     let mut db = MockDB::new();
@@ -1535,7 +1557,7 @@ async fn test_sign_up_activates_pre_registered_user() {
         .withf(move |id| *id == session_id)
         .returning(move |_| Ok(Some(session_record.clone())));
     db.expect_get_site_settings()
-        .times(1)
+        .times(2)
         .returning(move || Ok(site_settings.clone()));
     db.expect_activate_pre_registered_user_email_password()
         .times(1)
@@ -1565,7 +1587,22 @@ async fn test_sign_up_activates_pre_registered_user() {
 
     // Setup notifications manager mock
     let mut nm = MockNotificationsManager::new();
-    nm.expect_enqueue().times(0);
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::SiteOnboarding)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref().is_some_and(|data| {
+                    serde_json::from_value::<SiteOnboarding>(data.clone()).is_ok_and(|onboarding| {
+                        onboarding.explore_link == "https://app.example/explore"
+                            && onboarding.user_dashboard_link
+                                == "https://app.example/dashboard/user"
+                            && onboarding.user_name == "Test User"
+                            && onboarding.theme.primary_color == onboarding_primary_color
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
 
     // Setup router
     let server_cfg = HttpServerConfig {

--- a/ocg-server/src/services/notifications.rs
+++ b/ocg-server/src/services/notifications.rs
@@ -33,7 +33,7 @@ use crate::{
         EventRefundRejected, EventRefundRequested, EventReminder, EventRescheduled,
         EventSeriesCanceled, EventSeriesPublished, EventWaitlistJoined, EventWaitlistLeft,
         EventWaitlistPromoted, EventWelcome, GroupCustom, GroupTeamInvitation, GroupWelcome,
-        SessionProposalCoSpeakerInvitation, SpeakerSeriesWelcome, SpeakerWelcome,
+        SessionProposalCoSpeakerInvitation, SiteOnboarding, SpeakerSeriesWelcome, SpeakerWelcome,
     },
 };
 
@@ -453,6 +453,12 @@ impl DeliveryWorker {
                 let body = template.render()?;
                 (subject, body)
             }
+            NotificationKind::SiteOnboarding => {
+                let subject = "Welcome to GOUP".to_string();
+                let template: SiteOnboarding = serde_json::from_value(template_data)?;
+                let body = template.render()?;
+                (subject, body)
+            }
             NotificationKind::SessionProposalCoSpeakerInvitation => {
                 let subject = "Session proposal co-speaker invitation".to_string();
                 let template: SessionProposalCoSpeakerInvitation =
@@ -709,6 +715,8 @@ pub(crate) enum NotificationKind {
     GroupTeamInvitation,
     /// Notification welcoming a new group member.
     GroupWelcome,
+    /// Notification with first steps for a newly created account.
+    SiteOnboarding,
     /// Notification inviting a co-speaker to respond to a session proposal invitation.
     SessionProposalCoSpeakerInvitation,
     /// Notification welcoming a speaker to multiple events in a linked series.

--- a/ocg-server/src/services/notifications/tests.rs
+++ b/ocg-server/src/services/notifications/tests.rs
@@ -439,6 +439,30 @@ fn test_delivery_worker_prepare_content_email_verification() {
 }
 
 #[test]
+fn test_delivery_worker_prepare_content_site_onboarding() {
+    // Setup notification
+    let notification = Notification {
+        attachments: vec![],
+        email: "user@example.test".to_string(),
+        kind: NotificationKind::SiteOnboarding,
+        notification_id: Uuid::new_v4(),
+        template_data: Some(sample_site_onboarding_template_data()),
+    };
+
+    // Prepare content
+    let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
+
+    // Check content matches expectations
+    assert_eq!(subject, "Welcome to GOUP");
+    assert!(body.contains("Hi Test User"));
+    assert!(body.contains("https://example.test/explore"));
+    assert!(body.contains("https://example.test/jobs"));
+    assert!(body.contains("https://example.test/landscape"));
+    assert!(body.contains("https://example.test/search"));
+    assert!(body.contains("https://example.test/dashboard/user"));
+}
+
+#[test]
 fn test_delivery_worker_prepare_content_event_attendance_canceled() {
     // Setup notification
     let notification = Notification {
@@ -1062,6 +1086,21 @@ fn sample_email_verification_template_data() -> serde_json::Value {
         "theme": {
             "primary_color": "#000000"
         }
+    })
+}
+
+/// Sample template payload for site onboarding notifications.
+fn sample_site_onboarding_template_data() -> serde_json::Value {
+    json!({
+        "explore_link": "https://example.test/explore",
+        "jobs_link": "https://example.test/jobs",
+        "landscape_link": "https://example.test/landscape",
+        "search_link": "https://example.test/search",
+        "theme": {
+            "primary_color": "#000000"
+        },
+        "user_dashboard_link": "https://example.test/dashboard/user",
+        "user_name": "Test User"
     })
 }
 

--- a/ocg-server/src/templates/notifications.rs
+++ b/ocg-server/src/templates/notifications.rs
@@ -319,6 +319,26 @@ pub(crate) struct GroupWelcome {
     pub theme: Theme,
 }
 
+/// Template for site onboarding notification.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "notifications/site_onboarding.html")]
+pub(crate) struct SiteOnboarding {
+    /// Link to the public events and groups page.
+    pub explore_link: String,
+    /// Link to the public jobs board.
+    pub jobs_link: String,
+    /// Link to the public landscape page.
+    pub landscape_link: String,
+    /// Link to the public search page.
+    pub search_link: String,
+    /// Theme configuration for the site.
+    pub theme: Theme,
+    /// Link to the user's dashboard.
+    pub user_dashboard_link: String,
+    /// Display name for the recipient.
+    pub user_name: String,
+}
+
 /// Template for session proposal co-speaker invitation notification.
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "notifications/session_proposal_co_speaker_invitation.html")]

--- a/ocg-server/templates/notifications/site_onboarding.html
+++ b/ocg-server/templates/notifications/site_onboarding.html
@@ -1,0 +1,59 @@
+{% extends "notifications/base.html" -%}
+{% import "macros/email.html" as email -%}
+
+{# Site Onboarding Notification -#}
+{% block subject -%}
+  Welcome to GOUP
+{% endblock subject -%}
+
+{% block preheader -%}
+  Start with events, groups, jobs, and your profile.
+{% endblock preheader -%}
+
+{% block content -%}
+  <p class="default mb-30" style="margin-bottom: 30px">
+    Hi {{ user_name }},
+    <br />
+    <br />
+    Welcome to <strong>GOUP</strong>. Here are the best places to start:
+  </p>
+
+  <ul class="default mb-30"
+      style="font-family: sans-serif;
+             font-size: 14px;
+             margin-bottom: 30px;
+             margin-top: 0;
+             padding-left: 20px">
+    <li>
+      <a href="{{ explore_link }}" target="_blank" rel="noopener noreferrer">Events & groups</a>
+      to find upcoming meetups and chapters.
+    </li>
+    <li>
+      <a href="{{ jobs_link }}" target="_blank" rel="noopener noreferrer">Jobs</a>
+      to browse roles shared by members.
+    </li>
+    <li>
+      <a href="{{ landscape_link }}" target="_blank" rel="noopener noreferrer">Landscape</a>
+      to discover companies, projects, and ecosystem links.
+    </li>
+    <li>
+      <a href="{{ search_link }}" target="_blank" rel="noopener noreferrer">Search GOUP</a>
+      when you want to find people, events, jobs, or resources quickly.
+    </li>
+  </ul>
+
+  {{ email::button(link = user_dashboard_link, text = "Open your dashboard", color = theme.primary_color) }}
+
+  <p class="default mt-30 mb-15"
+     style="margin-top: 30px;
+            margin-bottom: 15px">
+    From your dashboard, you can complete your profile and manage your events,
+    invitations, and posted roles.
+  </p>
+{% endblock content -%}
+
+{% block footer -%}
+  You received this email notification because you created a GOUP account. If
+  that wasn't you, you can ignore this message.
+{% endblock footer -%}
+{# End site onboarding notification -#}


### PR DESCRIPTION
## Summary
- Add a queued site onboarding notification with links to Events & Groups, Jobs, Landscape, Search, and the user dashboard.
- Enqueue onboarding best-effort after email/password account creation, while keeping email verification as the separate required verification step.
- Register the new notification kind in database reference data.

## Test plan
- `uvx djlint --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/notifications/site_onboarding.html`
- `cargo test -p ocg-server test_sign_up_success`
- `cargo test -p ocg-server test_sign_up_activates_pre_registered_user`
- `cargo test -p ocg-server test_delivery_worker_prepare_content_site_onboarding`
- `cargo check -p ocg-server`

Made with [Cursor](https://cursor.com)