### PR TITLE
Add role-based GOUP runbooks

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -11,6 +11,9 @@
   - [User Dashboard](/guides/user-dashboard.md)
   - [Alliance Dashboard](/guides/alliance-dashboard.md)
   - [Group Dashboard](/guides/group-dashboard.md)
+  - [Group Leads Runbook](/guides/group-leads-runbook.md)
+  - [Group Members Runbook](/guides/group-members-runbook.md)
+  - [Project Contributors Runbook](/guides/project-contributors-runbook.md)
   - [Payments Setup](/guides/payments-setup.md)
   - [Event Operations](/guides/event-operations.md)
 

--- a/docs/guides/group-leads-runbook.md
+++ b/docs/guides/group-leads-runbook.md
@@ -1,0 +1,126 @@
+<!-- markdownlint-disable MD013 -->
+
+# Group Leads Runbook
+
+Use this runbook when you are responsible for keeping a GOUP group active, useful, and well-run.
+It focuses on the weekly operating rhythm for organizers rather than one-time setup.
+
+Path: [/dashboard/group](/dashboard/group ':ignore')
+
+## What Group Leads Own
+
+Group leads are responsible for the health of a group inside an alliance.
+
+Your core responsibilities:
+
+- Keep the public group profile clear and current.
+- Maintain an organizer team with enough coverage.
+- Plan, publish, and follow up on events.
+- Welcome members and communicate with them respectfully.
+- Keep sponsors, store items, and spotlights accurate when your group uses them.
+- Review dashboard logs when something changes unexpectedly.
+
+For full dashboard reference, read the [Group Dashboard Guide](group-dashboard.md).
+
+## Weekly Operating Checklist
+
+Run this checklist once a week or before a major event.
+
+1. Open [Group Dashboard](/dashboard/group ':ignore').
+2. Check [Events](/dashboard/group?tab=events ':ignore') for drafts, upcoming events, waitlists, and events that need publishing.
+3. Review [Members](/dashboard/group?tab=members ':ignore') for new members or communication needs.
+4. Review [Team](/dashboard/group?tab=team ':ignore') to confirm at least two trusted organizers have admin coverage.
+5. Check [Analytics](/dashboard/group?tab=analytics ':ignore') for attendance and growth trends.
+6. Update [Settings](/dashboard/group?tab=settings ':ignore') if links, descriptions, location, or branding changed.
+7. Review [Logs](/dashboard/group?tab=logs ':ignore') if anything looks unexpected.
+
+## Event Runbook
+
+Use this flow for every group event.
+
+### Before Publishing
+
+- Confirm event title, description, location, timezone, and schedule.
+- Add hosts, speakers, sessions, sponsor references, and registration questions if needed.
+- Confirm ticketing and payment setup before creating paid tickets.
+- Preview the public event page.
+- Publish only when the event is ready for members to share.
+
+### During Registration
+
+- Watch attendee counts, waitlist status, and invitation requests.
+- Answer questions from members and speakers.
+- Keep event changes small after people register. If schedule or location changes, communicate clearly.
+- Use custom notifications only for useful updates.
+
+### Event Day
+
+- Use the check-in tools from the event dashboard.
+- Keep a backup organizer available.
+- Track issues that should be fixed before the next event.
+
+### After the Event
+
+- Close out attendance and refunds if payments are enabled.
+- Add member spotlights or group updates when there is a useful story to share.
+- Review analytics and decide what to repeat or change next time.
+
+For deeper event details, read [Event Operations](event-operations.md).
+
+## Member Communication
+
+Use member communication carefully. Members should feel informed, not broadcast to.
+
+Good reasons to message members:
+
+- Event reminders and important schedule changes.
+- Community updates with clear value.
+- Requests for speakers, mentors, volunteers, or project help.
+- Sponsor or partner opportunities that are relevant to the group.
+
+Avoid:
+
+- Repeating the same announcement too often.
+- Sending sponsor messages without context.
+- Asking members to take action without a clear next step.
+
+## Organizer Team Health
+
+Healthy groups avoid single-person ownership.
+
+Maintain:
+
+- At least two active admins.
+- Clear event ownership for each upcoming event.
+- Read-only viewer access for people who need visibility but should not edit.
+- A simple handoff note when organizers rotate out.
+
+If your alliance restricts group team management, ask an alliance admin or groups manager to update organizer access.
+
+## Escalation Paths
+
+Escalate to alliance leads when:
+
+- A group admin is unavailable and access needs repair.
+- Group identity, category, or region choices need alliance-level changes.
+- Payment or refund behavior looks wrong.
+- Member safety, spam, abuse, or trust issues appear.
+- A sponsor request needs alliance-level approval.
+
+Escalate to technical contributors when:
+
+- The dashboard returns an unexpected error.
+- A published event, member directory, or form behaves differently than documented.
+- A migration, integration, or deployment issue blocks operations.
+
+## Quality Bar
+
+A healthy group page should answer these questions quickly:
+
+- What is this group about?
+- Who is it for?
+- What can I attend or join next?
+- How do I participate?
+- Who is organizing it?
+
+If the page cannot answer those questions, update the group profile before adding more events.

--- a/docs/guides/group-members-runbook.md
+++ b/docs/guides/group-members-runbook.md
@@ -1,0 +1,110 @@
+<!-- markdownlint-disable MD013 -->
+
+# Group Members Runbook
+
+Use this runbook if you joined a GOUP group and want to participate, attend events, connect with
+other members, or contribute to the community.
+
+## What Members Can Do
+
+Members can use GOUP to:
+
+- Discover groups and events.
+- Join groups that match their interests.
+- View member directories for groups they belong to.
+- Attend events and manage their registrations.
+- Respond to invitations.
+- Submit talks when a Call for Speakers is open.
+- Share useful projects, jobs, and community updates through the right group or alliance channels.
+
+Start with the [Quickstart](../getting-started/quickstart.md) if you are new.
+
+## Join a Group
+
+1. Open the public group page.
+2. Review the group description, upcoming events, and community focus.
+3. Select `Join` when you want to become a member.
+4. After joining, you can access member-only areas such as the group member directory.
+
+If you open a member directory before joining, GOUP asks you to join the group first.
+
+## Manage Your Activity
+
+Use [User Dashboard](/dashboard/user ':ignore') for your personal GOUP activity.
+
+Important tabs:
+
+- [My Events](/dashboard/user?tab=events ':ignore'): view upcoming events and manage attendance.
+- [Invitations](/dashboard/user?tab=invitations ':ignore'): accept or reject alliance, group, and event invitations.
+- [Session proposals](/dashboard/user?tab=session-proposals ':ignore'): draft and manage proposed talks.
+- [Submissions](/dashboard/user?tab=submissions ':ignore'): track submitted talks and respond to review outcomes.
+- [Profile](/dashboard/user?tab=account ':ignore'): keep your name, bio, timezone, and profile details current.
+
+When you have pending invitations, the dashboard shows a count and an action to review them.
+
+## Attend Events
+
+Before registering:
+
+- Check event date, timezone, format, location, and eligibility.
+- Review registration questions and ticketing details if present.
+- Join the group when the event expects group membership.
+
+After registering:
+
+- Watch for confirmation and reminder emails.
+- Update your registration if plans change.
+- Cancel early if you cannot attend so someone else can use the spot.
+- Complete required questions before the event if prompted.
+
+On event day:
+
+- Bring the check-in QR code or follow the organizer instructions.
+- Respect the organizer's code of conduct and local event rules.
+
+## Respond to Invitations
+
+Invitations appear in [User Dashboard -> Invitations](/dashboard/user?tab=invitations ':ignore').
+
+Common invitation types:
+
+- Group team invitation: join an organizer team.
+- Alliance team invitation: help manage alliance-level setup.
+- Event invitation: attend or participate in an event.
+
+Review the invitation before accepting. If the role or event does not look right, reject it and ask
+the organizer to resend with the correct details.
+
+## Contribute Well
+
+Good member contributions are specific and useful:
+
+- Offer to speak, mentor, volunteer, or help run an event.
+- Share a project with enough context for others to understand it.
+- Post jobs or opportunities through the correct dashboard flow.
+- Nominate members for spotlights when they shipped something worth celebrating.
+- Keep messages respectful and relevant to the group.
+
+Avoid:
+
+- Joining many groups just to broadcast.
+- Sending unrelated job, sponsor, or sales messages.
+- Sharing private member information outside the group.
+
+## Troubleshooting
+
+If you cannot see a members page:
+
+- Confirm you are logged in.
+- Confirm you joined that group.
+- Refresh after joining.
+- Ask a group lead if your membership looks wrong.
+
+If you cannot register for an event:
+
+- Check whether registration is closed.
+- Check whether the event is full or waitlisted.
+- Complete any required profile or registration questions.
+- Contact the organizer when the event page looks inconsistent.
+
+For more help, read [Troubleshooting](../support/troubleshooting.md).

--- a/docs/guides/project-contributors-runbook.md
+++ b/docs/guides/project-contributors-runbook.md
@@ -1,0 +1,135 @@
+<!-- markdownlint-disable MD013 -->
+
+# Project Contributors Runbook
+
+Use this runbook if you contribute projects to GOUP, maintain project listings, or work on the GOUP
+application as a developer.
+
+## Contributor Paths
+
+There are two common contributor paths:
+
+- **Project contributor:** You want to share or maintain a project in the GOUP ecosystem, usually through an alliance landscape or group program.
+- **Application contributor:** You want to improve the GOUP application, docs, database, templates, tests, or deployment tooling.
+
+For code architecture details, read the [Development Guide](../development.md).
+
+## Add or Maintain a Project
+
+Projects should be useful to the community and easy for members to evaluate.
+
+Before adding a project, collect:
+
+- Project name.
+- Short description.
+- Website or repository URL.
+- Tags or categories.
+- Maintainer or organization context.
+- GitHub URL when the project is hosted on GitHub.
+
+When a GitHub URL is available, GOUP can display repository metadata such as owner, repository name,
+stars, forks, watchers, and open issues where that feature is enabled.
+
+Good project entries:
+
+- Explain what the project does in plain language.
+- Link to a maintained source, website, or documentation page.
+- Use tags that help people discover it.
+- Avoid marketing-only descriptions.
+- Stay current when ownership, URLs, or status changes.
+
+## Project Listing Review Checklist
+
+Use this checklist before publishing or requesting review:
+
+1. The project has a working URL.
+2. The description explains user value, not only internal implementation.
+3. Tags are relevant and not excessive.
+4. The project owner or maintainer is clear.
+5. GitHub metadata points to the canonical repository.
+6. The project does not impersonate another organization.
+7. The listing is appropriate for the alliance or group audience.
+
+## Contribute to GOUP Code
+
+GOUP is a Rust server-rendered application with PostgreSQL, Askama templates, HTMX, and focused
+client-side JavaScript.
+
+Recommended local flow:
+
+1. Read [Development Guide](../development.md).
+2. Create a branch for one focused change.
+3. Make the smallest change that solves the user problem.
+4. Add or update focused tests.
+5. Run the checks that match the risk.
+6. Open a pull request with a clear summary and test plan.
+
+Use existing patterns before adding new abstractions:
+
+- Handlers live in `ocg-server/src/handlers/`.
+- Template view models live in `ocg-server/src/templates/`.
+- Askama HTML templates live in `ocg-server/templates/`.
+- Database functions live in `database/migrations/functions/`.
+- Schema migrations live in `database/migrations/schema/`.
+- Docs live in `docs/`.
+
+## Testing Checklist for App Contributors
+
+Use focused tests first, then broaden when behavior is shared.
+
+Common checks:
+
+```bash
+cargo fmt --all -- --check
+cargo check -p ocg-server
+cargo clippy -p ocg-server --all-targets --all-features -- --deny warnings
+cargo test -p ocg-server
+uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates
+npx markdownlint-cli2 "**/*.md"
+```
+
+Database changes may also require:
+
+```bash
+just db-tests
+just db-contract-tests
+```
+
+Browser-facing changes may require:
+
+```bash
+just frontend-unit-tests
+just e2e-tests
+```
+
+## Pull Request Checklist
+
+Before asking for review:
+
+- Keep the PR focused on one problem.
+- Include screenshots for visible UI changes when helpful.
+- Include migrations, generated mocks, and tests when behavior changes.
+- Mention any operational steps reviewers or deployers need to know.
+- Avoid unrelated formatting or ownership churn.
+- Confirm docs are updated when user-facing behavior changes.
+
+## Safety Rules
+
+Protect community trust:
+
+- Do not expose private member data in public pages, logs, or docs.
+- Do not weaken role checks to make a UI easier to implement.
+- Do not send email from public forms without authentication or spam controls.
+- Do not make project metadata look official unless the maintainers approved it.
+- Do not publish secrets, access tokens, `.env` values, or private credentials.
+
+## Maintenance Runbook
+
+For ongoing project and app health:
+
+- Review stale project listings periodically.
+- Remove or update broken project links.
+- Keep docs aligned with the shipped UI.
+- Watch CI after merging PRs.
+- Prefer small follow-up PRs over large mixed changes.
+- Use the audit logs and dashboard tests to debug permission-sensitive behavior.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,13 @@ issues when something does not work as expected.
 | Understand where to work                   | [Choose Your Dashboard](getting-started/choose-dashboard.md) |
 | Understand role permissions                | [Choose Your Dashboard](getting-started/choose-dashboard.md#fixed-role-model) |
 | Discover groups and attend events          | [Public Site Guide](guides/public-site.md)                   |
+| Participate as a group member              | [Group Members Runbook](guides/group-members-runbook.md)     |
 | Manage events, profile, proposals, and submissions | [User Dashboard Guide](guides/user-dashboard.md)             |
 | Run a alliance                            | [Alliance Dashboard Guide](guides/alliance-dashboard.md)   |
 | Run a group and events                     | [Group Dashboard Guide](guides/group-dashboard.md)           |
+| Lead a group week to week                  | [Group Leads Runbook](guides/group-leads-runbook.md)         |
 | Run the full event lifecycle               | [Event Operations](guides/event-operations.md)               |
+| Add projects or contribute code            | [Project Contributors Runbook](guides/project-contributors-runbook.md) |
 
 ## How OCG Is Organized
 
@@ -51,7 +54,8 @@ it to manage events, organizers, members, sponsors, and communication.
 
 1. [Quickstart](getting-started/quickstart.md)
 2. [Public Site Guide](guides/public-site.md)
-3. [Troubleshooting](support/troubleshooting.md)
+3. [Group Members Runbook](guides/group-members-runbook.md)
+4. [Troubleshooting](support/troubleshooting.md)
 
 ### Speaker path
 
@@ -64,8 +68,15 @@ it to manage events, organizers, members, sponsors, and communication.
 1. [Choose Your Dashboard](getting-started/choose-dashboard.md)
 2. [Alliance Dashboard Guide](guides/alliance-dashboard.md) or
    [Group Dashboard Guide](guides/group-dashboard.md)
-3. [Event Operations Guide](guides/event-operations.md)
-4. [Troubleshooting](support/troubleshooting.md)
+3. [Group Leads Runbook](guides/group-leads-runbook.md)
+4. [Event Operations Guide](guides/event-operations.md)
+5. [Troubleshooting](support/troubleshooting.md)
+
+### Project contributor path
+
+1. [Project Contributors Runbook](guides/project-contributors-runbook.md)
+2. [Development Guide](development.md)
+3. [Troubleshooting](support/troubleshooting.md)
 
 ## If You Get Stuck
 

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -59,7 +59,28 @@
           </div>
         </div>
         {{ header::link(content = "Landscape", href = "/landscape", current_path = path, path = "/landscape") -}}
-        {{ header::link(content = "Resources", href = "/wiki", current_path = path, path = "/wiki") -}}
+        <div class="group relative">
+          {{ header::link(content = "Resources", href = "/wiki", current_path = path, path = "/wiki") -}}
+          <div class="absolute left-1/2 top-full z-[100] hidden w-64 -translate-x-1/2 pt-4 group-hover:block group-focus-within:block">
+            <div class="overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-xl shadow-stone-200/70">
+              <a href="/wiki"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="block px-4 py-3 text-sm font-bold text-stone-900 transition hover:bg-stone-50">
+                Reading brief
+                <span class="mt-1 block text-xs/5 font-medium text-stone-500">Browse GOUP community resources.</span>
+              </a>
+              <a href="https://github.com/sakomws/goup.vc/tree/main/docs"
+                 hx-boost="false"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-primary-700 transition hover:bg-primary-50">
+                Docs
+                <span class="mt-1 block text-xs/5 font-medium text-stone-500">Guides and runbooks for members, leads, and contributors.</span>
+              </a>
+            </div>
+          </div>
+        </div>
         {{ header::link(content = "Stats", href = "/stats", current_path = path, path = "/stats") -}}
         {{ header::link(content = "Sponsor", href = "/sponsor", current_path = path, path = "/sponsor") -}}
       </div>
@@ -238,6 +259,21 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-list bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Resources</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="https://github.com/sakomws/goup.vc/tree/main/docs"
+               hx-boost="false"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-list bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Docs</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>
@@ -447,6 +483,21 @@
               <div class="flex items-center">
                 <div class="svg-icon size-4 icon-search bg-stone-600"></div>
                 <div class="ms-2 text-xs/6">Browse roles</div>
+                <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
+              </div>
+            </a>
+          </li>
+
+          <li class="lg:hidden" role="none">
+            <a href="https://github.com/sakomws/goup.vc/tree/main/docs"
+               hx-boost="false"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
+               role="menuitem">
+              <div class="flex items-center">
+                <div class="svg-icon size-4 icon-list bg-stone-600"></div>
+                <div class="ms-2 text-xs/6">Docs</div>
                 <div class="ms-auto hx-spinner">{{ ui::spinner(size = "size-4") -}}</div>
               </div>
             </a>

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -52,6 +52,10 @@ test.describe("site header", () => {
     await expect(
       navigation.getByRole("link", { name: "Resources" }),
     ).toHaveAttribute("href", "/wiki");
+    await navigation.getByRole("link", { name: "Resources" }).hover();
+    await expect(
+      navigation.getByRole("link", { name: "Docs" }),
+    ).toHaveAttribute("href", "https://github.com/sakomws/goup.vc/tree/main/docs");
     await expect(
       navigation.getByRole("link", { name: "Join GOUP" }),
     ).toHaveAttribute("href", "/log-in/oidc/linkedin");
@@ -61,7 +65,6 @@ test.describe("site header", () => {
     await expect(navigation.getByRole("link", { name: "About" })).toHaveCount(
       0,
     );
-    await expect(navigation.getByRole("link", { name: "Docs" })).toHaveCount(0);
   });
 
   test("guest user menu links point to authentication pages", async ({


### PR DESCRIPTION
## Summary
- Add runbooks for group leads, group members, and project/application contributors.
- Link the new runbooks from the docs sidebar and overview reading paths.

## Test plan
- `npx markdownlint-cli2 "docs/**/*.md"`


Made with [Cursor](https://cursor.com)