### PR TITLE
Send onboarding for new external users

### DIFF
--- a/ocg-server/src/auth.rs
+++ b/ocg-server/src/auth.rs
@@ -280,10 +280,12 @@ impl AuthnBackend {
             .await?
         {
             if user.registration_status == "pre-registered" {
-                return self
+                let mut user = self
                     .db
                     .activate_pre_registered_user_external_provider(&user.user_id, user_summary)
-                    .await;
+                    .await?;
+                user.newly_registered = true;
+                return Ok(user);
             }
 
             if let Some(provider) = user_summary.provider.clone() {
@@ -305,7 +307,8 @@ impl AuthnBackend {
             }
             Ok(user)
         } else {
-            let (user, _) = self.db.sign_up_user(user_summary, true, None).await?;
+            let (mut user, _) = self.db.sign_up_user(user_summary, true, None).await?;
+            user.newly_registered = true;
             Ok(user)
         }
     }
@@ -562,6 +565,9 @@ pub(crate) struct User {
     pub email_verified: bool,
     /// User's display name.
     pub name: String,
+    /// Whether this request just created or activated the user account.
+    #[serde(default, skip_serializing)]
+    pub newly_registered: bool,
     /// Whether the user receives optional notifications.
     pub optional_notifications_enabled: bool,
     /// Whether the user can manage platform-level resources.

--- a/ocg-server/src/auth.rs
+++ b/ocg-server/src/auth.rs
@@ -553,6 +553,7 @@ pub(crate) struct PasswordCredentials {
 // User types and implementations.
 
 /// Represents a user in the system.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub(crate) struct User {
     /// Unique user ID.

--- a/ocg-server/src/handlers/auth.rs
+++ b/ocg-server/src/handlers/auth.rs
@@ -241,6 +241,7 @@ pub(crate) async fn log_out(
 }
 
 /// Handler that completes the oauth2 authorization process.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
 pub(crate) async fn oauth2_callback(
     mut auth_session: AuthSession,
@@ -292,6 +293,7 @@ pub(crate) async fn oauth2_redirect(
 }
 
 /// Handler that completes the oidc authorization process.
+#[allow(clippy::too_many_arguments)]
 #[instrument(skip_all)]
 pub(crate) async fn oidc_callback(
     mut auth_session: AuthSession,
@@ -518,6 +520,7 @@ impl CallbackAuth for AuthSession {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn oauth2_callback_with_auth<A, F>(
     auth: &mut A,
     session: Session,
@@ -616,6 +619,7 @@ async fn try_auto_join_linkedin_baku_chapter(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn oidc_callback_with_auth<A, F>(
     auth: &mut A,
     session: Session,

--- a/ocg-server/src/handlers/auth.rs
+++ b/ocg-server/src/handlers/auth.rs
@@ -247,6 +247,8 @@ pub(crate) async fn oauth2_callback(
     messages: Messages,
     session: Session,
     State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
+    State(server_cfg): State<HttpServerConfig>,
     Path(provider): Path<OAuth2Provider>,
     Query(OAuth2AuthorizationResponse { code, state }): Query<OAuth2AuthorizationResponse>,
 ) -> Result<impl IntoResponse, HandlerError> {
@@ -254,6 +256,8 @@ pub(crate) async fn oauth2_callback(
         &mut auth_session,
         session,
         &db,
+        &notifications_manager,
+        &server_cfg,
         provider,
         code,
         state,
@@ -294,6 +298,8 @@ pub(crate) async fn oidc_callback(
     messages: Messages,
     session: Session,
     State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
+    State(server_cfg): State<HttpServerConfig>,
     Path(provider): Path<OidcProvider>,
     Query(OAuth2AuthorizationResponse { code, state }): Query<OAuth2AuthorizationResponse>,
 ) -> Result<impl IntoResponse, HandlerError> {
@@ -301,6 +307,8 @@ pub(crate) async fn oidc_callback(
         &mut auth_session,
         session,
         &db,
+        &notifications_manager,
+        &server_cfg,
         provider,
         code,
         state,
@@ -514,6 +522,8 @@ async fn oauth2_callback_with_auth<A, F>(
     auth: &mut A,
     session: Session,
     db: &DynDB,
+    notifications_manager: &DynNotificationsManager,
+    server_cfg: &HttpServerConfig,
     provider: OAuth2Provider,
     code: String,
     state: oauth2::CsrfToken,
@@ -558,6 +568,10 @@ where
 
     // LinkedIn users should automatically join the Baku chapter when it exists.
     auto_join_linkedin_baku_chapter(db, &user.user_id).await;
+
+    if user.newly_registered {
+        enqueue_site_onboarding_notification(db, notifications_manager, server_cfg, &user).await;
+    }
 
     // Select the first alliance and group as selected in the session
     select_first_alliance_and_group(db, &session, &user.user_id).await?;
@@ -606,6 +620,8 @@ async fn oidc_callback_with_auth<A, F>(
     auth: &mut A,
     session: Session,
     db: &DynDB,
+    notifications_manager: &DynNotificationsManager,
+    server_cfg: &HttpServerConfig,
     provider: OidcProvider,
     code: String,
     state: oauth2::CsrfToken,
@@ -659,6 +675,10 @@ where
 
     // Select the first alliance and group as selected in the session
     select_first_alliance_and_group(db, &session, &user.user_id).await?;
+
+    if user.newly_registered {
+        enqueue_site_onboarding_notification(db, notifications_manager, server_cfg, &user).await;
+    }
 
     // Track auth provider in the session
     session.insert(AUTH_PROVIDER_KEY, provider).await?;

--- a/ocg-server/src/handlers/auth/tests.rs
+++ b/ocg-server/src/handlers/auth/tests.rs
@@ -29,7 +29,10 @@ use crate::{
         extractors::{OAuth2, Oidc},
         tests::*,
     },
-    services::{images::MockImageStorage, notifications::MockNotificationsManager},
+    services::{
+        images::MockImageStorage,
+        notifications::{DynNotificationsManager, MockNotificationsManager},
+    },
 };
 
 use super::*;
@@ -755,6 +758,8 @@ async fn test_oauth2_callback_authorization_error() {
         &mut callback_auth,
         session.clone(),
         &db,
+        &sample_notifications_manager(),
+        &sample_tracking_server_cfg(),
         OAuth2Provider::GitHub,
         "test-code".to_string(),
         oauth2::CsrfToken::new("state-in-session".to_string()),
@@ -830,6 +835,8 @@ async fn test_oauth2_callback_success() {
         &mut callback_auth,
         session.clone(),
         &db,
+        &sample_notifications_manager(),
+        &sample_tracking_server_cfg(),
         OAuth2Provider::GitHub,
         "test-code".to_string(),
         oauth2::CsrfToken::new("state-in-session".to_string()),
@@ -1189,6 +1196,8 @@ async fn test_oidc_callback_authorization_error() {
         &mut callback_auth,
         session.clone(),
         &db,
+        &sample_notifications_manager(),
+        &sample_tracking_server_cfg(),
         OidcProvider::LinkedIn,
         "test-code".to_string(),
         oauth2::CsrfToken::new("state-in-session".to_string()),
@@ -1263,6 +1272,8 @@ async fn test_oidc_callback_success() {
         &mut callback_auth,
         session.clone(),
         &db,
+        &sample_notifications_manager(),
+        &sample_tracking_server_cfg(),
         OidcProvider::LinkedIn,
         "test-code".to_string(),
         oauth2::CsrfToken::new("state-in-session".to_string()),
@@ -1287,6 +1298,91 @@ async fn test_oidc_callback_success() {
     assert_eq!(auth_provider, Some(OidcProvider::LinkedIn));
     assert_eq!(selected_alliance_id, Some(alliance_id));
     assert_eq!(selected_group_id, Some(group_id));
+}
+
+#[tokio::test]
+async fn test_oidc_callback_enqueues_onboarding_for_new_external_user() {
+    // Setup identifiers and data structures
+    let alliance_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let user_id = Uuid::new_v4();
+    let auth_hash = "hash".to_string();
+    let groups = sample_user_groups_by_alliance(alliance_id, group_id);
+
+    // Setup in-memory session
+    let store = Arc::new(MemoryStore::default());
+    let session = Session::new(None, store, None);
+    session
+        .insert(OAUTH2_CSRF_STATE_KEY, "state-in-session")
+        .await
+        .unwrap();
+    session.insert(OIDC_NONCE_KEY, "nonce-in-session").await.unwrap();
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_list_user_groups()
+        .times(1)
+        .withf(move |uid| uid == &user_id)
+        .returning(move |_| Ok(groups.clone()));
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(|| Ok(sample_site_settings()));
+
+    // Setup callback auth mock
+    let mut user = sample_auth_user(user_id, &auth_hash);
+    user.newly_registered = true;
+    let mut callback_auth = MockCallbackAuth {
+        login_called: false,
+        login_result: Some(Ok(())),
+        oidc_result: Some(Ok(Some(user))),
+        oauth2_result: None,
+    };
+    let db: DynDB = Arc::new(db);
+
+    // Setup notifications manager mock
+    let mut nm = MockNotificationsManager::new();
+    nm.expect_enqueue()
+        .times(1)
+        .withf(move |notification| {
+            matches!(notification.kind, NotificationKind::SiteOnboarding)
+                && notification.recipients == vec![user_id]
+                && notification.template_data.as_ref().is_some_and(|data| {
+                    serde_json::from_value::<SiteOnboarding>(data.clone()).is_ok_and(|onboarding| {
+                        onboarding.explore_link == "https://example.test/explore"
+                            && onboarding.user_dashboard_link
+                                == "https://example.test/dashboard/user"
+                            && onboarding.user_name == "Test User"
+                    })
+                })
+        })
+        .returning(|_| Box::pin(async { Ok(()) }));
+    let notifications_manager: DynNotificationsManager = Arc::new(nm);
+
+    // Execute helper
+    let redirect = oidc_callback_with_auth(
+        &mut callback_auth,
+        session.clone(),
+        &db,
+        &notifications_manager,
+        &sample_tracking_server_cfg(),
+        OidcProvider::LinkedIn,
+        "test-code".to_string(),
+        oauth2::CsrfToken::new("state-in-session".to_string()),
+        |_| {
+            panic!("oidc callback success should not emit an error message");
+        },
+    )
+    .await
+    .unwrap();
+
+    // Check callback result and side effects
+    let response = redirect.into_response();
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        response.headers().get(LOCATION).unwrap(),
+        &HeaderValue::from_static("/")
+    );
+    assert!(callback_auth.login_called);
 }
 
 #[tokio::test]
@@ -4941,4 +5037,8 @@ impl CallbackAuth for MockCallbackAuth {
             .take()
             .expect("callback login result should be configured in tests")
     }
+}
+
+fn sample_notifications_manager() -> DynNotificationsManager {
+    Arc::new(MockNotificationsManager::new())
 }


### PR DESCRIPTION
## Summary
- Mark externally created or activated users during authentication so LinkedIn/GitHub signups receive onboarding once.
- Keep returning external logins from receiving repeated onboarding emails.
- Continue skipping email verification for externally verified identities.

## Test plan
- `cargo test -p ocg-server test_oidc_callback_success`
- `cargo test -p ocg-server test_oidc_callback_enqueues_onboarding_for_new_external_user`
- `cargo test -p ocg-server test_oauth2_callback_success`
- `cargo check -p ocg-server`

Made with [Cursor](https://cursor.com)