### PR TITLE
Add editable onboarding email template

### DIFF
--- a/database/migrations/schema/0016_site_email_template.sql
+++ b/database/migrations/schema/0016_site_email_template.sql
@@ -1,0 +1,25 @@
+create table if not exists site_email_template (
+    notification_kind_name text primary key references notification_kind(name) on delete restrict,
+    subject text not null check (btrim(subject) <> ''),
+    preheader text not null check (btrim(preheader) <> ''),
+    body text not null check (btrim(body) <> ''),
+    cta_text text not null check (btrim(cta_text) <> ''),
+    updated_at timestamp with time zone not null default current_timestamp,
+    updated_by uuid references "user"(user_id) on delete set null
+);
+
+insert into site_email_template (
+    notification_kind_name,
+    subject,
+    preheader,
+    body,
+    cta_text
+)
+values (
+    'site-onboarding',
+    'Welcome to GOUP',
+    'Start with events, groups, jobs, and your profile.',
+    'Welcome to GOUP. Here are the best places to start:',
+    'Open your dashboard'
+)
+on conflict (notification_kind_name) do nothing;

--- a/database/tests/schema/06_constraints_and_reference_data.sql
+++ b/database/tests/schema/06_constraints_and_reference_data.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(57);
+select plan(59);
 
 -- ============================================================================
 -- VARIABLES
@@ -179,6 +179,9 @@ select has_check('group', 'group_slug_pretty_chk');
 -- Test: site table expected constraints exist
 select has_check('site', 'site_og_image_url_check');
 
+-- Test: site email template table expected constraints exist
+select has_check('site_email_template');
+
 -- Test: session table expected constraints exist
 select has_check('session', 'session_check');
 select has_check('session', 'session_meeting_conflict_chk');
@@ -330,6 +333,25 @@ select results_eq(
         ('speaker-welcome', false)
     $$,
     'Notification kinds should exist'
+);
+
+-- Test: site email template defaults should exist
+select results_eq(
+    $$
+        select notification_kind_name, subject, preheader, body, cta_text
+        from site_email_template
+        order by notification_kind_name
+    $$,
+    $$ values
+        (
+            'site-onboarding',
+            'Welcome to GOUP',
+            'Start with events, groups, jobs, and your profile.',
+            'Welcome to GOUP. Here are the best places to start:',
+            'Open your dashboard'
+        )
+    $$,
+    'Site email template defaults should exist'
 );
 
 -- Test: session kinds should match expected values

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -1220,6 +1220,9 @@ mock! {
         async fn get_site_recently_added_groups(
             &self,
         ) -> Result<Vec<crate::types::group::GroupSummary>>;
+        async fn get_site_onboarding_email_template(
+            &self,
+        ) -> Result<crate::templates::dashboard::alliance::email_templates::SiteOnboardingEmailTemplate>;
         async fn get_site_settings(&self) -> Result<crate::types::site::SiteSettings>;
         async fn get_site_stats(&self) -> Result<crate::templates::site::stats::SiteStats>;
         async fn get_site_upcoming_events(
@@ -1227,5 +1230,10 @@ mock! {
             event_kinds: Vec<crate::types::event::EventKind>,
         ) -> Result<Vec<crate::types::event::EventSummary>>;
         async fn list_alliances(&self) -> Result<Vec<crate::types::alliance::AllianceSummary>>;
+        async fn update_site_onboarding_email_template(
+            &self,
+            user_id: Uuid,
+            template: &crate::templates::dashboard::alliance::email_templates::SiteOnboardingEmailTemplate,
+        ) -> Result<()>;
     }
 }

--- a/ocg-server/src/db/site.rs
+++ b/ocg-server/src/db/site.rs
@@ -8,8 +8,11 @@ use tracing::instrument;
 
 use crate::{
     db::{PgClient, PgExecutor},
-    templates::site::explore::{Entity, FiltersOptions},
     templates::site::stats::SiteStats,
+    templates::{
+        dashboard::alliance::email_templates::SiteOnboardingEmailTemplate,
+        site::explore::{Entity, FiltersOptions},
+    },
     types::{
         alliance::AllianceSummary,
         event::{EventKind, EventSummary},
@@ -40,6 +43,9 @@ pub(crate) trait DBSite {
     /// Retrieves the site settings.
     async fn get_site_settings(&self) -> Result<SiteSettings>;
 
+    /// Retrieves the editable site onboarding email template.
+    async fn get_site_onboarding_email_template(&self) -> Result<SiteOnboardingEmailTemplate>;
+
     /// Retrieves the site stats for the stats page.
     async fn get_site_stats(&self) -> Result<SiteStats>;
 
@@ -51,6 +57,13 @@ pub(crate) trait DBSite {
 
     /// Lists all active alliances.
     async fn list_alliances(&self) -> Result<Vec<AllianceSummary>>;
+
+    /// Updates the editable site onboarding email template.
+    async fn update_site_onboarding_email_template(
+        &self,
+        user_id: uuid::Uuid,
+        template: &SiteOnboardingEmailTemplate,
+    ) -> Result<()>;
 }
 
 #[async_trait]
@@ -102,6 +115,27 @@ where
     }
 
     #[instrument(skip(self), err)]
+    async fn get_site_onboarding_email_template(&self) -> Result<SiteOnboardingEmailTemplate> {
+        let template = self
+            .fetch_json_opt(
+                "select (
+                    select json_strip_nulls(json_build_object(
+                        'body', body,
+                        'cta_text', cta_text,
+                        'preheader', preheader,
+                        'subject', subject
+                    ))
+                    from site_email_template
+                    where notification_kind_name = 'site-onboarding'
+                )",
+                &[],
+            )
+            .await?;
+
+        Ok(template.unwrap_or_default())
+    }
+
+    #[instrument(skip(self), err)]
     async fn get_site_stats(&self) -> Result<SiteStats> {
         self.fetch_json_one("select get_site_stats()", &[]).await
     }
@@ -136,5 +170,39 @@ where
 
         let db = self.client().await?;
         inner(db).await
+    }
+
+    #[instrument(skip(self, template), err)]
+    async fn update_site_onboarding_email_template(
+        &self,
+        user_id: uuid::Uuid,
+        template: &SiteOnboardingEmailTemplate,
+    ) -> Result<()> {
+        self.execute(
+            "insert into site_email_template (
+                notification_kind_name,
+                subject,
+                preheader,
+                body,
+                cta_text,
+                updated_by
+            )
+            values ('site-onboarding', $1::text, $2::text, $3::text, $4::text, $5::uuid)
+            on conflict (notification_kind_name) do update
+            set subject = excluded.subject,
+                preheader = excluded.preheader,
+                body = excluded.body,
+                cta_text = excluded.cta_text,
+                updated_at = current_timestamp,
+                updated_by = excluded.updated_by",
+            &[
+                &template.subject,
+                &template.preheader,
+                &template.body,
+                &template.cta_text,
+                &user_id,
+            ],
+        )
+        .await
     }
 }

--- a/ocg-server/src/handlers/auth.rs
+++ b/ocg-server/src/handlers/auth.rs
@@ -1046,13 +1046,20 @@ async fn try_enqueue_site_onboarding_notification(
     server_cfg: &HttpServerConfig,
     user: &auth::User,
 ) -> Result<(), HandlerError> {
-    let site_settings = db.get_site_settings().await?;
+    let (site_settings, onboarding_template) = tokio::try_join!(
+        db.get_site_settings(),
+        db.get_site_onboarding_email_template()
+    )?;
     let base_url = server_cfg.base_url.trim_end_matches('/');
     let template_data = SiteOnboarding {
+        body: onboarding_template.body,
+        cta_text: onboarding_template.cta_text,
         explore_link: format!("{base_url}/explore"),
         jobs_link: format!("{base_url}/jobs"),
         landscape_link: format!("{base_url}/landscape"),
+        preheader: onboarding_template.preheader,
         search_link: format!("{base_url}/search"),
+        subject: onboarding_template.subject,
         theme: site_settings.theme,
         user_dashboard_link: format!("{base_url}/dashboard/user"),
         user_name: user.name.clone(),

--- a/ocg-server/src/handlers/auth/tests.rs
+++ b/ocg-server/src/handlers/auth/tests.rs
@@ -1327,6 +1327,11 @@ async fn test_oidc_callback_enqueues_onboarding_for_new_external_user() {
     db.expect_get_site_settings()
         .times(1)
         .returning(|| Ok(sample_site_settings()));
+    db.expect_get_site_onboarding_email_template()
+        .times(1)
+        .returning(|| {
+            Ok(crate::templates::dashboard::alliance::email_templates::SiteOnboardingEmailTemplate::default())
+        });
 
     // Setup callback auth mock
     let mut user = sample_auth_user(user_id, &auth_hash);
@@ -1521,6 +1526,7 @@ async fn test_oidc_redirect_success() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_sign_up_success() {
     // Setup identifiers and data structures
     let session_id = session::Id::default();
@@ -1541,6 +1547,11 @@ async fn test_sign_up_success() {
     db.expect_get_site_settings()
         .times(2)
         .returning(move || Ok(site_settings.clone()));
+    db.expect_get_site_onboarding_email_template()
+        .times(1)
+        .returning(|| {
+            Ok(crate::templates::dashboard::alliance::email_templates::SiteOnboardingEmailTemplate::default())
+        });
     db.expect_activate_pre_registered_user_email_password()
         .times(1)
         .withf(move |summary, verification| {
@@ -1655,6 +1666,11 @@ async fn test_sign_up_activates_pre_registered_user() {
     db.expect_get_site_settings()
         .times(2)
         .returning(move || Ok(site_settings.clone()));
+    db.expect_get_site_onboarding_email_template()
+        .times(1)
+        .returning(|| {
+            Ok(crate::templates::dashboard::alliance::email_templates::SiteOnboardingEmailTemplate::default())
+        });
     db.expect_activate_pre_registered_user_email_password()
         .times(1)
         .withf(move |summary, verification| {

--- a/ocg-server/src/handlers/dashboard/alliance.rs
+++ b/ocg-server/src/handlers/dashboard/alliance.rs
@@ -23,6 +23,7 @@ mod tests;
 
 pub(crate) mod analytics;
 pub(crate) mod create;
+pub(crate) mod email_templates;
 pub(crate) mod event_categories;
 pub(crate) mod group_categories;
 pub(crate) mod groups;

--- a/ocg-server/src/handlers/dashboard/alliance/email_templates.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/email_templates.rs
@@ -1,0 +1,56 @@
+//! HTTP handlers for alliance email template settings.
+
+use askama::Template;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, ValidatedFormQs},
+    },
+    templates::dashboard::alliance::email_templates::{self, SiteOnboardingEmailTemplate},
+    types::permissions::AlliancePermission,
+};
+
+/// Displays the editable email templates page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (can_manage_settings, onboarding) = tokio::try_join!(
+        db.user_has_alliance_permission(
+            &alliance_id,
+            &user.user_id,
+            AlliancePermission::SettingsWrite,
+        ),
+        db.get_site_onboarding_email_template()
+    )?;
+
+    let template = email_templates::Page {
+        can_manage_settings,
+        onboarding,
+    };
+
+    Ok(Html(template.render()?))
+}
+
+/// Updates the editable onboarding email template.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedFormQs(template): ValidatedFormQs<SiteOnboardingEmailTemplate>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_site_onboarding_email_template(user.user_id, &template)
+        .await?;
+
+    Ok((StatusCode::NO_CONTENT, [("HX-Trigger", "refresh-body")]).into_response())
+}

--- a/ocg-server/src/handlers/dashboard/alliance/home.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/home.rs
@@ -21,7 +21,7 @@ use crate::{
         PageId,
         auth::User,
         dashboard::alliance::{
-            analytics, event_categories, group_categories,
+            analytics, email_templates, event_categories, group_categories,
             home::{Content, Page, Tab},
             regions, settings,
         },
@@ -72,6 +72,20 @@ pub(crate) async fn page(
                 return Err(HandlerError::Forbidden);
             }
             Content::CreateAlliance(crate::templates::dashboard::alliance::create::Page)
+        }
+        Tab::EmailTemplates => {
+            let (can_manage_settings, onboarding) = tokio::try_join!(
+                db.user_has_alliance_permission(
+                    &alliance_id,
+                    &user_id,
+                    AlliancePermission::SettingsWrite
+                ),
+                db.get_site_onboarding_email_template()
+            )?;
+            Content::EmailTemplates(Box::new(email_templates::Page {
+                can_manage_settings,
+                onboarding,
+            }))
         }
         Tab::EventCategories => {
             let (can_manage_taxonomy, categories) = tokio::try_join!(

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -43,6 +43,10 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
         .route("/analytics", get(dashboard::alliance::analytics::page))
         .route("/create", get(dashboard::alliance::create::page))
         .route(
+            "/email-templates",
+            get(dashboard::alliance::email_templates::page),
+        )
+        .route(
             "/event-categories",
             get(dashboard::alliance::event_categories::list_page),
         )
@@ -139,6 +143,10 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
 
     // Alliance settings management endpoints
     let settings_management = Router::new()
+        .route(
+            "/email-templates",
+            put(dashboard::alliance::email_templates::update),
+        )
         .route(
             "/settings/update",
             put(dashboard::alliance::settings::update),

--- a/ocg-server/src/services/notifications.rs
+++ b/ocg-server/src/services/notifications.rs
@@ -454,8 +454,8 @@ impl DeliveryWorker {
                 (subject, body)
             }
             NotificationKind::SiteOnboarding => {
-                let subject = "Welcome to GOUP".to_string();
                 let template: SiteOnboarding = serde_json::from_value(template_data)?;
+                let subject = template.subject.clone();
                 let body = template.render()?;
                 (subject, body)
             }

--- a/ocg-server/src/services/notifications/tests.rs
+++ b/ocg-server/src/services/notifications/tests.rs
@@ -453,8 +453,10 @@ fn test_delivery_worker_prepare_content_site_onboarding() {
     let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
 
     // Check content matches expectations
-    assert_eq!(subject, "Welcome to GOUP");
+    assert_eq!(subject, "Custom onboarding subject");
     assert!(body.contains("Hi Test User"));
+    assert!(body.contains("Custom onboarding body"));
+    assert!(body.contains("Start now"));
     assert!(body.contains("https://example.test/explore"));
     assert!(body.contains("https://example.test/jobs"));
     assert!(body.contains("https://example.test/landscape"));
@@ -1092,10 +1094,14 @@ fn sample_email_verification_template_data() -> serde_json::Value {
 /// Sample template payload for site onboarding notifications.
 fn sample_site_onboarding_template_data() -> serde_json::Value {
     json!({
+        "body": "Custom onboarding body",
+        "cta_text": "Start now",
         "explore_link": "https://example.test/explore",
         "jobs_link": "https://example.test/jobs",
         "landscape_link": "https://example.test/landscape",
+        "preheader": "Custom onboarding preheader",
         "search_link": "https://example.test/search",
+        "subject": "Custom onboarding subject",
         "theme": {
             "primary_color": "#000000"
         },

--- a/ocg-server/src/templates/dashboard/alliance.rs
+++ b/ocg-server/src/templates/dashboard/alliance.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod analytics;
 pub(crate) mod create;
+pub(crate) mod email_templates;
 pub(crate) mod event_categories;
 pub(crate) mod group_categories;
 pub(crate) mod groups;

--- a/ocg-server/src/templates/dashboard/alliance/email_templates.rs
+++ b/ocg-server/src/templates/dashboard/alliance/email_templates.rs
@@ -1,0 +1,53 @@
+//! Templates for alliance dashboard email template settings.
+
+use askama::Template;
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::notifications::{
+        default_site_onboarding_body, default_site_onboarding_cta_text,
+        default_site_onboarding_preheader, default_site_onboarding_subject,
+    },
+    validation::{
+        MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_M, MAX_LEN_NOTIFICATION_BODY, trimmed_non_empty,
+    },
+};
+
+/// Page template for editable email templates.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/alliance/email_templates.html")]
+pub(crate) struct Page {
+    /// Whether the current user can manage settings.
+    pub can_manage_settings: bool,
+    /// Editable onboarding email template.
+    pub onboarding: SiteOnboardingEmailTemplate,
+}
+
+/// Editable onboarding email template fields.
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct SiteOnboardingEmailTemplate {
+    /// Main body copy shown before the fixed starting links.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_NOTIFICATION_BODY))]
+    pub body: String,
+    /// Button label for the dashboard CTA.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub cta_text: String,
+    /// Inbox preheader text.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub preheader: String,
+    /// Email subject.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub subject: String,
+}
+
+impl Default for SiteOnboardingEmailTemplate {
+    fn default() -> Self {
+        Self {
+            body: default_site_onboarding_body(),
+            cta_text: default_site_onboarding_cta_text(),
+            preheader: default_site_onboarding_preheader(),
+            subject: default_site_onboarding_subject(),
+        }
+    }
+}

--- a/ocg-server/src/templates/dashboard/alliance/home.rs
+++ b/ocg-server/src/templates/dashboard/alliance/home.rs
@@ -11,8 +11,8 @@ use crate::{
         auth::User,
         dashboard::{
             alliance::{
-                analytics, create, event_categories, group_categories, groups, landscape, regions,
-                settings, team,
+                analytics, create, email_templates, event_categories, group_categories, groups,
+                landscape, regions, settings, team,
             },
             audit,
         },
@@ -51,6 +51,8 @@ pub(crate) enum Content {
     Analytics(Box<analytics::Page>),
     /// Alliance create page.
     CreateAlliance(create::Page),
+    /// Email templates page.
+    EmailTemplates(Box<email_templates::Page>),
     /// Event categories management page.
     EventCategories(event_categories::ListPage),
     /// Group categories management page.
@@ -78,6 +80,11 @@ impl Content {
     /// Check if the content is the alliance create page.
     fn is_create_alliance(&self) -> bool {
         matches!(self, Content::CreateAlliance(_))
+    }
+
+    /// Check if the content is the email templates page.
+    fn is_email_templates(&self) -> bool {
+        matches!(self, Content::EmailTemplates(_))
     }
 
     /// Check if the content is the event categories page.
@@ -126,6 +133,7 @@ impl std::fmt::Display for Content {
         match self {
             Content::Analytics(template) => write!(f, "{}", template.render()?),
             Content::CreateAlliance(template) => write!(f, "{}", template.render()?),
+            Content::EmailTemplates(template) => write!(f, "{}", template.render()?),
             Content::EventCategories(template) => write!(f, "{}", template.render()?),
             Content::GroupCategories(template) => write!(f, "{}", template.render()?),
             Content::Groups(template) => write!(f, "{}", template.render()?),
@@ -150,6 +158,8 @@ pub(crate) enum Tab {
     Analytics,
     /// Alliance create tab.
     CreateAlliance,
+    /// Email templates tab.
+    EmailTemplates,
     /// Event categories management tab.
     EventCategories,
     /// Group categories management tab.

--- a/ocg-server/src/templates/notifications.rs
+++ b/ocg-server/src/templates/notifications.rs
@@ -323,6 +323,12 @@ pub(crate) struct GroupWelcome {
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "notifications/site_onboarding.html")]
 pub(crate) struct SiteOnboarding {
+    /// Editable body copy for the onboarding email.
+    #[serde(default = "default_site_onboarding_body")]
+    pub body: String,
+    /// Editable call-to-action button text.
+    #[serde(default = "default_site_onboarding_cta_text")]
+    pub cta_text: String,
     /// Link to the public events and groups page.
     pub explore_link: String,
     /// Link to the public jobs board.
@@ -331,12 +337,34 @@ pub(crate) struct SiteOnboarding {
     pub landscape_link: String,
     /// Link to the public search page.
     pub search_link: String,
+    /// Editable preheader text for the onboarding email.
+    #[serde(default = "default_site_onboarding_preheader")]
+    pub preheader: String,
+    /// Editable subject for the onboarding email.
+    #[serde(default = "default_site_onboarding_subject")]
+    pub subject: String,
     /// Theme configuration for the site.
     pub theme: Theme,
     /// Link to the user's dashboard.
     pub user_dashboard_link: String,
     /// Display name for the recipient.
     pub user_name: String,
+}
+
+pub(crate) fn default_site_onboarding_subject() -> String {
+    "Welcome to GOUP".to_string()
+}
+
+pub(crate) fn default_site_onboarding_preheader() -> String {
+    "Start with events, groups, jobs, and your profile.".to_string()
+}
+
+pub(crate) fn default_site_onboarding_body() -> String {
+    "Welcome to GOUP. Here are the best places to start:".to_string()
+}
+
+pub(crate) fn default_site_onboarding_cta_text() -> String {
+    "Open your dashboard".to_string()
 }
 
 /// Template for session proposal co-speaker invitation notification.

--- a/ocg-server/templates/dashboard/alliance/email_templates.html
+++ b/ocg-server/templates/dashboard/alliance/email_templates.html
@@ -1,0 +1,102 @@
+{% import "macros/dashboard.html" as dashboard -%}
+{% import "macros/ui.html" as ui -%}
+
+<form id="email-templates-form"
+      hx-put="/dashboard/alliance/email-templates"
+      hx-target="#dashboard-content"
+      hx-indicator="#dashboard-spinner, #email-templates-spinner"
+      hx-disabled-elt="button[type=submit]"
+      data-htmx-response
+      data-success-message="You have successfully updated the email template."
+      data-error-message="Something went wrong updating the email template. Please try again later.">
+  <div class="space-y-12">
+    {{ dashboard::page_title(title = "Email Templates", description = "Update copy for automated emails sent by the site.") -}}
+
+    {% if !can_manage_settings -%}
+      {{ dashboard::permission_warning(message = "Your role cannot update email templates.") -}}
+    {% endif -%}
+
+    <div class="inert-form space-y-12"
+         {% if !can_manage_settings -%}
+           inert
+         {% endif -%}>
+      <div class="border-b border-stone-900/10 pb-12">
+        {{ dashboard::form_title(title = "Onboarding Email", description = "Sent once after a user creates an account. Links and layout are managed by the app; these fields control the editable copy.") -}}
+
+        <div class="mt-10 grid grid-cols-1 gap-x-6 gap-y-8 md:grid-cols-6 max-w-5xl">
+          <div class="col-span-full lg:col-span-3">
+            <label for="subject" class="form-label">
+              Subject <span class="asterisk">*</span>
+            </label>
+            <div class="mt-2">
+              <input type="text"
+                     name="subject"
+                     id="subject"
+                     maxlength="{{ crate::validation::MAX_LEN_M }}"
+                     class="input-primary"
+                     value="{{ onboarding.subject }}"
+                     required>
+            </div>
+          </div>
+
+          <div class="col-span-full lg:col-span-3">
+            <label for="preheader" class="form-label">
+              Preheader <span class="asterisk">*</span>
+            </label>
+            <div class="mt-2">
+              <input type="text"
+                     name="preheader"
+                     id="preheader"
+                     maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION_SHORT }}"
+                     class="input-primary"
+                     value="{{ onboarding.preheader }}"
+                     required>
+            </div>
+            <p class="form-legend">Short preview text shown by email clients.</p>
+          </div>
+
+          <div class="col-span-full">
+            <label for="body" class="form-label">
+              Body <span class="asterisk">*</span>
+            </label>
+            <div class="mt-2">
+              <textarea name="body"
+                        id="body"
+                        maxlength="{{ crate::validation::MAX_LEN_NOTIFICATION_BODY }}"
+                        class="input-primary min-h-32"
+                        required>{{ onboarding.body }}</textarea>
+            </div>
+            <p class="form-legend">
+              Intro copy shown before the fixed Events, Jobs, Landscape, and Search links.
+            </p>
+          </div>
+
+          <div class="col-span-full lg:col-span-3">
+            <label for="cta_text" class="form-label">
+              Button Text <span class="asterisk">*</span>
+            </label>
+            <div class="mt-2">
+              <input type="text"
+                     name="cta_text"
+                     id="cta_text"
+                     maxlength="{{ crate::validation::MAX_LEN_M }}"
+                     class="input-primary"
+                     value="{{ onboarding.cta_text }}"
+                     required>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-3">
+        <button type="submit" class="btn-primary">
+          Save email template
+          <span id="email-templates-spinner"
+                class="group hx-spinner relative align-text-bottom inline-block -mt-0.5">
+            {{ ui::spinner(size = "size-4") -}}
+          </span>
+        </button>
+      </div>
+    </div>
+  </div>
+</form>

--- a/ocg-server/templates/dashboard/alliance/home.html
+++ b/ocg-server/templates/dashboard/alliance/home.html
@@ -37,6 +37,7 @@
           {{ dashboard::menu_item(name = "Create Alliance", icon = "groups", is_active = content.is_create_alliance() , href = "/dashboard/alliance?tab=create-alliance") -}}
         {% endif -%}
         {{ dashboard::menu_item(name = "Settings", icon = "gears", is_active = content.is_settings() , href = "/dashboard/alliance?tab=settings") -}}
+        {{ dashboard::menu_item(name = "Email Templates", icon = "mail", is_active = content.is_email_templates() , href = "/dashboard/alliance?tab=email-templates") -}}
         {{ dashboard::menu_item(name = "Team", icon = "team", is_active = content.is_team() , href = "/dashboard/alliance?tab=team") -}}
         {{ dashboard::menu_item(name = "Regions", icon = "map", is_active = content.is_regions() , href = "/dashboard/alliance?tab=regions") -}}
         {{ dashboard::menu_item(name = "Group Categories", icon = "list", is_active = content.is_group_categories() , href = "/dashboard/alliance?tab=group-categories") -}}
@@ -75,7 +76,7 @@
 
 {% block dashboard_main -%}
   <div id="dashboard-content"
-       hx-get="/dashboard/alliance/{%- if content.is_team() -%}team{%- elif content.is_settings() -%}settings/update{%- elif content.is_regions() -%}regions{%- elif content.is_logs() -%}logs{%- elif content.is_group_categories() -%}group-categories{%- elif content.is_event_categories() -%}event-categories{%- elif content.is_analytics() -%}analytics{%- elif content.is_create_alliance() -%}create{%- elif content.is_landscape() -%}landscape{%- else -%}groups{%- endif -%}"
+       hx-get="/dashboard/alliance/{%- if content.is_team() -%}team{%- elif content.is_settings() -%}settings/update{%- elif content.is_email_templates() -%}email-templates{%- elif content.is_regions() -%}regions{%- elif content.is_logs() -%}logs{%- elif content.is_group_categories() -%}group-categories{%- elif content.is_event_categories() -%}event-categories{%- elif content.is_analytics() -%}analytics{%- elif content.is_create_alliance() -%}create{%- elif content.is_landscape() -%}landscape{%- else -%}groups{%- endif -%}"
        hx-trigger="refresh-alliance-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/notifications/site_onboarding.html
+++ b/ocg-server/templates/notifications/site_onboarding.html
@@ -3,11 +3,11 @@
 
 {# Site Onboarding Notification -#}
 {% block subject -%}
-  Welcome to GOUP
+  {{ subject }}
 {% endblock subject -%}
 
 {% block preheader -%}
-  Start with events, groups, jobs, and your profile.
+  {{ preheader }}
 {% endblock preheader -%}
 
 {% block content -%}
@@ -15,7 +15,7 @@
     Hi {{ user_name }},
     <br />
     <br />
-    Welcome to <strong>GOUP</strong>. Here are the best places to start:
+    {{ body }}
   </p>
 
   <ul class="default mb-30"
@@ -42,7 +42,7 @@
     </li>
   </ul>
 
-  {{ email::button(link = user_dashboard_link, text = "Open your dashboard", color = theme.primary_color) }}
+  {{ email::button(link = user_dashboard_link, text = cta_text, color = theme.primary_color) }}
 
   <p class="default mt-30 mb-15"
      style="margin-top: 30px;


### PR DESCRIPTION
## Summary
- Add an Alliance Dashboard Email Templates tab for editing onboarding email subject, preheader, body, and CTA text.
- Store editable onboarding copy in a new `site_email_template` table with default seed data.
- Render onboarding notifications from saved copy while keeping backward-compatible defaults for already queued notifications.

## Test plan
- `cargo check -p ocg-server`
- `cargo test -p ocg-server test_delivery_worker_prepare_content_site_onboarding`
- `cargo test -p ocg-server test_oidc_callback_enqueues_onboarding_for_new_external_user`
- `cargo clippy --all-targets --all-features -- --deny warnings`

Made with [Cursor](https://cursor.com)