### PR TITLE
Add member-only group directory

### DIFF
--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -3,7 +3,7 @@
 use askama::Template;
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, RawQuery, State},
     http::{HeaderMap, StatusCode, Uri},
     response::{Html, IntoResponse, Redirect},
 };
@@ -20,14 +20,16 @@ use crate::{
         extractors::CurrentUser, request_matches_site, site::not_found, trim_public_gallery_images,
     },
     router::PUBLIC_SHARED_CACHE_HEADERS,
+    router::serde_qs_config,
     services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
     templates::{
         PageId,
         auth::User,
-        group::{self, Page, SpotlightsPage, StorePage},
+        dashboard::group::members::GroupMembersFilters,
+        group::{self, MembersPage, Page, SpotlightsPage, StorePage},
         notifications::GroupWelcome,
     },
-    types::{event::EventKind, group::GroupFull},
+    types::{event::EventKind, group::GroupFull, pagination::NavigationLinks},
 };
 
 use super::{error::HandlerError, extractors::AllianceId};
@@ -137,6 +139,72 @@ pub(crate) async fn spotlights_page(
         site_settings,
         spotlights,
         user: User::from_session(auth_session).await?,
+    };
+
+    Ok(Html(template.render()?).into_response())
+}
+
+/// Handler that renders a logged-in group member directory.
+#[instrument(skip_all)]
+pub(crate) async fn members_page(
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((alliance_name, group_slug)): Path<(String, String)>,
+    RawQuery(raw_query): RawQuery,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let Some(mut group) = db.get_group_full_by_slug(alliance_id, &group_slug).await? else {
+        return not_found::render(site_settings);
+    };
+    trim_public_gallery_images(&mut group.photos_urls);
+    group.sponsors.clear();
+
+    let is_member = db.is_group_member(alliance_id, group.group_id, user.user_id).await?;
+    if !is_member {
+        return Err(HandlerError::Forbidden);
+    }
+
+    let filters: GroupMembersFilters =
+        serde_qs_config().deserialize_str(raw_query.as_deref().unwrap_or_default())?;
+    let results = db.list_group_members(group.group_id, &filters).await?;
+    let page_url = format!(
+        "/{}/group/{}/members",
+        group.alliance.name,
+        group.public_slug()
+    );
+    let navigation_links =
+        NavigationLinks::from_filters(&filters, results.total, &page_url, &page_url)?;
+    let template_user = User {
+        logged_in: true,
+        auth_provider: None,
+        belongs_to_any_group_team: user.belongs_to_any_group_team,
+        belongs_to_alliance_team: user.belongs_to_alliance_team,
+        name: Some(user.name),
+        platform_admin: user.platform_admin,
+        username: Some(user.username),
+    };
+
+    let template = MembersPage {
+        base_url: server_cfg.base_url,
+        group,
+        members: results.members,
+        navigation_links,
+        offset: filters.offset,
+        page_id: PageId::Group,
+        path: uri.path().to_string(),
+        query: filters.query.clone(),
+        site_settings,
+        total: results.total,
+        user: template_user,
     };
 
     Ok(Html(template.render()?).into_response())

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -219,6 +219,10 @@ pub(crate) async fn setup(
             "/{alliance}/group/{group_slug}/spotlights",
             get(group::spotlights_page),
         )
+        .route(
+            "/{alliance}/group/{group_slug}/members",
+            get(group::members_page),
+        )
         .route("/jobs/{job_id}/apply", post(site::jobs::apply))
         // Protected dashboard routes
         .route(

--- a/ocg-server/src/templates/dashboard/group/spotlights.rs
+++ b/ocg-server/src/templates/dashboard/group/spotlights.rs
@@ -10,8 +10,8 @@ use uuid::Uuid;
 use crate::{
     templates::{dashboard::group::members::GroupMember, helpers::user_initials},
     validation::{
-        MAX_LEN_DESCRIPTION, MAX_LEN_L, MAX_LEN_M, image_url_opt, trimmed_non_empty,
-        trimmed_non_empty_opt,
+        MAX_LEN_DESCRIPTION, MAX_LEN_L, MAX_LEN_M, image_url_opt, optional_trimmed_string,
+        trimmed_non_empty, trimmed_non_empty_opt,
     },
 };
 
@@ -41,9 +41,11 @@ pub(crate) struct SpotlightInput {
     #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION))]
     pub story: String,
     /// Optional image URL for the story card.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(custom(image_url_opt))]
     pub image_url: Option<String>,
     /// Optional link to a deeper article, demo, video, or profile.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
     pub link_url: Option<String>,
     /// Whether the spotlight should be emphasized.

--- a/ocg-server/src/templates/dashboard/group/store.rs
+++ b/ocg-server/src/templates/dashboard/group/store.rs
@@ -8,8 +8,8 @@ use serde_with::skip_serializing_none;
 use uuid::Uuid;
 
 use crate::validation::{
-    MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_L, MAX_LEN_M, image_url_opt, trimmed_non_empty,
-    trimmed_non_empty_opt,
+    MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_L, MAX_LEN_M, image_url_opt, optional_trimmed_string,
+    trimmed_non_empty, trimmed_non_empty_opt,
 };
 
 /// Group dashboard store management page.
@@ -33,6 +33,7 @@ pub(crate) struct StoreItemInput {
     #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
     pub description: Option<String>,
     /// Optional product image URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(custom(image_url_opt))]
     pub image_url: Option<String>,
     /// Price in minor units, for example cents.

--- a/ocg-server/src/templates/group.rs
+++ b/ocg-server/src/templates/group.rs
@@ -4,7 +4,9 @@ use askama::Template;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    templates::dashboard::group::{spotlights::GroupMemberSpotlight, store::GroupStoreItem},
+    templates::dashboard::group::{
+        members::GroupMember, spotlights::GroupMemberSpotlight, store::GroupStoreItem,
+    },
     templates::{
         PageId,
         auth::User,
@@ -14,6 +16,7 @@ use crate::{
     types::{
         event::{EventKind, EventSummary},
         group::GroupFull,
+        pagination,
         site::SiteSettings,
     },
 };
@@ -62,6 +65,34 @@ pub(crate) struct SpotlightsPage {
     pub site_settings: SiteSettings,
     /// Published member spotlights.
     pub spotlights: Vec<GroupMemberSpotlight>,
+    /// Authenticated user information.
+    pub user: User,
+}
+
+/// Logged-in group member directory page template.
+#[derive(Debug, Clone, Template)]
+#[template(path = "group/members.html")]
+pub(crate) struct MembersPage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Detailed information about the group.
+    pub group: GroupFull,
+    /// List of members in the group.
+    pub members: Vec<GroupMember>,
+    /// Pagination navigation links.
+    pub navigation_links: pagination::NavigationLinks,
+    /// Pagination offset for results.
+    pub offset: Option<usize>,
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Text search query used to filter members.
+    pub query: Option<String>,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Total number of members in the group.
+    pub total: usize,
     /// Authenticated user information.
     pub user: User,
 }
@@ -146,6 +177,39 @@ impl SpotlightsPage {
     }
 
     /// Returns the Open Graph image URL for the page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.group
+            .og_image_url
+            .as_deref()
+            .or(self.group.alliance.og_image_url.as_deref())
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+}
+
+impl MembersPage {
+    /// Returns the canonical URL for the group members page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!(
+                "/{}/group/{}/members",
+                self.group.alliance.name,
+                self.group.public_slug()
+            ),
+        )
+    }
+
+    /// Returns the preview title.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} Members", self.group.name)
+    }
+
+    /// Returns the preview description.
+    pub(crate) fn preview_description(&self) -> String {
+        format!("Member directory for {}.", self.group.name)
+    }
+
+    /// Returns the `OpenGraph` image URL for the group members page.
     pub(crate) fn open_graph_image_url(&self) -> Option<String> {
         self.group
             .og_image_url

--- a/ocg-server/src/types/landscape.rs
+++ b/ocg-server/src/types/landscape.rs
@@ -11,7 +11,8 @@ use crate::{
     types::pagination::{Pagination, ToRawQuery},
     validation::{
         MAX_LEN_DESCRIPTION, MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_ENTITY_NAME, MAX_LEN_M,
-        MAX_LEN_TAG, MAX_PAGINATION_LIMIT, trimmed_non_empty, trimmed_non_empty_opt,
+        MAX_LEN_TAG, MAX_PAGINATION_LIMIT, image_url_opt, optional_trimmed_string,
+        trimmed_non_empty, trimmed_non_empty_opt,
     },
 };
 
@@ -99,21 +100,27 @@ pub(crate) struct LandscapeEntryInput {
     #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION_SHORT))]
     pub summary: String,
     /// Full description.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
     pub description: Option<String>,
     /// Website URL.
-    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_M), custom(trimmed_non_empty_opt))]
     pub website_url: Option<String>,
     /// GitHub URL.
-    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_M), custom(trimmed_non_empty_opt))]
     pub github_url: Option<String>,
     /// Logo URL.
-    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(image_url_opt))]
     pub logo_url: Option<String>,
     /// Category label.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
     pub category: Option<String>,
     /// Tags, comma-separated.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(length(max = MAX_LEN_M))]
     pub tags: Option<String>,
 }

--- a/ocg-server/src/validation.rs
+++ b/ocg-server/src/validation.rs
@@ -13,6 +13,7 @@ use std::collections::BTreeMap;
 
 use garde::rules::email::parse_email;
 use reqwest::Url;
+use serde::{Deserialize, Deserializer};
 
 /// Allowed CFS label colors.
 pub const CFS_LABEL_COLORS: [&str; 10] = [
@@ -169,6 +170,18 @@ pub fn trimmed_non_empty_opt(value: &Option<String>, _ctx: &()) -> garde::Result
         ));
     }
     Ok(())
+}
+
+/// Deserializes optional form strings, treating blank values as absent.
+pub(crate) fn optional_trimmed_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.and_then(|value| {
+        let value = value.trim().to_string();
+        (!value.is_empty()).then_some(value)
+    }))
 }
 
 /// Validates that each tag in a vector is non-empty, within max length, and within max items.

--- a/ocg-server/templates/dashboard/alliance/email_templates.html
+++ b/ocg-server/templates/dashboard/alliance/email_templates.html
@@ -66,9 +66,7 @@
                         class="input-primary min-h-32"
                         required>{{ onboarding.body }}</textarea>
             </div>
-            <p class="form-legend">
-              Intro copy shown before the fixed Events, Jobs, Landscape, and Search links.
-            </p>
+            <p class="form-legend">Intro copy shown before the fixed Events, Jobs, Landscape, and Search links.</p>
           </div>
 
           <div class="col-span-full lg:col-span-3">

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -1,4 +1,5 @@
 {% import "macros/dashboard.html" as dashboard -%}
+{% import "macros/form_fields.html" as form_fields -%}
 {% import "macros/pagination.html" as pagination -%}
 
 {{ dashboard::page_title(title = "Landscape", description = "Manage startups and GitHub projects shown on the public landscape.") -}}
@@ -73,6 +74,7 @@
           <input id="new-landscape-website"
                  name="website_url"
                  class="input"
+                 type="url"
                  placeholder="https://..." />
         </div>
         <div>
@@ -80,15 +82,10 @@
           <input id="new-landscape-github"
                  name="github_url"
                  class="input"
+                 type="url"
                  placeholder="https://github.com/..." />
         </div>
-        <div>
-          <label class="label" for="new-landscape-logo">Logo URL</label>
-          <input id="new-landscape-logo"
-                 name="logo_url"
-                 class="input"
-                 placeholder="https://..." />
-        </div>
+        {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", field_class = "lg:col-span-2") -}}
         <div>
           <label class="label" for="new-landscape-tags">Tags</label>
           <input id="new-landscape-tags"
@@ -211,6 +208,7 @@
               <input id="landscape-website-{{ entry.landscape_entry_id }}"
                      name="website_url"
                      class="input"
+                     type="url"
                      value="{{ entry.website_url.as_deref().unwrap_or("") }}" />
             </div>
             <div>
@@ -218,48 +216,46 @@
               <input id="landscape-github-{{ entry.landscape_entry_id }}"
                      name="github_url"
                      class="input"
+                     type="url"
                      value="{{ entry.github_url.as_deref().unwrap_or("") }}" />
             </div>
-            <div>
-              <label class="label" for="landscape-logo-{{ entry.landscape_entry_id }}">Logo URL</label>
-              <input id="landscape-logo-{{ entry.landscape_entry_id }}"
-                     name="logo_url"
-                     class="input"
-                     value="{{ entry.logo_url.as_deref().unwrap_or("") }}" />
-            </div>
-            <div>
-              <label class="label" for="landscape-tags-{{ entry.landscape_entry_id }}">Tags</label>
-              <input id="landscape-tags-{{ entry.landscape_entry_id }}"
-                     name="tags"
-                     class="input"
-                     value="{{ entry.tags.join(", ") }}" />
-            </div>
+            {% let logo_value -%}
+            {% if let Some(logo_url) = &entry.logo_url %}value="{{ logo_url }}"{% endif %}
+          {%- endlet %}
+          {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", value_attr = logo_value, field_class = "lg:col-span-2") -}}
+          <div>
+            <label class="label" for="landscape-tags-{{ entry.landscape_entry_id }}">Tags</label>
+            <input id="landscape-tags-{{ entry.landscape_entry_id }}"
+                   name="tags"
+                   class="input"
+                   value="{{ entry.tags.join(", ") }}" />
           </div>
-          {% if can_manage_landscape -%}
-            <div class="flex flex-wrap gap-2">
-              <button class="btn-primary" type="submit">Save changes</button>
-              {% if entry.published -%}
-                <button class="btn-secondary"
-                        type="button"
-                        hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/unpublish"
-                        hx-target="#dashboard-content">Unpublish</button>
-              {% else -%}
-                <button class="btn-secondary"
-                        type="button"
-                        hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/publish"
-                        hx-target="#dashboard-content">Publish</button>
-              {% endif -%}
-              <button class="btn-tertiary"
+        </div>
+        {% if can_manage_landscape -%}
+          <div class="flex flex-wrap gap-2">
+            <button class="btn-primary" type="submit">Save changes</button>
+            {% if entry.published -%}
+              <button class="btn-secondary"
                       type="button"
-                      hx-delete="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/delete"
-                      hx-confirm="Delete this landscape entry?"
-                      hx-target="#dashboard-content">Delete</button>
-            </div>
-          {% endif -%}
-        </form>
-      </article>
-    {% endfor -%}
-  </div>
+                      hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/unpublish"
+                      hx-target="#dashboard-content">Unpublish</button>
+            {% else -%}
+              <button class="btn-secondary"
+                      type="button"
+                      hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/publish"
+                      hx-target="#dashboard-content">Publish</button>
+            {% endif -%}
+            <button class="btn-tertiary"
+                    type="button"
+                    hx-delete="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/delete"
+                    hx-confirm="Delete this landscape entry?"
+                    hx-target="#dashboard-content">Delete</button>
+          </div>
+        {% endif -%}
+      </form>
+    </article>
+  {% endfor -%}
+</div>
 
-  {{ pagination::navigation_links(links = navigation_links, hx_target = "#dashboard-content") }}
+{{ pagination::navigation_links(links = navigation_links, hx_target = "#dashboard-content") }}
 {% endif -%}

--- a/ocg-server/templates/dashboard/group/spotlights_list.html
+++ b/ocg-server/templates/dashboard/group/spotlights_list.html
@@ -172,55 +172,55 @@
               {% if let Some(image_url) = &spotlight.image_url %}value="{{ image_url }}"{% endif %}
             {%- endlet %}
             {{ form_fields::image_field(label = "Image", name = "image_url", image_kind = "banner", legend = "Optional spotlight image shown on the group page and spotlight cards.", value_attr = image_value, field_class = "col-span-full") -}}
-              <label class="block">
-                <span class="label">Link URL</span>
-                <input name="link_url"
-                       class="input"
-                       value="{{ spotlight.link_url.as_deref().unwrap_or("") }}">
-              </label>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-2">
-              <label class="block">
-                <span class="label">Featured</span>
-                <select name="featured" class="input">
-                  <option value="false" {% if !spotlight.featured %}selected{% endif %}>No</option>
-                  <option value="true" {% if spotlight.featured %}selected{% endif %}>Yes</option>
-                </select>
-              </label>
-              <label class="block">
-                <span class="label">Published</span>
-                <select name="published" class="input">
-                  <option value="true" {% if spotlight.published %}selected{% endif %}>Yes</option>
-                  <option value="false" {% if !spotlight.published %}selected{% endif %}>No</option>
-                </select>
-              </label>
-            </div>
+            <label class="block">
+              <span class="label">Link URL</span>
+              <input name="link_url"
+                     class="input"
+                     value="{{ spotlight.link_url.as_deref().unwrap_or("") }}">
+            </label>
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2">
+            <label class="block">
+              <span class="label">Featured</span>
+              <select name="featured" class="input">
+                <option value="false" {% if !spotlight.featured %}selected{% endif %}>No</option>
+                <option value="true" {% if spotlight.featured %}selected{% endif %}>Yes</option>
+              </select>
+            </label>
+            <label class="block">
+              <span class="label">Published</span>
+              <select name="published" class="input">
+                <option value="true" {% if spotlight.published %}selected{% endif %}>Yes</option>
+                <option value="false" {% if !spotlight.published %}selected{% endif %}>No</option>
+              </select>
+            </label>
+          </div>
 
-            <div class="flex flex-wrap gap-2">
-              <button type="submit"
-                      class="btn-primary"
-                      {% if !can_manage_spotlights -%}
-                        disabled
-                      {% endif -%}>Save</button>
-              <button type="button"
-                      class="btn-tertiary"
-                      hx-delete="/dashboard/group/spotlights/{{ spotlight.group_member_spotlight_id }}"
-                      hx-target="#dashboard-content"
-                      hx-indicator="#dashboard-spinner"
-                      hx-confirm="Delete this spotlight?"
-                      {% if !can_manage_spotlights -%}
-                        disabled
-                      {% endif -%}>Delete</button>
-              {% if let Some(link_url) = &spotlight.link_url -%}
-                <a href="{{ link_url }}"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="btn-secondary-anchor">Open link</a>
-              {% endif -%}
-            </div>
-          </form>
-        </article>
-      {% endfor -%}
-    </section>
-  {% endif -%}
+          <div class="flex flex-wrap gap-2">
+            <button type="submit"
+                    class="btn-primary"
+                    {% if !can_manage_spotlights -%}
+                      disabled
+                    {% endif -%}>Save</button>
+            <button type="button"
+                    class="btn-tertiary"
+                    hx-delete="/dashboard/group/spotlights/{{ spotlight.group_member_spotlight_id }}"
+                    hx-target="#dashboard-content"
+                    hx-indicator="#dashboard-spinner"
+                    hx-confirm="Delete this spotlight?"
+                    {% if !can_manage_spotlights -%}
+                      disabled
+                    {% endif -%}>Delete</button>
+            {% if let Some(link_url) = &spotlight.link_url -%}
+              <a href="{{ link_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="btn-secondary-anchor">Open link</a>
+            {% endif -%}
+          </div>
+        </form>
+      </article>
+    {% endfor -%}
+  </section>
+{% endif -%}
 </div>

--- a/ocg-server/templates/dashboard/group/spotlights_list.html
+++ b/ocg-server/templates/dashboard/group/spotlights_list.html
@@ -71,7 +71,7 @@
         {{ form_fields::image_field(label = "Image", name = "image_url", image_kind = "banner", legend = "Optional spotlight image shown on the group page and spotlight cards.", field_class = "col-span-full") -}}
         <label class="block">
           <span class="label">Link URL</span>
-          <input name="link_url" class="input" placeholder="https://...">
+          <input name="link_url" class="input" type="url" placeholder="https://...">
         </label>
       </div>
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -176,6 +176,7 @@
               <span class="label">Link URL</span>
               <input name="link_url"
                      class="input"
+                     type="url"
                      value="{{ spotlight.link_url.as_deref().unwrap_or("") }}">
             </label>
           </div>

--- a/ocg-server/templates/dashboard/group/store_list.html
+++ b/ocg-server/templates/dashboard/group/store_list.html
@@ -186,72 +186,72 @@
               {% if let Some(image_url) = &item.image_url %}value="{{ image_url }}"{% endif %}
             {%- endlet %}
             {{ form_fields::image_field(label = "Image", name = "image_url", image_kind = "banner", legend = "Optional product image shown on the group page and store.", value_attr = image_value, field_class = "col-span-full") -}}
-              <label class="block">
-                <span class="label">Price in cents</span>
-                <input name="price_minor"
-                       class="input"
-                       type="number"
-                       min="0"
-                       value="{{ item.price_minor }}"
-                       required>
-              </label>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <label class="block">
-                <span class="label">Currency</span>
-                <input name="currency_code"
-                       class="input uppercase"
-                       maxlength="3"
-                       value="{{ item.currency_code }}"
-                       required>
-              </label>
-              <label class="block">
-                <span class="label">Inventory</span>
-                <input name="inventory_count"
-                       class="input"
-                       type="number"
-                       min="0"
-                       value="{{ item.inventory_input_value() }}">
-              </label>
-              <label class="block">
-                <span class="label">Featured</span>
-                <select name="featured" class="input">
-                  <option value="false" {% if !item.featured %}selected{% endif %}>No</option>
-                  <option value="true" {% if item.featured %}selected{% endif %}>Yes</option>
-                </select>
-              </label>
-              <label class="block">
-                <span class="label">Active</span>
-                <select name="active" class="input">
-                  <option value="true" {% if item.active %}selected{% endif %}>Yes</option>
-                  <option value="false" {% if !item.active %}selected{% endif %}>No</option>
-                </select>
-              </label>
-            </div>
+            <label class="block">
+              <span class="label">Price in cents</span>
+              <input name="price_minor"
+                     class="input"
+                     type="number"
+                     min="0"
+                     value="{{ item.price_minor }}"
+                     required>
+            </label>
+          </div>
+          <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <label class="block">
+              <span class="label">Currency</span>
+              <input name="currency_code"
+                     class="input uppercase"
+                     maxlength="3"
+                     value="{{ item.currency_code }}"
+                     required>
+            </label>
+            <label class="block">
+              <span class="label">Inventory</span>
+              <input name="inventory_count"
+                     class="input"
+                     type="number"
+                     min="0"
+                     value="{{ item.inventory_input_value() }}">
+            </label>
+            <label class="block">
+              <span class="label">Featured</span>
+              <select name="featured" class="input">
+                <option value="false" {% if !item.featured %}selected{% endif %}>No</option>
+                <option value="true" {% if item.featured %}selected{% endif %}>Yes</option>
+              </select>
+            </label>
+            <label class="block">
+              <span class="label">Active</span>
+              <select name="active" class="input">
+                <option value="true" {% if item.active %}selected{% endif %}>Yes</option>
+                <option value="false" {% if !item.active %}selected{% endif %}>No</option>
+              </select>
+            </label>
+          </div>
 
-            <div class="flex flex-wrap gap-2">
-              <button type="submit"
-                      class="btn-primary"
-                      {% if !can_manage_store -%}
-                        disabled
-                      {% endif -%}>Save</button>
-              <button type="button"
-                      class="btn-tertiary"
-                      hx-delete="/dashboard/group/store/{{ item.group_store_item_id }}"
-                      hx-target="#dashboard-content"
-                      hx-indicator="#dashboard-spinner"
-                      hx-confirm="Delete this store item?"
-                      {% if !can_manage_store -%}
-                        disabled
-                      {% endif -%}>Delete</button>
-              <a href="{{ item.checkout_url }}"
-                 target="_blank"
-                 rel="noopener noreferrer"
-                 class="btn-secondary-anchor">Open checkout</a>
-            </div>
-          </form>
-        </article>
-      {% endfor -%}
-    </section>
-  {% endif -%}
+          <div class="flex flex-wrap gap-2">
+            <button type="submit"
+                    class="btn-primary"
+                    {% if !can_manage_store -%}
+                      disabled
+                    {% endif -%}>Save</button>
+            <button type="button"
+                    class="btn-tertiary"
+                    hx-delete="/dashboard/group/store/{{ item.group_store_item_id }}"
+                    hx-target="#dashboard-content"
+                    hx-indicator="#dashboard-spinner"
+                    hx-confirm="Delete this store item?"
+                    {% if !can_manage_store -%}
+                      disabled
+                    {% endif -%}>Delete</button>
+            <a href="{{ item.checkout_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="btn-secondary-anchor">Open checkout</a>
+          </div>
+        </form>
+      </article>
+    {% endfor -%}
+  </section>
+{% endif -%}
 </div>

--- a/ocg-server/templates/group/members.html
+++ b/ocg-server/templates/group/members.html
@@ -77,7 +77,9 @@
               <div class="flex w-full flex-col gap-5 p-5">
                 <div class="flex items-start gap-4">
                   <logo-image
-                  {% if let Some(photo_url) = &member.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+                  {% if let Some(photo_url) = &member.photo_url -%}
+                    image-url="{{ photo_url }}"
+                  {% endif -%}
                   size="size-16" placeholder="{{ self::user_initials(member.name.as_deref() , member.username.as_str()) }}">
                   </logo-image>
                   <div class="min-w-0 flex-1">

--- a/ocg-server/templates/group/members.html
+++ b/ocg-server/templates/group/members.html
@@ -1,0 +1,156 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+{% import "macros/pagination.html" as pagination -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() |demoji }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &group.name) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl p-4 sm:p-6 lg:p-8">
+    <div class="rounded-3xl border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+      <div class="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}"
+             class="text-sm font-medium text-primary-700 hover:text-primary-900">← Back to {{ group.name|demoji }}</a>
+          <h1 class="mt-4 text-3xl font-semibold text-stone-950 sm:text-4xl">Members</h1>
+          <p class="mt-3 max-w-2xl text-base leading-7 text-stone-600">
+            Browse members of {{ group.name|demoji }}. This directory is visible to logged-in members of the group.
+          </p>
+        </div>
+        <div class="text-sm text-stone-600">
+          {{ pagination::range_display(offset = offset.unwrap_or(0) , count = members.len(), total = total, label = "member") }}
+        </div>
+      </div>
+
+      <form action="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/members"
+            method="get"
+            class="mt-8 flex max-w-xl gap-3">
+        <label class="sr-only" for="members-query">Search members</label>
+        <input id="members-query"
+               type="search"
+               name="query"
+               value="{{ query|assigned_or("") }}"
+               class="input-primary"
+               placeholder="Search members"
+               autocomplete="off"
+               autocorrect="off"
+               autocapitalize="off"
+               spellcheck="false">
+        <button type="submit" class="btn-primary">Search</button>
+      </form>
+
+      {% if members.is_empty() -%}
+        <div class="mt-10 rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-8 py-12 text-center">
+          <div class="mx-auto flex size-12 items-center justify-center rounded-full bg-primary-50">
+            <div class="svg-icon size-6 icon-people bg-primary-500"></div>
+          </div>
+          <h2 class="mt-4 text-lg font-semibold text-stone-950">No members found</h2>
+          <p class="mt-2 text-sm text-stone-600">Try a different search or check back after more members join.</p>
+        </div>
+      {% else -%}
+        <div class="mt-10 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {% for member in members -%}
+            <article class="flex overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm">
+              <div class="flex w-full flex-col gap-5 p-5">
+                <div class="flex items-start gap-4">
+                  <logo-image
+                  {% if let Some(photo_url) = &member.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+                  size="size-16" placeholder="{{ self::user_initials(member.name.as_deref() , member.username.as_str()) }}">
+                  </logo-image>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <h2 class="truncate text-lg font-semibold text-stone-950">{{ member.name|assigned_or(member.username) }}</h2>
+                      {% if member.linkedin_connected -%}
+                        <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">Verified</span>
+                      {% endif -%}
+                    </div>
+                    <div class="mt-1 text-sm text-stone-500">@{{ member.username }}</div>
+                    <div class="mt-3 text-sm leading-5 text-stone-700">
+                      <span class="font-medium text-stone-900">{{ member.title.as_deref() |assigned_or("Member") }}</span>
+                      {% if let Some(company) = &member.company -%}
+                        <span class="text-stone-400">&nbsp;at&nbsp;</span><span>{{ company }}</span>
+                      {% endif -%}
+                    </div>
+                  </div>
+                </div>
+
+                {% if let Some(bio) = &member.bio -%}
+                  <p class="line-clamp-3 text-sm leading-6 text-stone-600">{{ bio }}</p>
+                {% endif -%}
+
+                {% if let Some(interests) = &member.interests -%}
+                  <div class="flex flex-wrap gap-2">
+                    {% for interest in interests -%}
+                      <span class="rounded-full bg-stone-50 px-2.5 py-1 text-xs font-medium text-stone-700 ring-1 ring-inset ring-stone-200">{{ interest }}</span>
+                    {% endfor -%}
+                  </div>
+                {% endif -%}
+
+                <div class="mt-auto flex flex-wrap items-center gap-2 border-t border-stone-100 pt-4">
+                  <a class="btn-secondary-anchor btn-mini"
+                     href="/profiles/{{ member.username }}"
+                     hx-boost="true"
+                     hx-target="body">Profile</a>
+                  {% if let Some(linkedin_url) = &member.linkedin_url -%}
+                    <a class="inline-flex size-9 items-center justify-center rounded-full bg-stone-50 ring-1 ring-inset ring-stone-200 transition hover:bg-primary-50 hover:ring-primary-200"
+                       href="{{ linkedin_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       title="LinkedIn profile">
+                      <div class="svg-icon size-4 icon-linkedin bg-primary-600"></div>
+                    </a>
+                  {% endif -%}
+                  {% if let Some(github_url) = &member.github_url -%}
+                    <a class="inline-flex size-9 items-center justify-center rounded-full bg-stone-50 ring-1 ring-inset ring-stone-200 transition hover:bg-stone-100 hover:ring-stone-300"
+                       href="{{ github_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       title="GitHub">
+                      <div class="svg-icon size-4 icon-github bg-stone-700"></div>
+                    </a>
+                  {% endif -%}
+                  {% if let Some(website_url) = &member.website_url -%}
+                    <a class="inline-flex size-9 items-center justify-center rounded-full bg-stone-50 ring-1 ring-inset ring-stone-200 transition hover:bg-stone-100 hover:ring-stone-300"
+                       href="{{ website_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       title="Website">
+                      <div class="svg-icon size-4 icon-link bg-stone-700"></div>
+                    </a>
+                  {% endif -%}
+                </div>
+              </div>
+            </article>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+
+      {% if total > members.len() -%}
+        {{ pagination::navigation_links(links = navigation_links, hx_target = "body") }}
+      {% endif -%}
+    </div>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/group/members.html
+++ b/ocg-server/templates/group/members.html
@@ -77,9 +77,7 @@
               <div class="flex w-full flex-col gap-5 p-5">
                 <div class="flex items-start gap-4">
                   <logo-image
-                  {% if let Some(photo_url) = &member.photo_url -%}
-                    image-url="{{ photo_url }}"
-                  {% endif -%}
+                  {% if let Some(photo_url) = &member.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
                   size="size-16" placeholder="{{ self::user_initials(member.name.as_deref() , member.username.as_str()) }}">
                   </logo-image>
                   <div class="min-w-0 flex-1">

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -322,9 +322,7 @@
                   <article class="rounded-xl border border-stone-200 bg-white p-4 shadow-sm">
                     <div class="flex items-start gap-3">
                       <logo-image
-                      {% if let Some(photo_url) = &spotlight.photo_url -%}
-                        image-url="{{ photo_url }}"
-                      {% endif -%}
+                      {% if let Some(photo_url) = &spotlight.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
                       size="size-11" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
                       </logo-image>
                       <div class="min-w-0 flex-1">

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -139,6 +139,11 @@
                   <div class="svg-icon size-4 icon-vertical-dots"></div>
                 </summary>
                 <div class="absolute left-4 z-20 mt-2 w-56 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border border-stone-200 bg-white py-1 shadow-lg sm:left-auto sm:right-0 sm:w-max sm:min-w-48">
+                  <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/members"
+                     class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
+                    <div class="svg-icon size-4 icon-people bg-stone-600"></div>
+                    Members
+                  </a>
                   <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/spotlights"
                      class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
                     <div class="svg-icon size-4 icon-star bg-stone-600"></div>

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -301,7 +301,9 @@
                 Member stories
               </div>
               <h2 class="mt-4 text-2xl font-semibold text-stone-950">Member spotlights</h2>
-              <p class="mt-2 text-sm/6 text-stone-600">Wins, stories, and profile cards from {{ group.name|demoji }} members.</p>
+              <p class="mt-2 text-sm/6 text-stone-600">
+                Wins, stories, and profile cards from {{ group.name|demoji }} members.
+              </p>
             </div>
             <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/spotlights"
                class="btn-secondary-anchor shrink-0"
@@ -320,7 +322,9 @@
                   <article class="rounded-xl border border-stone-200 bg-white p-4 shadow-sm">
                     <div class="flex items-start gap-3">
                       <logo-image
-                      {% if let Some(photo_url) = &spotlight.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+                      {% if let Some(photo_url) = &spotlight.photo_url -%}
+                        image-url="{{ photo_url }}"
+                      {% endif -%}
                       size="size-11" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
                       </logo-image>
                       <div class="min-w-0 flex-1">


### PR DESCRIPTION
## Summary
- Add a logged-in, member-only group directory at `/{alliance}/group/{group}/members`.
- Link the member directory from the public group page actions menu.
- Show profile/social details without exposing dashboard email fields or admin actions.

## Test plan
- `cargo fmt`
- `cargo check -p ocg-server`

Made with [Cursor](https://cursor.com)