### PR TITLE
Fix user dashboard invitation banner rendering

### DIFF
--- a/ocg-server/src/templates/dashboard/user/invitations.rs
+++ b/ocg-server/src/templates/dashboard/user/invitations.rs
@@ -27,9 +27,10 @@ pub(crate) struct ListPage {
 impl ListPage {
     /// Returns the total number of pending invitations shown on the page.
     pub(crate) fn total_invitations(&self) -> i64 {
-        (self.alliance_invitations.len()
+        let total = self.alliance_invitations.len()
             + self.event_invitations.len()
-            + self.group_invitations.len()) as i64
+            + self.group_invitations.len();
+        i64::try_from(total).expect("invitation count to fit in i64")
     }
 }
 

--- a/ocg-server/templates/dashboard/user/home.html
+++ b/ocg-server/templates/dashboard/user/home.html
@@ -65,8 +65,7 @@
             </div>
             <div>
               <div class="text-sm font-semibold text-stone-900">
-                You have {{ pending_invitation_count }} pending invitation
-                {% if pending_invitation_count != 1 %}s{% endif %}
+                You have {{ pending_invitation_count }} pending invitation{%- if pending_invitation_count != 1 -%}s{%- endif %}
               </div>
               <p class="mt-1 text-sm text-stone-600">Review your invitations to accept or reject them.</p>
             </div>


### PR DESCRIPTION
## Summary
- Render the pending invitation banner text without template whitespace splitting the plural suffix.
- Replace the invitation total cast with a checked conversion to satisfy stricter Clippy runs.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test -p ocg-server handlers::dashboard::user::home::tests::test_page_account_tab_success`
- `cargo clippy -p ocg-server --all-targets --all-features -- --deny warnings`
- `uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/dashboard/user/home.html`


Made with [Cursor](https://cursor.com)