### PR TITLE
Render docs inside GOUP

### DIFF
--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -1,6 +1,7 @@
 //! HTTP handlers for the global site.
 
 pub(crate) mod about;
+pub(crate) mod docs;
 pub(crate) mod explore;
 pub(crate) mod home;
 pub(crate) mod jobs;

--- a/ocg-server/src/handlers/site/docs.rs
+++ b/ocg-server/src/handlers/site/docs.rs
@@ -1,0 +1,195 @@
+//! HTTP handlers for the public docs pages.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    response::{Html, IntoResponse, Response},
+};
+use rust_embed::Embed;
+use tracing::instrument;
+
+use crate::{
+    auth::AuthSession,
+    db::DynDB,
+    handlers::{error::HandlerError, extend_public_shared_cache_headers},
+    templates::{PageId, auth::User, site::docs::Page},
+};
+
+const DOCS_URL: &str = "/docs";
+const INDEX_DOC: &str = "index.md";
+
+#[derive(Embed)]
+#[folder = "../docs"]
+struct DocsAsset;
+
+/// Render the docs index page.
+#[instrument(skip_all, err)]
+pub(crate) async fn index(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    render_doc(auth_session, db, INDEX_DOC.to_string()).await
+}
+
+/// Render a nested docs page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+    Path(doc_path): Path<String>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let Some(doc_path) = normalize_doc_path(&doc_path) else {
+        return Err(HandlerError::NotFound);
+    };
+    render_doc(auth_session, db, doc_path).await
+}
+
+async fn render_doc(
+    auth_session: AuthSession,
+    db: DynDB,
+    doc_path: String,
+) -> Result<Response, HandlerError> {
+    let Some(file) = DocsAsset::get(&doc_path) else {
+        return Err(HandlerError::NotFound);
+    };
+    let markdown = std::str::from_utf8(file.data.as_ref())
+        .map_err(|error| HandlerError::Other(anyhow::anyhow!(error)))?;
+    let content_html = render_markdown(markdown, &doc_path);
+    let path = if doc_path == INDEX_DOC {
+        DOCS_URL.to_string()
+    } else {
+        format!("{DOCS_URL}/{doc_path}")
+    };
+
+    let template = Page {
+        page_id: PageId::SiteDocs,
+        path,
+        site_settings: db.get_site_settings().await?,
+        user: User::from_session(auth_session).await?,
+        content_html,
+    };
+
+    Ok((
+        extend_public_shared_cache_headers(&[])?,
+        Html(template.render()?),
+    )
+        .into_response())
+}
+
+fn render_markdown(markdown: &str, doc_path: &str) -> String {
+    let html = markdown::to_html_with_options(markdown, &markdown::Options::gfm())
+        .unwrap_or_else(|_| "Unable to render docs.".to_string());
+    rewrite_relative_doc_links(&html, doc_path)
+}
+
+fn normalize_doc_path(raw_path: &str) -> Option<String> {
+    let mut path = raw_path.trim_start_matches('/').trim().to_string();
+    if path.is_empty() {
+        return Some(INDEX_DOC.to_string());
+    }
+    if path.contains('\\') || path.split('/').any(|part| matches!(part, "" | "." | "..")) {
+        return None;
+    }
+    if path.ends_with('/') {
+        path.push_str(INDEX_DOC);
+    } else if !path.contains('.') {
+        path.push_str(".md");
+    }
+    path.ends_with(".md").then_some(path)
+}
+
+fn rewrite_relative_doc_links(html: &str, doc_path: &str) -> String {
+    let mut output = String::with_capacity(html.len());
+    let mut remaining = html;
+    while let Some(index) = remaining.find("href=\"") {
+        let (before, after_before) = remaining.split_at(index + 6);
+        output.push_str(before);
+        let Some(end_quote) = after_before.find('"') else {
+            output.push_str(after_before);
+            return output;
+        };
+        let (href, after_href) = after_before.split_at(end_quote);
+        output.push_str(&rewrite_href(href, doc_path));
+        remaining = after_href;
+    }
+    output.push_str(remaining);
+    output
+}
+
+fn rewrite_href(href: &str, doc_path: &str) -> String {
+    if href.starts_with('#')
+        || href.starts_with('/')
+        || href.starts_with("http://")
+        || href.starts_with("https://")
+        || href.starts_with("mailto:")
+        || href.starts_with("tel:")
+    {
+        return href.to_string();
+    }
+
+    let (href_path, fragment) = href
+        .split_once('#')
+        .map_or((href, ""), |(path, fragment)| (path, fragment));
+    let base = doc_path.rsplit_once('/').map_or("", |(base, _)| base);
+    let combined = if base.is_empty() {
+        href_path.to_string()
+    } else {
+        format!("{base}/{href_path}")
+    };
+    let normalized = normalize_relative_path(&combined);
+    if fragment.is_empty() {
+        format!("{DOCS_URL}/{normalized}")
+    } else {
+        format!("{DOCS_URL}/{normalized}#{fragment}")
+    }
+}
+
+fn normalize_relative_path(path: &str) -> String {
+    let mut parts = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            _ => parts.push(part),
+        }
+    }
+    parts.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_doc_path() {
+        assert_eq!(normalize_doc_path(""), Some("index.md".to_string()));
+        assert_eq!(
+            normalize_doc_path("guides/group-leads-runbook"),
+            Some("guides/group-leads-runbook.md".to_string())
+        );
+        assert_eq!(normalize_doc_path("../secret"), None);
+        assert_eq!(normalize_doc_path("guides/../secret"), None);
+    }
+
+    #[test]
+    fn test_rewrite_relative_doc_links() {
+        assert_eq!(
+            rewrite_href("guides/group-leads-runbook.md", INDEX_DOC),
+            "/docs/guides/group-leads-runbook.md"
+        );
+        assert_eq!(
+            rewrite_href("../support/faq.md#help", "guides/group-leads-runbook.md"),
+            "/docs/support/faq.md#help"
+        );
+        assert_eq!(
+            rewrite_href("/dashboard/user", INDEX_DOC),
+            "/dashboard/user"
+        );
+        assert_eq!(
+            rewrite_href("https://example.com/docs", INDEX_DOC),
+            "https://example.com/docs"
+        );
+    }
+}

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -300,6 +300,8 @@ pub(crate) async fn setup(
         .route("/images/{file_name}", get(images::serve))
         .route("/log-in", get(auth::log_in_page))
         .route("/about", get(site::about::page))
+        .route("/docs", get(site::docs::index))
+        .route("/docs/{*doc_path}", get(site::docs::page))
         .route("/jobs", get(site::jobs::page))
         .route("/jobs/{slug}", get(site::jobs::details))
         .route("/landscape", get(site::landscape::page))

--- a/ocg-server/src/templates.rs
+++ b/ocg-server/src/templates.rs
@@ -39,6 +39,7 @@ pub(crate) enum PageId {
     LogIn,
     SignUp,
     SiteAbout,
+    SiteDocs,
     SiteExplore,
     SiteHome,
     SiteJobs,

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -2,6 +2,8 @@
 
 /// Templates for the about page.
 pub(crate) mod about;
+/// Templates for the docs page.
+pub(crate) mod docs;
 /// Templates for the explore page.
 pub(crate) mod explore;
 /// Templates for the home page.

--- a/ocg-server/src/templates/site/docs.rs
+++ b/ocg-server/src/templates/site/docs.rs
@@ -1,0 +1,25 @@
+//! Templates for the public docs page.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    templates::{PageId, auth::User, filters, helpers::user_initials},
+    types::site::SiteSettings,
+};
+
+/// Public docs page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/docs/page.html")]
+pub(crate) struct Page {
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+    /// Rendered Markdown document content.
+    pub content_html: String,
+}

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -70,10 +70,9 @@
                 Reading brief
                 <span class="mt-1 block text-xs/5 font-medium text-stone-500">Browse GOUP community resources.</span>
               </a>
-              <a href="https://github.com/sakomws/goup.vc/tree/main/docs"
-                 hx-boost="false"
-                 target="_blank"
-                 rel="noopener noreferrer"
+              <a href="/docs"
+                 hx-boost="true"
+                 hx-target="body"
                  class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-primary-700 transition hover:bg-primary-50">
                 Docs
                 <span class="mt-1 block text-xs/5 font-medium text-stone-500">Guides and runbooks for members, leads, and contributors.</span>
@@ -106,7 +105,7 @@
           <span class="svg-icon block size-4 bg-current icon-magnifying-glass"></span>
         </button>
       </form>
-      {% if page_id == PageId::SiteHome || page_id == PageId::SiteAbout || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteSearch || page_id == PageId::SiteSponsor || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
+      {% if page_id == PageId::SiteHome || page_id == PageId::SiteAbout || page_id == PageId::SiteDocs || page_id == PageId::SiteExplore || page_id == PageId::SiteJobs || page_id == PageId::SiteLandscape || page_id == PageId::SiteSearch || page_id == PageId::SiteSponsor || page_id == PageId::SiteStats || page_id == PageId::SiteWiki || page_id == PageId::SiteNotFound || page_id == PageId::Alliance || page_id == PageId::Group || page_id == PageId::Event -%}
         <div hx-get="/section/user-menu"
              hx-trigger="load"
              hx-target="this"
@@ -265,10 +264,9 @@
           </li>
 
           <li class="lg:hidden" role="none">
-            <a href="https://github.com/sakomws/goup.vc/tree/main/docs"
-               hx-boost="false"
-               target="_blank"
-               rel="noopener noreferrer"
+            <a href="/docs"
+               hx-boost="true"
+               hx-target="body"
                class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
                role="menuitem">
               <div class="flex items-center">
@@ -489,10 +487,9 @@
           </li>
 
           <li class="lg:hidden" role="none">
-            <a href="https://github.com/sakomws/goup.vc/tree/main/docs"
-               hx-boost="false"
-               target="_blank"
-               rel="noopener noreferrer"
+            <a href="/docs"
+               hx-boost="true"
+               hx-target="body"
                class="inline-block w-full text-start px-4 py-2 hover:bg-stone-100"
                role="menuitem">
               <div class="flex items-center">

--- a/ocg-server/templates/site/docs/page.html
+++ b/ocg-server/templates/site/docs/page.html
@@ -1,0 +1,23 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <div class="relative container mx-auto max-w-7xl px-4 pt-4 xl:pt-7 sm:px-6 lg:px-8">
+    <div class="relative max-w-3xl">
+      <p class="mb-3 text-sm font-semibold uppercase tracking-[0.22em] text-primary-600">Docs</p>
+      <h1 class="mb-4 text-3xl font-semibold tracking-tight text-stone-950 sm:text-4xl lg:text-5xl">
+        GOUP documentation
+      </h1>
+      <p class="max-w-2xl text-base/7 text-stone-600">
+        Guides and runbooks for members, group leads, alliance managers, and project contributors.
+      </p>
+    </div>
+  </div>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-5xl p-4 pb-12 sm:p-6 lg:p-8 lg:pb-16">
+    <article class="markdown rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-8 lg:p-10">
+      {{ content_html|safe }}
+    </article>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/sponsor/page.html
+++ b/ocg-server/templates/site/sponsor/page.html
@@ -84,19 +84,19 @@
                 hx-post="/sponsor"
                 hx-target="body"
                 hx-disabled-elt="button[type='submit']"
-                class="mt-8 grid gap-5">
-            <div class="grid gap-5 sm:grid-cols-2">
-              <div>
+                class="mt-8 grid gap-6">
+            <div class="grid gap-5 lg:grid-cols-12">
+              <div class="space-y-2 lg:col-span-6">
                 <label for="sponsor-name" class="form-label">Name</label>
                 <input id="sponsor-name"
                        name="name"
                        required
                        maxlength="{{ crate::validation::MAX_LEN_S }}"
                        autocomplete="name"
-                       class="input"
+                       class="input-primary"
                        placeholder="Your name" />
               </div>
-              <div>
+              <div class="space-y-2 lg:col-span-6">
                 <label for="sponsor-email" class="form-label">Email</label>
                 <input id="sponsor-email"
                        name="email"
@@ -104,54 +104,49 @@
                        required
                        maxlength="{{ crate::validation::MAX_LEN_M }}"
                        autocomplete="email"
-                       class="input"
+                       class="input-primary"
                        placeholder="you@example.com" />
               </div>
-            </div>
-
-            <div class="grid gap-5 sm:grid-cols-2">
-              <div>
+              <div class="space-y-2 lg:col-span-6">
                 <label for="sponsor-company" class="form-label">Company / organization</label>
                 <input id="sponsor-company"
                        name="company"
                        required
                        maxlength="{{ crate::validation::MAX_LEN_S }}"
                        autocomplete="organization"
-                       class="input"
+                       class="input-primary"
                        placeholder="Company name" />
               </div>
-              <div>
+              <div class="space-y-2 lg:col-span-6">
                 <label for="sponsor-website" class="form-label">Website</label>
                 <input id="sponsor-website"
                        name="website"
                        maxlength="{{ crate::validation::MAX_LEN_M }}"
                        autocomplete="url"
-                       class="input"
+                       class="input-primary"
                        placeholder="https://example.com" />
+              </div>
+              <div class="space-y-2 lg:col-span-12">
+                <label for="sponsor-budget" class="form-label">Budget or sponsorship range</label>
+                <input id="sponsor-budget"
+                       name="budget"
+                       maxlength="{{ crate::validation::MAX_LEN_S }}"
+                       class="input-primary"
+                       placeholder="Optional" />
+              </div>
+              <div class="space-y-2 lg:col-span-12">
+                <label for="sponsor-message" class="form-label">Message</label>
+                <textarea id="sponsor-message"
+                          name="message"
+                          required
+                          maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION }}"
+                          rows="7"
+                          class="input-primary min-h-48 resize-y"
+                          placeholder="What would you like to sponsor? What goals, audience, timing, or package are you considering?"></textarea>
               </div>
             </div>
 
-            <div>
-              <label for="sponsor-budget" class="form-label">Budget or sponsorship range</label>
-              <input id="sponsor-budget"
-                     name="budget"
-                     maxlength="{{ crate::validation::MAX_LEN_S }}"
-                     class="input"
-                     placeholder="Optional" />
-            </div>
-
-            <div>
-              <label for="sponsor-message" class="form-label">Message</label>
-              <textarea id="sponsor-message"
-                        name="message"
-                        required
-                        maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION }}"
-                        rows="7"
-                        class="textarea"
-                        placeholder="What would you like to sponsor? What goals, audience, timing, or package are you considering?"></textarea>
-            </div>
-
-            <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+            <div class="flex flex-col gap-4 rounded-3xl border border-stone-100 bg-stone-50/80 p-4 sm:flex-row sm:items-center sm:justify-end">
               <a href="/"
                  hx-boost="true"
                  hx-target="body"

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -55,7 +55,7 @@ test.describe("site header", () => {
     await navigation.getByRole("link", { name: "Resources" }).hover();
     await expect(
       navigation.getByRole("link", { name: "Docs" }),
-    ).toHaveAttribute("href", "https://github.com/sakomws/goup.vc/tree/main/docs");
+    ).toHaveAttribute("href", "/docs");
     await expect(
       navigation.getByRole("link", { name: "Join GOUP" }),
     ).toHaveAttribute("href", "/log-in/oidc/linkedin");


### PR DESCRIPTION
## Summary
- Render GOUP docs at `/docs` and nested docs paths inside the app instead of sending users to GitHub.
- Update desktop and mobile header Docs links to use the in-app route.
- Refresh the sponsor inquiry form with the newer jobs-style form layout and input styling.

## Test plan
- cargo test -p ocg-server handlers::site::docs::tests
- cargo check -p ocg-server
- uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/site/docs/page.html ocg-server/templates/common/header.html ocg-server/templates/site/sponsor/page.html
- node --check tests/e2e/site/common/header.spec.js


Made with [Cursor](https://cursor.com)