### PR TITLE
Improve sponsor access and logout behavior

### DIFF
--- a/ocg-server/src/handlers/auth.rs
+++ b/ocg-server/src/handlers/auth.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use axum::{
     Form,
     extract::{Path, Query, Request, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode, header::SET_COOKIE},
     middleware::Next,
     response::{Html, IntoResponse, Redirect, Response},
 };
@@ -64,6 +64,13 @@ pub(crate) const LOG_OUT_URL: &str = "/log-out";
 
 /// Key used to store the next URL in the session.
 pub(crate) const NEXT_URL_KEY: &str = "next_url";
+
+/// Expired cookie for the app session identifier.
+const EXPIRED_SESSION_COOKIE: &str = "id=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure";
+
+/// Expired cookie for legacy auth provider state if it was ever set client-side.
+const EXPIRED_AUTH_PROVIDER_COOKIE: &str =
+    "auth_provider=; Max-Age=0; Path=/; HttpOnly; SameSite=Lax; Secure";
 
 /// Key used to store the `OAuth2` CSRF state in the session.
 pub(crate) const OAUTH2_CSRF_STATE_KEY: &str = "oauth2.csrf_state";
@@ -237,7 +244,9 @@ pub(crate) async fn log_out(
         .await
         .map_err(|e| HandlerError::Auth(e.to_string()))?;
 
-    Ok(Redirect::to(LOG_IN_URL))
+    let mut response = Redirect::to(LOG_IN_URL).into_response();
+    append_logout_cookie_expirations(&mut response);
+    Ok(response)
 }
 
 /// Handler that completes the oauth2 authorization process.
@@ -323,7 +332,10 @@ pub(crate) async fn oidc_callback(
 #[instrument(skip_all)]
 pub(crate) async fn oidc_redirect(
     session: Session,
-    Oidc(oidc_provider): Oidc,
+    Oidc {
+        provider,
+        details: oidc_provider,
+    }: Oidc,
     Query(NextUrl { next_url }): Query<NextUrl>,
 ) -> Result<impl IntoResponse, HandlerError> {
     // Generate the authorization url
@@ -335,6 +347,9 @@ pub(crate) async fn oidc_redirect(
     for scope in &oidc_provider.scopes {
         builder = builder.add_scope(oidc::Scope::new(scope.clone()));
     }
+    builder = match provider {
+        OidcProvider::LinkedIn => builder.add_extra_param("prompt", "select_account"),
+    };
     let (authorize_url, csrf_state, nonce) = builder.url();
 
     // Sanitize the next url (if provided)
@@ -1159,7 +1174,19 @@ pub(crate) async fn log_out_for_stale_dashboard_context(
         .await
         .map_err(|e| HandlerError::Auth(e.to_string()))?;
 
-    Ok(redirect_to_log_in_for_request(headers))
+    let mut response = redirect_to_log_in_for_request(headers);
+    append_logout_cookie_expirations(&mut response);
+    Ok(response)
+}
+
+/// Adds cookie expirations for browser auth state controlled by this app.
+fn append_logout_cookie_expirations(response: &mut Response) {
+    let headers = response.headers_mut();
+    headers.append(SET_COOKIE, HeaderValue::from_static(EXPIRED_SESSION_COOKIE));
+    headers.append(
+        SET_COOKIE,
+        HeaderValue::from_static(EXPIRED_AUTH_PROVIDER_COOKIE),
+    );
 }
 
 /// Builds the log-in redirect response expected by the request type.

--- a/ocg-server/src/handlers/auth/tests.rs
+++ b/ocg-server/src/handlers/auth/tests.rs
@@ -7,7 +7,7 @@ use axum::{
     body::{Body, to_bytes},
     http::{
         HeaderValue, Request, StatusCode,
-        header::{CONTENT_TYPE, COOKIE, HOST, LOCATION},
+        header::{CONTENT_TYPE, COOKIE, HOST, LOCATION, SET_COOKIE},
     },
     middleware,
     response::IntoResponse,
@@ -511,6 +511,17 @@ async fn test_log_in_validation_error() {
         parts.headers.get(LOCATION).unwrap(),
         &HeaderValue::from_static(LOG_IN_URL),
     );
+    let set_cookies = parts.headers.get_all(SET_COOKIE);
+    assert!(set_cookies.iter().any(|value| {
+        value
+            .to_str()
+            .is_ok_and(|cookie| cookie.contains("id=") && cookie.contains("Max-Age=0"))
+    }));
+    assert!(set_cookies.iter().any(|value| {
+        value
+            .to_str()
+            .is_ok_and(|cookie| cookie.contains("auth_provider=") && cookie.contains("Max-Age=0"))
+    }));
     assert!(bytes.is_empty());
 }
 
@@ -1490,10 +1501,17 @@ async fn test_oidc_redirect_success() {
     };
 
     // Execute handler
-    let response = oidc_redirect(session.clone(), Oidc(Arc::new(provider)), query)
-        .await
-        .expect("oidc redirect should succeed")
-        .into_response();
+    let response = oidc_redirect(
+        session.clone(),
+        Oidc {
+            provider: OidcProvider::LinkedIn,
+            details: Arc::new(provider),
+        },
+        query,
+    )
+    .await
+    .expect("oidc redirect should succeed")
+    .into_response();
     let (parts, body) = response.into_parts();
     let bytes = to_bytes(body, usize::MAX).await.unwrap();
     let location = parts.headers.get(LOCATION).unwrap().to_str().unwrap();
@@ -1521,6 +1539,7 @@ async fn test_oidc_redirect_success() {
             .find_map(|pair| pair.strip_prefix("nonce=").map(String::from))
             .as_deref(),
     );
+    assert!(query.split('&').any(|pair| pair == "prompt=select_account"));
     assert_eq!(next_url, Some(Some("/dashboard".to_string())));
     assert!(bytes.is_empty());
 }

--- a/ocg-server/src/handlers/extractors.rs
+++ b/ocg-server/src/handlers/extractors.rs
@@ -105,7 +105,12 @@ impl FromRequestParts<router::State> for OAuth2 {
 }
 
 /// Extractor for `Oidc` provider details from the authenticated session.
-pub(crate) struct Oidc(pub Arc<OidcProviderDetails>);
+pub(crate) struct Oidc {
+    /// Provider selected in the route.
+    pub provider: OidcProvider,
+    /// Provider configuration details.
+    pub details: Arc<OidcProviderDetails>,
+}
 
 impl FromRequestParts<router::State> for Oidc {
     type Rejection = (StatusCode, &'static str);
@@ -124,7 +129,10 @@ impl FromRequestParts<router::State> for Oidc {
         let Some(provider_details) = auth_session.backend.oidc_providers.get(&provider) else {
             return Err((StatusCode::BAD_REQUEST, "oidc provider not supported"));
         };
-        Ok(Oidc(provider_details.clone()))
+        Ok(Oidc {
+            provider: provider.0,
+            details: provider_details.clone(),
+        })
     }
 }
 

--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -170,7 +170,11 @@ pub(crate) async fn members_page(
 
     let is_member = db.is_group_member(alliance_id, group.group_id, user.user_id).await?;
     if !is_member {
-        return Err(HandlerError::Forbidden);
+        return Ok((
+            StatusCode::FORBIDDEN,
+            "Join this group first to see members.",
+        )
+            .into_response());
     }
 
     let filters: GroupMembersFilters =

--- a/ocg-server/src/handlers/group/tests.rs
+++ b/ocg-server/src/handlers/group/tests.rs
@@ -346,6 +346,62 @@ fn expect_empty_group_home_previews(db: &mut MockDB, group_id: Uuid) {
 }
 
 #[tokio::test]
+async fn test_members_page_non_member_explains_join_required() {
+    // Setup identifiers and data structures
+    let alliance_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let auth_hash = "hash".to_string();
+    let session_record = sample_session_record(session_id, user_id, &auth_hash, None, None);
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_get_session()
+        .times(1)
+        .withf(move |id| *id == session_id)
+        .returning(move |_| Ok(Some(session_record.clone())));
+    db.expect_get_user_by_id()
+        .times(1)
+        .withf(move |id| *id == user_id)
+        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
+    db.expect_get_alliance_id_by_name()
+        .times(1)
+        .withf(|name| name == "test-alliance")
+        .returning(move |_| Ok(Some(alliance_id)));
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(|| Ok(sample_site_settings()));
+    db.expect_get_group_full_by_slug()
+        .times(1)
+        .withf(move |id, slug| *id == alliance_id && slug == "test-group")
+        .returning(move |_, _| Ok(Some(sample_group_full(alliance_id, group_id))));
+    db.expect_is_group_member()
+        .times(1)
+        .withf(move |aid, gid, uid| *aid == alliance_id && *gid == group_id && *uid == user_id)
+        .returning(|_, _, _| Ok(false));
+
+    // Setup router and send request
+    let router = TestRouterBuilder::new(db, MockNotificationsManager::new())
+        .build()
+        .await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/test-alliance/group/test-group/members")
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+
+    // Check response matches expectations
+    assert_eq!(parts.status, StatusCode::FORBIDDEN);
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(body.contains("Join this group first to see members."));
+}
+
+#[tokio::test]
 async fn test_join_group_success() {
     // Setup identifiers and data structures
     let alliance_id = Uuid::new_v4();

--- a/ocg-server/src/handlers/site/sponsor.rs
+++ b/ocg-server/src/handlers/site/sponsor.rs
@@ -3,8 +3,8 @@
 use askama::Template;
 use axum::{
     extract::State,
-    http::Uri,
-    response::{Html, IntoResponse},
+    http::{Uri, header::CACHE_CONTROL},
+    response::{Html, IntoResponse, Redirect},
 };
 use tracing::instrument;
 
@@ -12,7 +12,7 @@ use crate::{
     auth::AuthSession,
     db::DynDB,
     handlers::{error::HandlerError, extractors::ValidatedForm},
-    router::PUBLIC_SHARED_CACHE_HEADERS,
+    router::CACHE_CONTROL_PRIVATE_NO_STORE,
     services::notifications::{DynNotificationsManager, OutboundEmail},
     templates::{
         PageId,
@@ -32,7 +32,7 @@ pub(crate) async fn page(
     uri: Uri,
 ) -> Result<impl IntoResponse, HandlerError> {
     Ok((
-        PUBLIC_SHARED_CACHE_HEADERS,
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
         Html(render_page(auth_session, &db, uri.path(), false).await?),
     ))
 }
@@ -45,6 +45,10 @@ pub(crate) async fn submit(
     State(notifications_manager): State<DynNotificationsManager>,
     ValidatedForm(input): ValidatedForm<SponsorInquiry>,
 ) -> Result<impl IntoResponse, HandlerError> {
+    if auth_session.user.is_none() {
+        return Ok(Redirect::to("/log-in?next_url=/sponsor").into_response());
+    }
+
     let email = OutboundEmail {
         body: input.email_body(),
         subject: input.email_subject(),
@@ -53,9 +57,10 @@ pub(crate) async fn submit(
     notifications_manager.send_email(&email).await?;
 
     Ok((
-        PUBLIC_SHARED_CACHE_HEADERS,
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
         Html(render_page(auth_session, &db, "/sponsor", true).await?),
-    ))
+    )
+        .into_response())
 }
 
 async fn render_page(

--- a/ocg-server/src/handlers/site/sponsor/tests.rs
+++ b/ocg-server/src/handlers/site/sponsor/tests.rs
@@ -1,8 +1,13 @@
 use axum::{
     body::{Body, to_bytes},
-    http::{HeaderValue, Request, StatusCode, header::CONTENT_TYPE},
+    http::{
+        HeaderValue, Request, StatusCode,
+        header::{CONTENT_TYPE, COOKIE, LOCATION},
+    },
 };
+use axum_login::tower_sessions::session;
 use tower::ServiceExt;
+use uuid::Uuid;
 
 use crate::{
     db::mock::MockDB,
@@ -41,13 +46,72 @@ async fn test_page_success() {
     );
     let body = String::from_utf8(bytes.to_vec()).unwrap();
     assert!(body.contains("Sponsor GOUP"));
+    assert!(body.contains("Log in to send a sponsor inquiry"));
+    assert!(!body.contains("Send sponsor inquiry"));
+}
+
+#[tokio::test]
+async fn test_page_logged_in_shows_form() {
+    // Setup identifiers and data structures
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let auth_hash = "hash".to_string();
+    let session_record = sample_session_record(session_id, user_id, &auth_hash, None, None);
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_get_session()
+        .times(1)
+        .withf(move |id| *id == session_id)
+        .returning(move |_| Ok(Some(session_record.clone())));
+    db.expect_get_user_by_id()
+        .times(1)
+        .withf(move |id| *id == user_id)
+        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(|| Ok(sample_site_settings()));
+
+    // Setup notifications manager mock
+    let nm = MockNotificationsManager::new();
+
+    // Setup router and send request
+    let router = TestRouterBuilder::new(db, nm).build().await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/sponsor")
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+
+    // Check response matches expectations
+    assert_eq!(parts.status, StatusCode::OK);
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
     assert!(body.contains("Send sponsor inquiry"));
+    assert!(!body.contains("Log in to send a sponsor inquiry"));
 }
 
 #[tokio::test]
 async fn test_submit_sends_email() {
+    // Setup identifiers and data structures
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let auth_hash = "hash".to_string();
+    let session_record = sample_session_record(session_id, user_id, &auth_hash, None, None);
+
     // Setup database mock
     let mut db = MockDB::new();
+    db.expect_get_session()
+        .times(1)
+        .withf(move |id| *id == session_id)
+        .returning(move |_| Ok(Some(session_record.clone())));
+    db.expect_get_user_by_id()
+        .times(1)
+        .withf(move |id| *id == user_id)
+        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
     db.expect_get_site_settings()
         .times(1)
         .returning(|| Ok(sample_site_settings()));
@@ -74,6 +138,7 @@ async fn test_submit_sends_email() {
         .method("POST")
         .uri("/sponsor")
         .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .header(COOKIE, format!("id={session_id}"))
         .body(Body::from(
             "name=Sponsor+Person&email=sponsor%40example.com&company=Example+Co&website=https%3A%2F%2Fexample.com&budget=%245k&message=We+want+to+sponsor+a+GOUP+event.",
         ))
@@ -86,4 +151,32 @@ async fn test_submit_sends_email() {
     assert_eq!(parts.status, StatusCode::OK);
     let body = String::from_utf8(bytes.to_vec()).unwrap();
     assert!(body.contains("Thanks for reaching out."));
+}
+
+#[tokio::test]
+async fn test_submit_requires_login() {
+    // Setup database mock
+    let db = MockDB::new();
+
+    // Setup notifications manager mock
+    let nm = MockNotificationsManager::new();
+
+    // Setup router and send request
+    let router = TestRouterBuilder::new(db, nm).build().await;
+    let request = Request::builder()
+        .method("POST")
+        .uri("/sponsor")
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+        .body(Body::from(
+            "name=Sponsor+Person&email=sponsor%40example.com&company=Example+Co&website=https%3A%2F%2Fexample.com&budget=%245k&message=We+want+to+sponsor+a+GOUP+event.",
+        ))
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+
+    // Check response matches expectations
+    assert_eq!(response.status(), StatusCode::SEE_OTHER);
+    assert_eq!(
+        response.headers().get(LOCATION).unwrap(),
+        &HeaderValue::from_static("/log-in?next_url=/sponsor")
+    );
 }

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -58,10 +58,10 @@
             </div>
           </div>
         </div>
-        {{ header::link(content = "Sponsor", href = "/sponsor", current_path = path, path = "/sponsor") -}}
         {{ header::link(content = "Landscape", href = "/landscape", current_path = path, path = "/landscape") -}}
         {{ header::link(content = "Resources", href = "/wiki", current_path = path, path = "/wiki") -}}
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
+        {{ header::link(content = "Sponsor", href = "/sponsor", current_path = path, path = "/sponsor") -}}
       </div>
       {# End desktop links -#}
     </div>
@@ -230,20 +230,6 @@
           </li>
 
           <li class="lg:hidden" role="none">
-            <a href="/sponsor"
-               hx-boost="true"
-               hx-target="body"
-               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
-               role="menuitem">
-              <div class="flex items-center">
-                <div class="svg-icon size-4 icon-handshake bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Sponsor GOUP</div>
-                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
-              </div>
-            </a>
-          </li>
-
-          <li class="lg:hidden" role="none">
             <a href="/wiki"
                hx-boost="true"
                hx-target="body"
@@ -266,6 +252,20 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-charts bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Stats</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="/sponsor"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-handshake bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Sponsor GOUP</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -439,20 +439,6 @@
           </li>
 
           <li class="lg:hidden" role="none">
-            <a href="/sponsor"
-               hx-boost="true"
-               hx-target="body"
-               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
-               role="menuitem">
-              <div class="flex items-center">
-                <div class="svg-icon size-4 icon-handshake bg-stone-600"></div>
-                <div class="ms-2 text-xs/6">Sponsor GOUP</div>
-                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
-              </div>
-            </a>
-          </li>
-
-          <li class="lg:hidden" role="none">
             <a href="/jobs"
                hx-boost="true"
                hx-target="body"
@@ -502,6 +488,20 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-map bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Landscape</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="/sponsor"
+               hx-boost="true"
+               hx-target="body"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-handshake bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Sponsor GOUP</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/ocg-server/templates/site/sponsor/page.html
+++ b/ocg-server/templates/site/sponsor/page.html
@@ -15,6 +15,11 @@
           Partner with GOUP to support events, hackathons, community programs, and useful
           opportunities for builders.
         </p>
+        <p class="mt-4 max-w-2xl text-base/7 text-stone-600">
+          Sponsorship helps keep GOUP warm, practical, and accessible: more rooms for builders to meet,
+          more projects discovered, more jobs shared, and more community programs that turn introductions
+          into real momentum.
+        </p>
       </div>
     </section>
   </div>
@@ -28,7 +33,14 @@
         <div class="mt-6 grid gap-4 text-sm/6 text-stone-200">
           <p>Reach a trusted network of founders, engineers, researchers, creators, and community leaders.</p>
           <p>Support high-signal events, learning, open source, AI, startup, and career initiatives.</p>
-          <p>Help GOUP stay useful, warm, and accessible to people who build.</p>
+          <p>Help members find collaborators, talent, sponsors, and opportunities without turning the community into noise.</p>
+        </div>
+        <div class="mt-8 rounded-3xl border border-white/10 bg-white/10 p-5 text-sm/6 text-stone-200">
+          <div class="font-bold text-white">Members-first sponsorship</div>
+          <p class="mt-2">
+            We prioritize useful support: community calls, member spotlights, event support, project visibility,
+            and jobs that help builders move forward.
+          </p>
         </div>
         <div class="mt-8 rounded-3xl border border-white/10 bg-white/10 p-5 text-sm/6 text-stone-200">
           We’ll reply from <a href="mailto:{{ crate::templates::site::sponsor::SPONSOR_INQUIRY_RECIPIENT }}"
@@ -47,6 +59,17 @@
                hx-boost="true"
                hx-target="body"
                class="btn-primary-anchor mt-6">Back to GOUP</a>
+          </div>
+        {% elif !user.logged_in -%}
+          <div class="rounded-3xl border border-primary-200 bg-primary-50 p-6">
+            <h2 class="text-2xl font-black tracking-tight text-stone-950">Log in to send a sponsor inquiry</h2>
+            <p class="mt-3 text-base/7 text-stone-600">
+              Please log in first so the GOUP team can follow up with a trusted account.
+            </p>
+            <a href="/log-in?next_url=/sponsor"
+               hx-boost="true"
+               hx-target="body"
+               class="btn-primary-anchor mt-6">Log in to continue</a>
           </div>
         {% else -%}
           <div>
@@ -139,5 +162,47 @@
         {% endif -%}
       </section>
     </div>
+
+    <section class="mt-10 rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+      <div class="max-w-3xl">
+        <h2 class="text-2xl font-black tracking-tight text-stone-950">Memberships to suit your organization</h2>
+        <p class="mt-3 text-sm/6 text-stone-600">
+          GOUP sponsorships are flexible. Start with a community contribution, grow into deeper ecosystem
+          support, or design a strategic partnership around events, hiring, open source, AI, and builder programs.
+        </p>
+      </div>
+
+      <div class="mt-8 grid gap-5 lg:grid-cols-3">
+        <article class="rounded-3xl border border-stone-200 bg-stone-50 p-6">
+          <h3 class="text-lg font-black tracking-tight text-stone-950">Community</h3>
+          <p class="mt-2 text-sm/6 text-stone-600">For academic, nonprofit, and early community partners.</p>
+          <ul class="mt-5 grid gap-3 text-sm/6 text-stone-700">
+            <li>Recognition on GOUP community channels.</li>
+            <li>Member-friendly event or hackathon support.</li>
+            <li>Access to share relevant opportunities with the network.</li>
+          </ul>
+        </article>
+
+        <article class="rounded-3xl border border-primary-200 bg-primary-50 p-6">
+          <h3 class="text-lg font-black tracking-tight text-stone-950">Builder</h3>
+          <p class="mt-2 text-sm/6 text-stone-600">For teams that want steady visibility and community touchpoints.</p>
+          <ul class="mt-5 grid gap-3 text-sm/6 text-stone-700">
+            <li>Everything in Community.</li>
+            <li>Featured member, job, project, or event spotlights.</li>
+            <li>Support for focused programs, workshops, and founder/operator sessions.</li>
+          </ul>
+        </article>
+
+        <article class="rounded-3xl border border-stone-900 bg-stone-950 p-6 text-white">
+          <h3 class="text-lg font-black tracking-tight">Ecosystem</h3>
+          <p class="mt-2 text-sm/6 text-stone-300">For organizations investing deeply in the builder network.</p>
+          <ul class="mt-5 grid gap-3 text-sm/6 text-stone-200">
+            <li>Everything in Builder.</li>
+            <li>Custom partnership around events, hiring, landscape visibility, or community programs.</li>
+            <li>Founder, engineering, research, and community leader engagement opportunities.</li>
+          </ul>
+        </article>
+      </div>
+    </section>
   </div>
 {% endblock content -%}


### PR DESCRIPTION
## Summary
- Require login before sponsor inquiries can be submitted, with anonymous users seeing a login prompt instead of the form.
- Improve logout and LinkedIn relogin behavior by expiring app auth cookies and requesting LinkedIn account selection on OIDC login.
- Move Sponsor to the end of the main navigation, expand the sponsor page story, and show a clearer join-required message on group member directories.

## Test plan
- `cargo fmt --all -- --check`
- `cargo test -p ocg-server handlers::auth::tests::test_log_in_invalid_credentials`
- `cargo test -p ocg-server handlers::auth::tests::test_log_out_success`
- `cargo test -p ocg-server handlers::auth::tests::test_oidc_redirect_success`
- `cargo test -p ocg-server handlers::site::sponsor::tests`
- `cargo test -p ocg-server handlers::group::tests::test_members_page_non_member_explains_join_required`
- `uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/common/header.html ocg-server/templates/site/sponsor/page.html`


Made with [Cursor](https://cursor.com)