### PR TITLE
Fix cleanup for disabled meeting providers

### DIFF
--- a/ocg-server/src/services/meetings.rs
+++ b/ocg-server/src/services/meetings.rs
@@ -420,13 +420,15 @@ impl MeetingsSyncWorker {
         let provider = self.providers.get(&meeting.provider);
 
         // Determine action and sync with provider
-        let result = match provider {
-            Some(provider) => match meeting.sync_action() {
-                SyncAction::Create => self.create_meeting(&meeting, provider).await,
-                SyncAction::Delete => self.delete_meeting(&meeting, provider).await,
-                SyncAction::Update => self.update_meeting(&meeting, provider).await,
-            },
-            None => Err(SyncError::ProviderNotConfigured(meeting.provider)),
+        let action = meeting.sync_action();
+        let result = match (provider, action) {
+            (Some(provider), SyncAction::Create) => self.create_meeting(&meeting, provider).await,
+            (Some(provider), SyncAction::Delete) => self.delete_meeting(&meeting, provider).await,
+            (Some(provider), SyncAction::Update) => self.update_meeting(&meeting, provider).await,
+            (None, SyncAction::Delete) => self.delete_meeting_locally(&meeting).await,
+            (None, SyncAction::Create | SyncAction::Update) => {
+                Err(SyncError::ProviderNotConfigured(meeting.provider))
+            }
         };
 
         // Handle errors based on type
@@ -500,6 +502,12 @@ impl MeetingsSyncWorker {
         self.db.delete_meeting(meeting).await.map_err(SyncError::Other)?;
 
         Ok(())
+    }
+
+    /// Complete local cleanup for a meeting whose original provider is no longer configured.
+    #[instrument(skip(self, meeting), err)]
+    async fn delete_meeting_locally(&self, meeting: &Meeting) -> Result<(), SyncError> {
+        self.db.delete_meeting(meeting).await.map_err(SyncError::Other)
     }
 
     /// Update a meeting on the provider and mark as synced in database.

--- a/ocg-server/src/services/meetings/tests.rs
+++ b/ocg-server/src/services/meetings/tests.rs
@@ -797,6 +797,38 @@ async fn test_worker_sync_meeting_provider_not_configured_records_error() {
     assert!(synced);
 }
 
+#[tokio::test]
+async fn test_worker_sync_meeting_delete_provider_not_configured_cleans_up_locally() {
+    // Setup identifiers and data structures
+    let meeting_id = Uuid::new_v4();
+    let meeting = Meeting {
+        delete: Some(true),
+        meeting_id: Some(meeting_id),
+        provider: MeetingProvider::Zoom,
+        provider_meeting_id: Some("old-zoom-meeting".to_string()),
+        ..Default::default()
+    };
+
+    // Setup database mock
+    let mut db = MockDB::new();
+    db.expect_claim_meeting_out_of_sync()
+        .times(1)
+        .returning(move || Ok(Some(meeting.clone())));
+    db.expect_delete_meeting()
+        .times(1)
+        .withf(move |m| m.meeting_id == Some(meeting_id))
+        .returning(|_| Ok(()));
+    db.expect_set_meeting_error().never();
+    let db: DynDB = Arc::new(db);
+
+    // Setup worker with no providers configured
+    let mut worker = sample_sync_worker_no_providers(db);
+    let synced = worker.sync_meeting().await.unwrap();
+
+    // Check result matches expectations
+    assert!(synced);
+}
+
 // Helpers.
 
 /// Create a sample auto-end worker with mock dependencies.


### PR DESCRIPTION
## Summary
- Allow meeting delete cleanup to finish when the old provider is no longer configured.
- Keep create/update paths failing for truly unconfigured providers.
- Add a regression test for stale Zoom meeting cleanup after moving off Zoom.

## Test plan
- cargo test -p ocg-server services::meetings::tests
- cargo check -p ocg-server