### PR TITLE
Update MCP server docs and footer link

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -4,6 +4,21 @@ This directory contains a lightweight remote MCP server for GOUP operational
 tools. It exposes MCP JSON-RPC over HTTP at `/mcp` and loads tool definitions
 from `tools.json`.
 
+## Architecture
+
+- `server.mjs` is the HTTP JSON-RPC server. It handles MCP initialization,
+  `tools/list`, `tools/call`, simple health checks, bearer-token auth, and the
+  built-in database-backed tool actions.
+- `tools.json` is the tool catalog. Static tools render `output.text` templates;
+  action tools call JavaScript handlers in `server.mjs`.
+- `package.json` declares the Node runtime and local scripts.
+- `scripts/setup-mcp-ec2.sh` in the repository root installs the EC2 systemd
+  service and writes `~/.config/ocg/mcp.env`.
+
+Static tool output supports `{{ name }}` placeholders from tool arguments. If an
+argument is omitted and the corresponding JSON schema property has a `default`,
+the default value is rendered.
+
 ## Run Locally
 
 ```bash
@@ -18,6 +33,13 @@ Useful checks:
 ```bash
 curl http://127.0.0.1:8787/health
 curl http://127.0.0.1:8787/tools
+```
+
+Validate server syntax and `tools.json`:
+
+```bash
+cd mcp
+npm run check
 ```
 
 ## Run Remotely
@@ -56,6 +78,30 @@ MCP_ENABLE_MUTATIONS=true
 
 The event creation tool uses `psql` and reads database connection details from
 `DATABASE_URL`, `TERN_CONF`, or `$HOME/.config/ocg/tern.conf`.
+
+## Update an Existing EC2 MCP Service
+
+After MCP code or `tools.json` changes are merged to `main`, update EC2 with:
+
+```bash
+cd ~/goup.vc
+git pull origin main
+cd mcp
+npm run check
+sudo systemctl restart goup-mcp
+sudo systemctl status goup-mcp --no-pager
+```
+
+Check the remote endpoint locally on EC2:
+
+```bash
+source "$HOME/.config/ocg/mcp.env"
+curl -H "Authorization: Bearer $MCP_BEARER_TOKEN" http://127.0.0.1:8787/health
+curl -H "Authorization: Bearer $MCP_BEARER_TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' \
+  http://127.0.0.1:8787/mcp
+```
 
 Authentication is done with an HTTP bearer token. Clients must send:
 
@@ -109,9 +155,11 @@ through the standard `tools/list` method.
 
 ## Included Tools
 
-- `goup_deploy_after_pull`: full EC2 update flow after `git pull`.
+- `goup_deploy_after_pull`: full EC2 update flow after pulling `origin main`.
+  Accepts optional `build_jobs` from `1` to `4`; default is `2`.
 - `goup_run_migrations`: run `tern` migrations.
 - `goup_release_build_background`: build `ocg-server` in the background.
+  Accepts optional `build_jobs` from `1` to `4`; default is `2`.
 - `goup_service_status`: inspect systemd logs and local HTTP status.
 - `goup_create_event`: create an unpublished draft event through `add_event`.
 - `goup_update_event`: update an existing event through `update_event`.

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "description": "Remote MCP server for GOUP VC operational tools.",
   "scripts": {
+    "check": "node --check server.mjs && node -e \"JSON.parse(require('node:fs').readFileSync('tools.json', 'utf8'))\"",
     "start": "node server.mjs"
   },
   "engines": {

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -985,7 +985,7 @@ async function readTernConfig(path) {
 
 function renderToolOutput(tool, args) {
   return tool.output.text.replace(/\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g, (_, key) => {
-    const value = args[key];
+    const value = args[key] ?? tool.inputSchema?.properties?.[key]?.default;
     return value === undefined || value === null ? "" : String(value);
   });
 }

--- a/mcp/tools.json
+++ b/mcp/tools.json
@@ -5,11 +5,19 @@
     "description": "Commands to run after pulling new GOUP code on EC2.",
     "inputSchema": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "build_jobs": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 4,
+          "description": "Cargo build job count for the EC2 release build."
+        }
+      },
       "additionalProperties": false
     },
     "output": {
-      "text": "cd ~/goup.vc\ngit pull\n\ncd database/migrations\nTERN_CONF=\"$HOME/.config/ocg/tern.conf\" ./migrate.sh\n\ncd ~/goup.vc\nnohup env CARGO_BUILD_JOBS=1 cargo build --release -p ocg-server > ~/goup-build.log 2>&1 &\ntail -f ~/goup-build.log\n\nsudo systemctl restart ocg-server\nsudo systemctl status ocg-server --no-pager\ncurl -I http://127.0.0.1:9000"
+      "text": "cd ~/goup.vc\ngit pull origin main\n\ncd ~/goup.vc/database/migrations\nTERN_CONF=\"$HOME/.config/ocg/tern.conf\" ./migrate.sh\n\ncd ~/goup.vc\nnohup env CARGO_BUILD_JOBS={{ build_jobs }} cargo build --release -p ocg-server > ~/goup-build.log 2>&1 &\ntail -f ~/goup-build.log\n\nsudo systemctl restart ocg-server\nsudo systemctl status ocg-server --no-pager\ncurl -I http://127.0.0.1:9000"
     }
   },
   {
@@ -31,11 +39,19 @@
     "description": "Build the ocg-server release binary in the background and stream the log.",
     "inputSchema": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "build_jobs": {
+          "type": "integer",
+          "default": 2,
+          "minimum": 1,
+          "maximum": 4,
+          "description": "Cargo build job count for the EC2 release build."
+        }
+      },
       "additionalProperties": false
     },
     "output": {
-      "text": "cd ~/goup.vc\nnohup env CARGO_BUILD_JOBS=1 cargo build --release -p ocg-server > ~/goup-build.log 2>&1 &\ntail -f ~/goup-build.log"
+      "text": "cd ~/goup.vc\nnohup env CARGO_BUILD_JOBS={{ build_jobs }} cargo build --release -p ocg-server > ~/goup-build.log 2>&1 &\ntail -f ~/goup-build.log"
     }
   },
   {

--- a/ocg-server/templates/common/footer.html
+++ b/ocg-server/templates/common/footer.html
@@ -174,6 +174,12 @@
           <p class="mt-4 text-sm leading-6 text-stone-400">
             Open source, community-led, and built for people who ship.
           </p>
+          <a href="https://github.com/sakomws/goup.vc/blob/main/docs/development.md"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="mt-4 inline-flex text-sm font-semibold text-stone-300 underline decoration-white/20 underline-offset-4 transition hover:text-white hover:decoration-white">
+            Developer Guide
+          </a>
         </div>
       </div>
       {# End navigation section -#}


### PR DESCRIPTION
## Summary
- Update MCP deploy/build helper output to pull `origin main`, use the migrations directory, and support configurable build jobs.
- Add an MCP package check script and README architecture/update notes.
- Add a public footer link to the developer guide.

## Test plan
- `cd mcp && npm run check`
- `cargo check -p ocg-server`
- `npx markdownlint-cli2 mcp/README.md`

Made with [Cursor](https://cursor.com)