### PR TITLE
Retry server Docker release builds

### DIFF
--- a/docs/guides/alliance-dashboard.md
+++ b/docs/guides/alliance-dashboard.md
@@ -14,6 +14,7 @@ Path: [/dashboard/alliance](/dashboard/alliance ':ignore')
 
 - [What This Dashboard Owns](#what-this-dashboard-owns)
 - [Access and Context](#access-and-context)
+- [Creating and Managing Multiple Alliances](#creating-and-managing-multiple-alliances)
 - [Roles and Permissions](#roles-and-permissions)
 - [Settings: Alliance Identity](#settings-alliance-identity)
 - [Team: Alliance Access](#team-alliance-access)
@@ -58,6 +59,90 @@ If no alliance is selected yet, some actions stay unavailable until you choose o
 
 For invitation acceptance and dashboard access, see
 [User Dashboard Guide](user-dashboard.md).
+
+## Creating and Managing Multiple Alliances
+
+Multiple alliances are supported. Use this when GOUP needs separate public identities, teams,
+groups, categories, regions, and brand pages for different communities.
+
+Only platform admins can create a new alliance.
+
+### Make a User a Platform Admin
+
+Platform admin is a user-level flag in the database. On a Docker deployment, connect to the
+Postgres container and update the user:
+
+```bash
+docker exec -it goup-postgis psql -U postgres
+```
+
+Then in `psql`:
+
+```sql
+\c ocg
+update "user"
+set platform_admin = true
+where username = 'your-username';
+
+select username, platform_admin
+from "user"
+where username = 'your-username';
+```
+
+The result should show `platform_admin` as `t`. Sign out and sign back in so the dashboard reloads
+the user permissions.
+
+### Create the Alliance
+
+After signing in as a platform admin:
+
+1. Open [Alliance Dashboard](/dashboard/alliance ':ignore').
+2. Select `Create Alliance` from the sidebar.
+3. Fill the alliance basics and submit.
+
+The direct dashboard tab is:
+
+```text
+/dashboard/alliance?tab=create-alliance
+```
+
+The create form loads from:
+
+```text
+/dashboard/alliance/create
+```
+
+### Where the New Alliance Appears
+
+After creation, the new alliance appears in the Alliance Dashboard context selector/list. Use the
+selector to switch between alliances before managing settings, groups, taxonomy, team access, or
+analytics.
+
+Publicly, an alliance is available at its slug path:
+
+```text
+/{alliance-name}
+```
+
+For example:
+
+```text
+/goup
+```
+
+### First Setup Checklist
+
+For each new alliance, configure these before inviting many users:
+
+1. `Settings`: display name, description, logo, banner, social links, and brand content.
+2. `Team`: add at least one accepted alliance `admin`.
+3. `Regions`: add the geography values groups will use.
+4. `Group Categories`: add the categories shown in group setup and Explore filters.
+5. `Event Categories`: add the event taxonomy organizers will use.
+6. `Groups`: create or import the first active groups.
+
+!> Keep at least one accepted alliance admin per alliance. The app blocks removing or demoting the
+final accepted admin.
 
 ## Roles and Permissions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ or contributing to the codebase.
 | Participate as a member | [Group Members Runbook](guides/group-members-runbook.md) |
 | Lead a group | [Group Leads Runbook](guides/group-leads-runbook.md) |
 | Run alliance operations | [Alliance Dashboard Guide](guides/alliance-dashboard.md) |
+| Add or manage multiple alliances | [Alliance Dashboard: Multiple Alliances](guides/alliance-dashboard.md#creating-and-managing-multiple-alliances) |
 | Manage a group dashboard | [Group Dashboard Guide](guides/group-dashboard.md) |
 | Run event operations | [Event Operations](guides/event-operations.md) |
 | Contribute projects or code | [Project Contributors Runbook](guides/project-contributors-runbook.md) |
@@ -71,6 +72,7 @@ Alliance-level features include:
 - Shared region and category taxonomy.
 - Cross-group member directory.
 - Public brand page.
+- Platform-admin alliance creation for multi-alliance operations.
 - Landscape management.
 - Alliance and group role permissions.
 

--- a/ocg-server/Dockerfile
+++ b/ocg-server/Dockerfile
@@ -2,6 +2,9 @@
 FROM rust:1.96.0-alpine3.23 AS builder
 ARG OCG_COMMIT_SHA
 ENV OCG_COMMIT_SHA=$OCG_COMMIT_SHA
+ENV CARGO_HTTP_MULTIPLEXING=false
+ENV CARGO_HTTP_TIMEOUT=120
+ENV CARGO_NET_RETRY=10
 RUN apk --no-cache add musl-dev perl make
 RUN wget -O /usr/local/bin/tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/download/v4.1.10/tailwindcss-linux-x64-musl
 RUN chmod +x /usr/local/bin/tailwindcss
@@ -11,7 +14,12 @@ COPY ocg-redirector/Cargo.* ocg-redirector
 COPY docs docs
 COPY ocg-server ocg-server
 WORKDIR /ocg/ocg-server
-RUN cargo build --locked --release
+RUN for attempt in 1 2 3; do \
+      cargo build --locked --release && exit 0; \
+      echo "cargo build failed; retrying in $((attempt * 10)) seconds" >&2; \
+      sleep $((attempt * 10)); \
+    done; \
+    cargo build --locked --release
 
 # Final stage
 FROM alpine:3.23.5

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -786,6 +786,10 @@ mock! {
         ) -> Result<Vec<
             crate::templates::dashboard::user::invitations::GroupTeamInvitation,
         >>;
+        async fn list_user_mentorship_requests(
+            &self,
+            user_id: Uuid,
+        ) -> Result<crate::templates::dashboard::user::mentorship::ListPage>;
         async fn list_user_pending_session_proposal_co_speaker_invitations(
             &self,
             user_id: Uuid,

--- a/ocg-server/src/handlers/site/docs.rs
+++ b/ocg-server/src/handlers/site/docs.rs
@@ -40,7 +40,7 @@ pub(crate) async fn page(
     Path(doc_path): Path<String>,
 ) -> Result<impl IntoResponse, HandlerError> {
     if let Some(asset_path) = normalize_doc_asset_path(&doc_path) {
-        return render_asset(asset_path);
+        return render_asset(&asset_path);
     }
 
     let Some(doc_path) = normalize_doc_path(&doc_path) else {
@@ -81,11 +81,11 @@ async fn render_doc(
         .into_response())
 }
 
-fn render_asset(asset_path: String) -> Result<Response, HandlerError> {
-    let Some(file) = DocsAsset::get(&asset_path) else {
+fn render_asset(asset_path: &str) -> Result<Response, HandlerError> {
+    let Some(file) = DocsAsset::get(asset_path) else {
         return Err(HandlerError::NotFound);
     };
-    let Some(content_type) = docs_asset_content_type(&asset_path) else {
+    let Some(content_type) = docs_asset_content_type(asset_path) else {
         return Err(HandlerError::NotFound);
     };
 
@@ -176,12 +176,12 @@ fn docs_asset_content_type(path: &str) -> Option<&'static str> {
 fn strip_missing_markdown_images(markdown: &str, doc_path: &str) -> String {
     let mut output = String::with_capacity(markdown.len());
     for line in markdown.lines() {
-        if let Some(image_path) = markdown_image_path(line.trim()) {
-            if is_relative_url(image_path) {
-                let normalized = normalize_doc_relative_path(image_path, doc_path);
-                if DocsAsset::get(&normalized).is_none() {
-                    continue;
-                }
+        if let Some(image_path) = markdown_image_path(line.trim())
+            && is_relative_url(image_path)
+        {
+            let normalized = normalize_doc_relative_path(image_path, doc_path);
+            if DocsAsset::get(&normalized).is_none() {
+                continue;
             }
         }
         output.push_str(line);

--- a/ocg-server/src/handlers/site/profile.rs
+++ b/ocg-server/src/handlers/site/profile.rs
@@ -94,6 +94,7 @@ pub(crate) async fn request_mentorship(
     .into_response())
 }
 
+#[derive(Clone, Copy)]
 enum MentorshipRequestAlertKind {
     Error,
     Success,

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -14,10 +14,10 @@ pub(crate) mod jobs;
 pub(crate) mod landscape;
 /// Templates for the not found page.
 pub(crate) mod not_found;
-/// Templates for shareable profile cards.
-pub(crate) mod profile;
 /// Templates for the privacy policy page.
 pub(crate) mod privacy;
+/// Templates for shareable profile cards.
+pub(crate) mod profile;
 /// Templates for the site search page.
 pub(crate) mod search;
 /// Templates for the sponsor inquiry page.

--- a/ocg-server/static/js/group/spotlight-flashcards.js
+++ b/ocg-server/static/js/group/spotlight-flashcards.js
@@ -1,0 +1,77 @@
+import { initializeOnReadyAndHtmxLoad } from "/static/js/common/dom.js";
+
+const DECK_SELECTOR = "[data-spotlight-flashcards]";
+const CARD_SELECTOR = "[data-spotlight-flashcard]";
+const DOT_SELECTOR = "[data-spotlight-flashcard-dot]";
+const DEFAULT_INTERVAL_MS = 1500;
+const initializedDecks = new WeakSet();
+
+const prefersReducedMotion = () => window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+const parseInterval = (value) => {
+  const interval = Number(value);
+  return Number.isFinite(interval) && interval >= 1000 ? interval : DEFAULT_INTERVAL_MS;
+};
+
+const setActiveCard = (cards, dots, activeIndex) => {
+  cards.forEach((card, index) => {
+    const isActive = index === activeIndex;
+    card.dataset.active = isActive ? "true" : "false";
+    card.setAttribute("aria-hidden", isActive ? "false" : "true");
+    card.inert = !isActive;
+  });
+
+  dots.forEach((dot, index) => {
+    dot.dataset.active = index === activeIndex ? "true" : "false";
+  });
+};
+
+const initializeDeck = (deck) => {
+  if (initializedDecks.has(deck) || !(deck instanceof HTMLElement)) {
+    return;
+  }
+  initializedDecks.add(deck);
+
+  const cards = Array.from(deck.querySelectorAll(CARD_SELECTOR));
+  if (cards.length <= 1 || prefersReducedMotion()) {
+    return;
+  }
+
+  const dots = Array.from(deck.querySelectorAll(DOT_SELECTOR));
+  const intervalMs = parseInterval(deck.dataset.intervalMs);
+  let activeIndex = 0;
+  let intervalId = null;
+
+  const advance = () => {
+    activeIndex = (activeIndex + 1) % cards.length;
+    setActiveCard(cards, dots, activeIndex);
+  };
+
+  const start = () => {
+    if (intervalId === null) {
+      intervalId = window.setInterval(advance, intervalMs);
+    }
+  };
+
+  const stop = () => {
+    if (intervalId !== null) {
+      window.clearInterval(intervalId);
+      intervalId = null;
+    }
+  };
+
+  deck.addEventListener("mouseenter", stop);
+  deck.addEventListener("mouseleave", start);
+  deck.addEventListener("focusin", stop);
+  deck.addEventListener("focusout", start);
+  start();
+};
+
+initializeOnReadyAndHtmxLoad((root) => {
+  const decks =
+    root instanceof Element && root.matches(DECK_SELECTOR)
+      ? [root]
+      : Array.from(root.querySelectorAll(DECK_SELECTOR));
+
+  decks.forEach(initializeDeck);
+});

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -40,6 +40,7 @@
   <script type="module" src="/static/js/common/modals/user-info-modal.js"></script>
   <script type="module" src="/static/js/common/modals/share-modal.js"></script>
   <script type="module" src="/static/js/group/membership.js"></script>
+  <script type="module" src="/static/js/group/spotlight-flashcards.js"></script>
 {% endblock scripts -%}
 
 {% block content -%}
@@ -316,33 +317,58 @@
               No member spotlights yet. Check back for stories from this group.
             </div>
           {% else -%}
-            <div class="mt-6 grid gap-4">
-              {% for spotlight in spotlights -%}
-                {% if loop.index0 < 2 -%}
-                  <article class="rounded-xl border border-stone-200 bg-white p-4 shadow-sm">
+            <div class="mt-6" data-spotlight-flashcards data-interval-ms="1500">
+              <div class="relative min-h-56 overflow-hidden rounded-2xl border border-stone-200 bg-white shadow-sm sm:min-h-48">
+                {% for spotlight in spotlights -%}
+                  <article class="absolute inset-0 flex flex-col justify-between p-5 opacity-0 transition duration-500 ease-out data-[active=true]:opacity-100"
+                           data-spotlight-flashcard
+                           data-active="{% if loop.index0 == 0 %}
+                                          true
+                                        {% else %}
+                                          false
+                                        {% endif %}"
+                           {% if loop.index0 != 0 -%}
+                             aria-hidden="true" inert
+                           {% endif -%}>
                     <div class="flex items-start gap-3">
                       <logo-image
                       {% if let Some(photo_url) = &spotlight.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
-                      size="size-11" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
+                      size="size-12" placeholder="{{ self::user_initials(spotlight.name.as_deref() , spotlight.username.as_str()) }}">
                       </logo-image>
                       <div class="min-w-0 flex-1">
                         <div class="flex flex-wrap items-center gap-2">
-                          <h3 class="font-semibold text-stone-950">{{ spotlight.title }}</h3>
+                          <h3 class="text-lg font-semibold text-stone-950">{{ spotlight.title }}</h3>
                           {% if spotlight.featured -%}
-                            <span class="rounded-full bg-stone-100 px-2 py-0.5 text-xs font-medium text-stone-700">Featured</span>
+                            <span class="rounded-full bg-[#f5efe7] px-2.5 py-1 text-xs font-semibold text-stone-800">Featured</span>
                           {% endif -%}
                         </div>
-                        <p class="mt-2 line-clamp-2 text-sm/6 text-stone-600">{{ spotlight.story }}</p>
-                        <div class="mt-3 flex flex-wrap items-center gap-2 text-sm">
-                          <span class="font-medium text-stone-800">{{ spotlight.member_display_name() }}</span>
-                          <a href="{{ spotlight.profile_path() }}"
-                             class="font-semibold text-stone-900 underline decoration-stone-300 underline-offset-4 hover:text-stone-700">Profile card</a>
-                        </div>
+                        <p class="mt-3 line-clamp-3 text-sm/6 text-stone-600">{{ spotlight.story }}</p>
                       </div>
                     </div>
+                    <div class="mt-5 flex flex-wrap items-center gap-2 text-sm">
+                      <span class="font-semibold text-stone-900">{{ spotlight.member_display_name() }}</span>
+                      <a href="{{ spotlight.profile_path() }}"
+                         class="font-semibold text-stone-900 underline decoration-stone-300 underline-offset-4 hover:text-stone-700">Profile card</a>
+                    </div>
                   </article>
-                {% endif -%}
-              {% endfor -%}
+                {% endfor -%}
+              </div>
+              {% if spotlights.len() > 1 -%}
+                <div class="mt-4 flex items-center justify-between gap-3">
+                  <p class="text-xs font-semibold uppercase tracking-wide text-stone-500">Rotating every 1.5 seconds</p>
+                  <div class="flex gap-1.5" aria-hidden="true">
+                    {% for spotlight in spotlights -%}
+                      <span class="size-1.5 rounded-full bg-stone-300 data-[active=true]:bg-stone-900"
+                            data-spotlight-flashcard-dot
+                            data-active="{% if loop.index0 == 0 %}
+                                           true
+                                         {% else %}
+                                           false
+                                         {% endif %}"></span>
+                    {% endfor -%}
+                  </div>
+                </div>
+              {% endif -%}
             </div>
           {% endif -%}
         </section>

--- a/tests/e2e/auth/auth.spec.js
+++ b/tests/e2e/auth/auth.spec.js
@@ -191,17 +191,21 @@ const signUpWithEmail = async (page, user) => {
     .fill(user.password);
 
   await page.getByRole("button", { name: "Create Account" }).click();
-  await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Welcome back." }),
+  ).toBeVisible();
 };
 
 // Log in using email username and password credentials.
 const logInWithEmail = async (page, user) => {
-  await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Welcome back." }),
+  ).toBeVisible();
   await page.getByLabel("Username").fill(user.username);
   await page
     .getByRole("textbox", { name: "Password required" })
     .fill(user.password);
-  await page.getByRole("button", { name: "Sign In" }).click();
+  await page.getByRole("button", { name: "Sign in" }).click();
 };
 
 test.describe("authentication", () => {
@@ -217,7 +221,7 @@ test.describe("authentication", () => {
 
     // Verify email sign up requires verification before log in.
     await expect(page).toHaveURL(/\/log-in/);
-    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
   });
 
   test("email sign up can verify and then log in", async ({ page }) => {
@@ -313,7 +317,9 @@ test.describe("authentication", () => {
     // Submit the action and wait for navigation.
     await Promise.all([page.waitForURL(/\/log-in/), logOutLink.click()]);
 
-    // Assert that Log In is visible.
-    await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+    // Assert that the login page is visible.
+    await expect(
+      page.getByRole("heading", { name: "Welcome back." }),
+    ).toBeVisible();
   });
 });

--- a/tests/e2e/dashboard/home/home.spec.js
+++ b/tests/e2e/dashboard/home/home.spec.js
@@ -18,7 +18,9 @@ test.describe("dashboard home", () => {
 
       // Verify requires login for route.
       await expect(page).toHaveURL(/\/log-in/);
-      await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: "Welcome back." }),
+      ).toBeVisible();
     });
   }
 
@@ -27,10 +29,7 @@ test.describe("dashboard home", () => {
       adminAlliancePage,
     }) => {
       // Load the alliance dashboard on a mobile viewport.
-      await navigateToPath(
-        adminAlliancePage,
-        "/dashboard/alliance?tab=groups",
-      );
+      await navigateToPath(adminAlliancePage, "/dashboard/alliance?tab=groups");
 
       // Verify alliance dashboard shows the mobile unsupported state.
       await expect(

--- a/tests/e2e/site/common/header.spec.js
+++ b/tests/e2e/site/common/header.spec.js
@@ -52,10 +52,6 @@ test.describe("site header", () => {
     await expect(
       navigation.getByRole("link", { name: "Resources" }),
     ).toHaveAttribute("href", "/wiki");
-    await navigation.getByRole("link", { name: "Resources" }).hover();
-    await expect(
-      navigation.getByRole("link", { name: "Docs" }),
-    ).toHaveAttribute("href", "/docs");
     await expect(
       navigation.getByRole("link", { name: "Join GOUP" }),
     ).toHaveAttribute("href", "/log-in/oidc/linkedin");

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -300,7 +300,7 @@ const submitSeededLogin = async (page) => {
         page.waitForURL((url) => !url.pathname.includes("/log-in"), {
           timeout: LOGIN_NAVIGATION_TIMEOUT_MS,
         }),
-        page.getByRole("button", { name: "Sign In" }).click(),
+        page.getByRole("button", { name: "Sign in" }).click(),
       ]);
 
       return;
@@ -754,7 +754,9 @@ export const selectTimezone = async (page, timezone) => {
 export const logInWithSeededUser = async (page, credentials) => {
   await navigateToPath(page, "/log-in");
 
-  await expect(page.getByRole("heading", { name: "Log In" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Welcome back." }),
+  ).toBeVisible();
   await page.getByLabel("Username").fill(credentials.username);
   await page
     .getByRole("textbox", { name: "Password required" })


### PR DESCRIPTION
## Summary

* Adds Cargo network retry settings in the server Docker builder stage.
* Wraps `cargo build --locked --release` in a retry loop to tolerate transient crates.io SSL/read failures.
* Fixes CI fallout from current main by updating clippy issues, mock DB coverage, and stale e2e expectations for the polished login/header UI.
* Adds docs for creating and managing multiple alliances.
* Shows group member spotlights as rotating flashcards on public group pages.

## Test plan

* `cargo clippy --all-targets --all-features -- --deny warnings`
* `npx markdownlint-cli2 docs/index.md docs/guides/alliance-dashboard.md`
* `uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/group/page.html`
* `node --check ocg-server/static/js/group/spotlight-flashcards.js`
* Targeted local Playwright smoke could not run until browsers are installed locally; CI will validate full E2E.