### PR TITLE
Add job visibility controls

### DIFF
--- a/database/migrations/functions/jobs/add_job.sql
+++ b/database/migrations/functions/jobs/add_job.sql
@@ -22,6 +22,7 @@ begin
         apply_url,
         location,
         remote,
+        members_only,
         tags
     )
     values (
@@ -34,6 +35,7 @@ begin
         trim(p_input->>'apply_url'),
         nullif(trim(p_input->>'location'), ''),
         coalesce((p_input->>'remote')::boolean, false),
+        coalesce((p_input->>'members_only')::boolean, false),
         coalesce(p_tags, '{}'::text[])
     )
     returning job_id into v_job_id;

--- a/database/migrations/functions/jobs/get_job_by_slug.sql
+++ b/database/migrations/functions/jobs/get_job_by_slug.sql
@@ -8,7 +8,8 @@ begin
     from jobs_job
     where slug = p_slug
     and published = true
-    and expires_at > current_timestamp;
+    and expires_at > current_timestamp
+    and (members_only = false or p_viewer_user_id is not null);
 
     if v_job.job_id is null then
         raise exception 'job not found';

--- a/database/migrations/functions/jobs/job_summary_json.sql
+++ b/database/migrations/functions/jobs/job_summary_json.sql
@@ -9,6 +9,7 @@ returns jsonb language sql stable as $$
         'description', p_job.description,
         'location', p_job.location,
         'remote', p_job.remote,
+        'members_only', p_job.members_only,
         'apply_url', p_job.apply_url,
         'tags', p_job.tags,
         'published', p_job.published,

--- a/database/migrations/functions/jobs/search_jobs.sql
+++ b/database/migrations/functions/jobs/search_jobs.sql
@@ -6,6 +6,7 @@ declare
     v_query text := nullif(trim(p_filters->>'query'), '');
     v_location text := nullif(trim(p_filters->>'location'), '');
     v_remote boolean := (p_filters->>'remote')::boolean;
+    v_include_members_only boolean := coalesce((p_filters->>'include_members_only')::boolean, false);
     v_total int;
     v_jobs jsonb;
 begin
@@ -14,6 +15,7 @@ begin
         from jobs_job j
         where j.published = true
         and j.expires_at > current_timestamp
+        and (v_include_members_only or j.members_only = false)
         and (
             v_query is null
             or j.title ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'

--- a/database/migrations/functions/jobs/update_job.sql
+++ b/database/migrations/functions/jobs/update_job.sql
@@ -9,6 +9,7 @@ begin
         apply_url = trim(p_input->>'apply_url'),
         location = nullif(trim(p_input->>'location'), ''),
         remote = coalesce((p_input->>'remote')::boolean, false),
+        members_only = coalesce((p_input->>'members_only')::boolean, false),
         tags = coalesce(p_tags, '{}'::text[]),
         updated_at = current_timestamp
     where job_id = p_job_id

--- a/database/migrations/schema/0003_jobs.sql
+++ b/database/migrations/schema/0003_jobs.sql
@@ -9,6 +9,7 @@ create table jobs_job (
     apply_url text not null,
     location text,
     remote boolean default false not null,
+    members_only boolean default false not null,
     tags text[] default '{}'::text[] not null,
     published boolean default true not null,
     expires_at timestamp with time zone default current_timestamp + interval '30 days' not null,

--- a/database/migrations/schema/0017_jobs_visibility.sql
+++ b/database/migrations/schema/0017_jobs_visibility.sql
@@ -1,0 +1,5 @@
+alter table jobs_job
+add column if not exists members_only boolean default false not null;
+
+create index if not exists jobs_job_published_members_only_created_at_idx
+on jobs_job (published, members_only, created_at desc);

--- a/ocg-server/src/handlers/site/jobs.rs
+++ b/ocg-server/src/handlers/site/jobs.rs
@@ -3,7 +3,7 @@
 use askama::Template;
 use axum::{
     extract::{Path, RawQuery, State},
-    http::StatusCode,
+    http::{StatusCode, header::CACHE_CONTROL},
     response::{Html, IntoResponse},
 };
 use axum_messages::Messages;
@@ -16,10 +16,9 @@ use crate::{
     db::DynDB,
     handlers::{
         error::HandlerError,
-        extend_public_shared_cache_headers,
         extractors::{CurrentUser, ValidatedForm},
     },
-    router::serde_qs_config,
+    router::{CACHE_CONTROL_PRIVATE_NO_STORE, serde_qs_config},
     templates::{PageId, auth::User, site::jobs},
     types::{
         jobs::{JobApplicationInput, JobsFilters},
@@ -36,7 +35,8 @@ pub(crate) async fn page(
     State(db): State<DynDB>,
     RawQuery(raw_query): RawQuery,
 ) -> Result<impl IntoResponse, HandlerError> {
-    let filters = parse_filters(raw_query.as_deref().unwrap_or_default())?;
+    let mut filters = parse_filters(raw_query.as_deref().unwrap_or_default())?;
+    filters.include_members_only = auth_session.user.is_some();
     let output = db.search_jobs(&filters).await?;
     let site_settings = db.get_site_settings().await?;
     let navigation_links =
@@ -54,7 +54,7 @@ pub(crate) async fn page(
     };
 
     Ok((
-        extend_public_shared_cache_headers(&[])?,
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
         Html(template.render()?),
     ))
 }
@@ -79,7 +79,7 @@ pub(crate) async fn details(
     };
 
     Ok((
-        extend_public_shared_cache_headers(&[])?,
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
         Html(template.render()?),
     ))
 }

--- a/ocg-server/src/templates/filters.rs
+++ b/ocg-server/src/templates/filters.rs
@@ -33,6 +33,7 @@ pub(crate) fn alliance_brand_path<S: AsRef<str>>(
         "alliances",
         "api",
         "dashboard",
+        "docs",
         "event",
         "explore",
         "favicon.ico",
@@ -44,6 +45,7 @@ pub(crate) fn alliance_brand_path<S: AsRef<str>>(
         "profiles",
         "search",
         "sign-up",
+        "sponsor",
         "static",
         "stats",
         "wiki",
@@ -124,6 +126,14 @@ mod tests {
         );
         assert_eq!(
             alliance_brand_path::default().execute("/jobs", values).unwrap(),
+            ""
+        );
+        assert_eq!(
+            alliance_brand_path::default().execute("/sponsor", values).unwrap(),
+            ""
+        );
+        assert_eq!(
+            alliance_brand_path::default().execute("/docs", values).unwrap(),
             ""
         );
         assert_eq!(

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -28,6 +28,10 @@ pub(crate) struct JobsFilters {
     /// Remote-only filter.
     #[garde(skip)]
     pub remote: Option<bool>,
+    /// Whether member-only jobs should be included in search results.
+    #[serde(default, skip_deserializing)]
+    #[garde(skip)]
+    pub include_members_only: bool,
     /// Number of results per page.
     #[serde(default = "dashboard::default_limit")]
     #[garde(range(max = MAX_PAGINATION_LIMIT))]
@@ -46,6 +50,7 @@ impl Default for JobsFilters {
             query: None,
             location: None,
             remote: None,
+            include_members_only: false,
             limit: Some(20),
             offset: Some(0),
         }
@@ -102,6 +107,9 @@ pub(crate) struct JobInput {
     /// Remote-friendly role.
     #[garde(skip)]
     pub remote: Option<bool>,
+    /// Restrict visibility to logged-in GOUP members.
+    #[garde(skip)]
+    pub members_only: Option<bool>,
     /// Job tags, comma-separated.
     #[garde(length(max = MAX_LEN_M))]
     pub tags: Option<String>,
@@ -183,6 +191,9 @@ pub(crate) struct JobSummary {
     pub location: Option<String>,
     /// Remote-friendly role.
     pub remote: bool,
+    /// Whether only logged-in members can view the role.
+    #[serde(default)]
+    pub members_only: bool,
     /// Apply URL.
     pub apply_url: String,
     /// Tags.

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -23,78 +23,77 @@
         </div>
       </div>
     </div>
-    <form class="grid gap-5 p-5 sm:p-6"
+    <form class="inert-form grid gap-6 p-5 sm:p-6 lg:p-8"
           hx-post="/dashboard/alliance/landscape/add"
-          hx-target="#dashboard-content">
-      <div class="grid gap-4 lg:grid-cols-3">
-        <div>
-          <label class="label" for="new-landscape-name">Name</label>
+          hx-target="#dashboard-content"
+          hx-indicator="#dashboard-spinner">
+      <div class="grid gap-5 lg:grid-cols-12">
+        <div class="space-y-2 lg:col-span-6">
+          <label class="form-label" for="new-landscape-name">Name</label>
           <input id="new-landscape-name"
                  name="name"
-                 class="input"
+                 class="input-primary"
                  placeholder="Project or startup name"
                  required />
         </div>
-        <div>
-          <label class="label" for="new-landscape-kind">Kind</label>
-          <select id="new-landscape-kind" name="kind" class="input" required>
+        <div class="space-y-2 lg:col-span-3">
+          <label class="form-label" for="new-landscape-kind">Kind</label>
+          <select id="new-landscape-kind" name="kind" class="select-primary" required>
             <option value="startup">Startup</option>
             <option value="github_project">GitHub project</option>
           </select>
         </div>
-        <div>
-          <label class="label" for="new-landscape-category">Category</label>
+        <div class="space-y-2 lg:col-span-3">
+          <label class="form-label" for="new-landscape-category">Category</label>
           <input id="new-landscape-category"
                  name="category"
-                 class="input"
+                 class="input-primary"
                  placeholder="AI, DevOps, Fintech" />
         </div>
-      </div>
-      <div>
-        <label class="label" for="new-landscape-summary">Summary</label>
-        <input id="new-landscape-summary"
-               name="summary"
-               class="input"
-               placeholder="One sentence explaining the project or startup"
-               required
-               maxlength="500" />
-        <p class="mt-1 text-xs text-stone-500">Shown on public landscape cards. Max 500 characters.</p>
-      </div>
-      <div>
-        <label class="label" for="new-landscape-description">Description</label>
-        <textarea id="new-landscape-description"
-                  name="description"
-                  rows="4"
-                  class="input"
-                  placeholder="What it does, who it is for, and why it belongs in the ecosystem"></textarea>
-      </div>
-      <div class="grid gap-4 lg:grid-cols-4">
-        <div>
-          <label class="label" for="new-landscape-website">Website URL</label>
+        <div class="space-y-2 lg:col-span-12">
+          <label class="form-label" for="new-landscape-summary">Summary</label>
+          <input id="new-landscape-summary"
+                 name="summary"
+                 class="input-primary"
+                 placeholder="One sentence explaining the project or startup"
+                 required
+                 maxlength="500" />
+          <p class="form-legend">Shown on public landscape cards. Max 500 characters.</p>
+        </div>
+        <div class="space-y-2 lg:col-span-12">
+          <label class="form-label" for="new-landscape-description">Description</label>
+          <textarea id="new-landscape-description"
+                    name="description"
+                    rows="6"
+                    class="input-primary min-h-40 resize-y"
+                    placeholder="What it does, who it is for, and why it belongs in the ecosystem"></textarea>
+        </div>
+        <div class="space-y-2 lg:col-span-5">
+          <label class="form-label" for="new-landscape-website">Website URL</label>
           <input id="new-landscape-website"
                  name="website_url"
-                 class="input"
+                 class="input-primary"
                  type="url"
                  placeholder="https://..." />
         </div>
-        <div>
-          <label class="label" for="new-landscape-github">GitHub URL</label>
+        <div class="space-y-2 lg:col-span-4">
+          <label class="form-label" for="new-landscape-github">GitHub URL</label>
           <input id="new-landscape-github"
                  name="github_url"
-                 class="input"
+                 class="input-primary"
                  type="url"
                  placeholder="https://github.com/..." />
         </div>
-        {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", field_class = "lg:col-span-2") -}}
-        <div>
-          <label class="label" for="new-landscape-tags">Tags</label>
+        <div class="space-y-2 lg:col-span-3">
+          <label class="form-label" for="new-landscape-tags">Tags</label>
           <input id="new-landscape-tags"
                  name="tags"
-                 class="input"
+                 class="input-primary"
                  placeholder="Rust, SaaS, OSS" />
         </div>
+        {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", field_class = "lg:col-span-12") -}}
       </div>
-      <div class="flex justify-end border-t border-stone-100 pt-5">
+      <div class="flex flex-col gap-4 rounded-3xl border border-stone-100 bg-stone-50/80 p-4 sm:flex-row sm:items-center sm:justify-end">
         <button class="btn-primary" type="submit">Add entry</button>
       </div>
     </form>
@@ -111,7 +110,7 @@
   <input id="landscape-dashboard-query"
          name="query"
          value="{{ filters.query.as_deref().unwrap_or("") }}"
-         class="input"
+         class="input-primary"
          placeholder="Search landscape entries" />
   <button class="btn-primary" type="submit">Search</button>
 </form>
@@ -154,68 +153,78 @@
           </div>
         </div>
 
-        <form class="grid gap-4"
+        <form class="inert-form grid gap-4"
               hx-put="/dashboard/alliance/landscape/{{ entry.landscape_entry_id }}/update"
-              hx-target="#dashboard-content">
+              hx-target="#dashboard-content"
+              hx-indicator="#dashboard-spinner"
+              {% if !can_manage_landscape -%}
+                inert
+              {% endif -%}>
           <div class="grid gap-4 lg:grid-cols-3">
-            <div>
-              <label class="label" for="landscape-name-{{ entry.landscape_entry_id }}">Name</label>
+            <div class="space-y-2">
+              <label class="form-label"
+                     for="landscape-name-{{ entry.landscape_entry_id }}">Name</label>
               <input id="landscape-name-{{ entry.landscape_entry_id }}"
                      name="name"
-                     class="input"
+                     class="input-primary"
                      value="{{ entry.name }}"
                      required />
             </div>
-            <div>
-              <label class="label" for="landscape-kind-{{ entry.landscape_entry_id }}">Kind</label>
+            <div class="space-y-2">
+              <label class="form-label"
+                     for="landscape-kind-{{ entry.landscape_entry_id }}">Kind</label>
               <select id="landscape-kind-{{ entry.landscape_entry_id }}"
                       name="kind"
-                      class="input"
+                      class="select-primary"
                       required>
                 <option value="startup" {% if entry.kind == "startup" %}selected{% endif %}>Startup</option>
                 <option value="github_project"
                         {% if entry.kind == "github_project" %}selected{% endif %}>GitHub project</option>
               </select>
             </div>
-            <div>
-              <label class="label" for="landscape-category-{{ entry.landscape_entry_id }}">Category</label>
+            <div class="space-y-2">
+              <label class="form-label"
+                     for="landscape-category-{{ entry.landscape_entry_id }}">Category</label>
               <input id="landscape-category-{{ entry.landscape_entry_id }}"
                      name="category"
-                     class="input"
+                     class="input-primary"
                      value="{{ entry.category.as_deref().unwrap_or("") }}" />
             </div>
           </div>
-          <div>
-            <label class="label" for="landscape-summary-{{ entry.landscape_entry_id }}">Summary</label>
+          <div class="space-y-2">
+            <label class="form-label"
+                   for="landscape-summary-{{ entry.landscape_entry_id }}">Summary</label>
             <input id="landscape-summary-{{ entry.landscape_entry_id }}"
                    name="summary"
-                   class="input"
+                   class="input-primary"
                    value="{{ entry.summary }}"
                    required
                    maxlength="500" />
           </div>
-          <div>
-            <label class="label"
+          <div class="space-y-2">
+            <label class="form-label"
                    for="landscape-description-{{ entry.landscape_entry_id }}">Description</label>
             <textarea id="landscape-description-{{ entry.landscape_entry_id }}"
                       name="description"
                       rows="4"
-                      class="input">{{ entry.description.as_deref().unwrap_or("") }}</textarea>
+                      class="input-primary min-h-32 resize-y">{{ entry.description.as_deref().unwrap_or("") }}</textarea>
           </div>
           <div class="grid gap-4 lg:grid-cols-4">
-            <div>
-              <label class="label" for="landscape-website-{{ entry.landscape_entry_id }}">Website URL</label>
+            <div class="space-y-2">
+              <label class="form-label"
+                     for="landscape-website-{{ entry.landscape_entry_id }}">Website URL</label>
               <input id="landscape-website-{{ entry.landscape_entry_id }}"
                      name="website_url"
-                     class="input"
+                     class="input-primary"
                      type="url"
                      value="{{ entry.website_url.as_deref().unwrap_or("") }}" />
             </div>
-            <div>
-              <label class="label" for="landscape-github-{{ entry.landscape_entry_id }}">GitHub URL</label>
+            <div class="space-y-2">
+              <label class="form-label"
+                     for="landscape-github-{{ entry.landscape_entry_id }}">GitHub URL</label>
               <input id="landscape-github-{{ entry.landscape_entry_id }}"
                      name="github_url"
-                     class="input"
+                     class="input-primary"
                      type="url"
                      value="{{ entry.github_url.as_deref().unwrap_or("") }}" />
             </div>
@@ -223,11 +232,12 @@
             {% if let Some(logo_url) = &entry.logo_url %}value="{{ logo_url }}"{% endif %}
           {%- endlet %}
           {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", value_attr = logo_value, field_class = "lg:col-span-2") -}}
-          <div>
-            <label class="label" for="landscape-tags-{{ entry.landscape_entry_id }}">Tags</label>
+          <div class="space-y-2">
+            <label class="form-label"
+                   for="landscape-tags-{{ entry.landscape_entry_id }}">Tags</label>
             <input id="landscape-tags-{{ entry.landscape_entry_id }}"
                    name="tags"
-                   class="input"
+                   class="input-primary"
                    value="{{ entry.tags.join(", ") }}" />
           </div>
         </div>

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -123,6 +123,13 @@
                    class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
             Remote-friendly role
           </label>
+          <label class="inline-flex w-fit items-center gap-3 rounded-2xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm font-medium text-stone-700">
+            <input type="checkbox"
+                   name="members_only"
+                   value="true"
+                   class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
+            Members-only visibility
+          </label>
           <button class="btn-primary" type="submit">Post job</button>
         </div>
       </form>
@@ -151,6 +158,11 @@
                     <span class="rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">Published</span>
                   {% else -%}
                     <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">Draft</span>
+                  {% endif -%}
+                  {% if job.members_only -%}
+                    <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">Members only</span>
+                  {% else -%}
+                    <span class="rounded-full bg-sky-50 px-2.5 py-1 text-xs font-medium text-sky-700">Public</span>
                   {% endif -%}
                 </div>
                 <p class="mt-1 text-sm text-stone-600">
@@ -232,6 +244,14 @@
                        {% if job.remote %}checked{% endif %}
                        class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
                 Remote-friendly role
+              </label>
+              <label class="inline-flex items-center gap-2 text-sm text-stone-700">
+                <input type="checkbox"
+                       name="members_only"
+                       value="true"
+                       {% if job.members_only %}checked{% endif %}
+                       class="rounded border-stone-300 text-primary-600 focus:ring-primary-500" />
+                Members-only visibility
               </label>
               <div class="flex flex-wrap gap-2">
                 <button class="btn-primary" type="submit">Save changes</button>

--- a/ocg-server/templates/site/jobs/details.html
+++ b/ocg-server/templates/site/jobs/details.html
@@ -19,6 +19,9 @@
         {% if job.summary.remote -%}
           <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">Remote</span>
         {% endif -%}
+        {% if job.summary.members_only -%}
+          <span class="rounded-full bg-primary-50 px-3 py-1 text-sm font-medium text-primary-700">Members only</span>
+        {% endif -%}
         {% if let Some(location) = &job.summary.location -%}
           <span class="rounded-full bg-stone-100 px-3 py-1 text-sm font-medium text-stone-700">{{ location }}</span>
         {% endif -%}

--- a/ocg-server/templates/site/jobs/page.html
+++ b/ocg-server/templates/site/jobs/page.html
@@ -79,6 +79,9 @@
                   {% if job.remote -%}
                     <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">Remote</span>
                   {% endif -%}
+                  {% if job.members_only -%}
+                    <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-medium text-primary-700">Members only</span>
+                  {% endif -%}
                   {% if let Some(location) = &job.location -%}
                     <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-medium text-stone-700">{{ location }}</span>
                   {% endif -%}


### PR DESCRIPTION
## Summary
- Add member-only visibility for jobs, including schema/function updates and dashboard/public badges.
- Hide member-only jobs from anonymous listing/detail views while allowing logged-in members to see them.
- Align the landscape dashboard form with the jobs dashboard styling and prevent footer brand links on reserved sponsor/docs routes.

## Test plan
- cargo fmt --all -- --check
- cargo check -p ocg-server
- uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/dashboard/alliance/landscape.html ocg-server/templates/dashboard/jobs.html ocg-server/templates/site/jobs/page.html ocg-server/templates/site/jobs/details.html
- git diff --check
- cargo clippy -p ocg-server --all-targets --all-features -- --deny warnings
- cargo test -p ocg-server handlers::site::home::tests::test_page_success
- cargo test -p ocg-server templates::filters::tests::test_alliance_brand_path


Made with [Cursor](https://cursor.com)