### PR TITLE
Add group event defaults

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -178,6 +178,7 @@
 {{ template "dashboard-group/unpublish_event_series_events.sql" }}
 {{ template "dashboard-group/update_cfs_submission.sql" }}
 {{ template "dashboard-group/validate_update_event_dates.sql" }} -- Dependency for update_event
+{{ template "dashboard-group/update_group_event_defaults.sql" }}
 {{ template "dashboard-group/update_group_sponsor.sql" }}
 {{ template "dashboard-group/update_group_sponsor_featured.sql" }}
 {{ template "dashboard-group/update_group_team_member_role.sql" }}

--- a/database/migrations/functions/common/get_group_full.sql
+++ b/database/migrations/functions/common/get_group_full.sql
@@ -33,6 +33,7 @@ returns json as $$
         'country_name', g.country_name,
         'description', g.description,
         'description_short', g.description_short,
+        'event_defaults', g.event_defaults,
         'extra_links', g.extra_links,
         'facebook_url', g.facebook_url,
         'flickr_url', g.flickr_url,

--- a/database/migrations/functions/dashboard-common/update_group.sql
+++ b/database/migrations/functions/dashboard-common/update_group.sql
@@ -69,6 +69,10 @@ begin
         country_name = nullif(p_group->>'country_name', ''),
         description = nullif(p_group->>'description', ''),
         description_short = nullif(p_group->>'description_short', ''),
+        event_defaults = case
+            when p_group ? 'event_defaults' then nullif(p_group->'event_defaults', 'null'::jsonb)
+            else event_defaults
+        end,
         extra_links = p_group->'extra_links',
         facebook_url = nullif(p_group->>'facebook_url', ''),
         flickr_url = nullif(p_group->>'flickr_url', ''),

--- a/database/migrations/functions/dashboard-group/update_group_event_defaults.sql
+++ b/database/migrations/functions/dashboard-group/update_group_event_defaults.sql
@@ -1,0 +1,27 @@
+-- update_group_event_defaults stores or clears the default event payload for a group.
+create or replace function update_group_event_defaults(
+    p_actor_user_id uuid,
+    p_group_id uuid,
+    p_event_defaults jsonb
+)
+returns void as $$
+begin
+    update "group"
+    set event_defaults = nullif(p_event_defaults, 'null'::jsonb)
+    where group_id = p_group_id
+      and deleted = false;
+
+    if not found then
+        raise exception 'group not found';
+    end if;
+
+    perform insert_audit_log(
+        'group_event_defaults_updated',
+        p_actor_user_id,
+        'group',
+        p_group_id,
+        null,
+        p_group_id
+    );
+end;
+$$ language plpgsql;

--- a/database/migrations/schema/0023_group_event_defaults.sql
+++ b/database/migrations/schema/0023_group_event_defaults.sql
@@ -1,0 +1,2 @@
+alter table "group"
+    add column event_defaults jsonb;

--- a/database/tests/schema/02_columns.sql
+++ b/database/tests/schema/02_columns.sql
@@ -543,6 +543,7 @@ select columns_are('group', array[
     'deleted_at',
     'description',
     'description_short',
+    'event_defaults',
     'extra_links',
     'facebook_url',
     'flickr_url',

--- a/database/tests/schema/05_functions_and_triggers.sql
+++ b/database/tests/schema/05_functions_and_triggers.sql
@@ -305,6 +305,7 @@ select has_function('update_event_category', array['uuid', 'uuid', 'uuid', 'json
 select has_function('update_event_views', array['jsonb']::name[]);
 select has_function('update_group', array['uuid', 'uuid', 'uuid', 'jsonb']::name[]);
 select has_function('update_group_category', array['uuid', 'uuid', 'uuid', 'jsonb']::name[]);
+select has_function('update_group_event_defaults', array['uuid', 'uuid', 'jsonb']::name[]);
 select has_function('update_group_sponsor', array['uuid', 'uuid', 'uuid', 'jsonb']::name[]);
 select has_function('update_group_sponsor_featured', array['uuid', 'uuid', 'uuid', 'boolean']::name[]);
 select has_function('update_group_team_member_role', array['uuid', 'uuid', 'uuid', 'text']::name[]);

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -212,6 +212,13 @@ pub(crate) trait DBDashboardGroup {
         group_id: Uuid,
     ) -> Result<Option<GroupPaymentRecipient>>;
 
+    /// Retrieves default event payload for a group.
+    async fn get_group_event_defaults(
+        &self,
+        alliance_id: Uuid,
+        group_id: Uuid,
+    ) -> Result<Option<serde_json::Value>>;
+
     /// Gets a single sponsor from the database.
     async fn get_group_sponsor(
         &self,
@@ -474,6 +481,14 @@ pub(crate) trait DBDashboardGroup {
         group_id: Uuid,
         group_store_item_id: Uuid,
         input: &StoreItemInput,
+    ) -> Result<()>;
+
+    /// Updates the default event payload for a group.
+    async fn update_group_event_defaults(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        event_defaults: Option<serde_json::Value>,
     ) -> Result<()>;
 
     /// Updates the featured flag for an existing sponsor.
@@ -916,6 +931,27 @@ where
             "
             select (
                 select payment_recipient
+                from \"group\"
+                where alliance_id = $1::uuid
+                and group_id = $2::uuid
+            )
+            ",
+            &[&alliance_id, &group_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::get_group_event_defaults`]
+    #[instrument(skip(self), err)]
+    async fn get_group_event_defaults(
+        &self,
+        alliance_id: Uuid,
+        group_id: Uuid,
+    ) -> Result<Option<serde_json::Value>> {
+        self.fetch_json_opt(
+            "
+            select (
+                select event_defaults
                 from \"group\"
                 where alliance_id = $1::uuid
                 and group_id = $2::uuid
@@ -1630,6 +1666,21 @@ where
                 &input.featured,
                 &input.active,
             ],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::update_group_event_defaults`]
+    #[instrument(skip(self, event_defaults), err)]
+    async fn update_group_event_defaults(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        event_defaults: Option<serde_json::Value>,
+    ) -> Result<()> {
+        self.execute(
+            "select update_group_event_defaults($1::uuid, $2::uuid, $3::jsonb)",
+            &[&actor_user_id, &group_id, &Json(&event_defaults)],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -482,6 +482,11 @@ mock! {
             alliance_id: Uuid,
             group_id: Uuid,
         ) -> Result<Option<crate::types::payments::GroupPaymentRecipient>>;
+        async fn get_group_event_defaults(
+            &self,
+            alliance_id: Uuid,
+            group_id: Uuid,
+        ) -> Result<Option<serde_json::Value>>;
         async fn get_group_sponsor(
             &self,
             group_id: Uuid,
@@ -680,6 +685,12 @@ mock! {
             group_id: Uuid,
             group_store_item_id: Uuid,
             input: &crate::templates::dashboard::group::store::StoreItemInput,
+        ) -> Result<()>;
+        async fn update_group_event_defaults(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            event_defaults: Option<serde_json::Value>,
         ) -> Result<()>;
         async fn update_group_sponsor_featured(
             &self,

--- a/ocg-server/src/handlers/dashboard/group/events.rs
+++ b/ocg-server/src/handlers/dashboard/group/events.rs
@@ -13,6 +13,7 @@ use axum::{
 use chrono::Utc;
 use garde::Validate;
 use serde::Deserialize;
+use serde_json::{Map, Value};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -76,6 +77,7 @@ pub(crate) async fn add_page(
         can_manage_events,
         categories,
         event_kinds,
+        event_defaults,
         payment_currency_codes,
         payment_recipient,
         session_kinds,
@@ -90,6 +92,7 @@ pub(crate) async fn add_page(
         ),
         db.list_event_categories(alliance_id),
         db.list_event_kinds(),
+        db.get_group_event_defaults(alliance_id, group_id),
         db.list_payment_currency_codes(),
         db.get_group_payment_recipient(alliance_id, group_id),
         db.list_session_kinds(),
@@ -102,6 +105,7 @@ pub(crate) async fn add_page(
         can_manage_events,
         categories,
         event_kinds,
+        event_defaults,
         group_id,
         meetings_enabled,
         payments_enabled: payments_cfg.is_some(),
@@ -239,6 +243,30 @@ pub(crate) async fn details(
     let event = db.get_event_full(alliance_id, group_id, event_id).await?;
 
     Ok(Json(event).into_response())
+}
+
+/// Stores the current event details as the default template for new group events.
+#[instrument(skip_all, err)]
+pub(crate) async fn set_group_defaults(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(event_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let event = db.get_event_full(alliance_id, group_id, event_id).await?;
+    let event_defaults = sanitize_event_defaults(
+        serde_json::to_value(event)
+            .map_err(|err| HandlerError::Deserialization(err.to_string()))?,
+    );
+    db.update_group_event_defaults(user.user_id, group_id, event_defaults)
+        .await?;
+
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "group-event-defaults-updated")],
+    )
+        .into_response())
 }
 
 // Actions handlers.
@@ -644,6 +672,76 @@ fn build_event_payload(event: &Event) -> Result<serde_json::Value, HandlerError>
     event
         .to_db_payload()
         .map_err(|err| HandlerError::Deserialization(err.to_string()))
+}
+
+/// Removes volatile event fields before storing an event as reusable group defaults.
+fn sanitize_event_defaults(event: Value) -> Option<Value> {
+    let Value::Object(mut payload) = event else {
+        return None;
+    };
+
+    for key in [
+        "attendee_count",
+        "canceled",
+        "created_at",
+        "ends_at",
+        "event_id",
+        "event_series_id",
+        "has_related_events",
+        "meeting_error",
+        "meeting_in_sync",
+        "meeting_join_url",
+        "meeting_password",
+        "meeting_recording_raw_urls",
+        "meeting_recording_url",
+        "published",
+        "published_at",
+        "registration_ends_at",
+        "registration_starts_at",
+        "sessions",
+        "slug",
+        "starts_at",
+        "waitlist_count",
+    ] {
+        payload.remove(key);
+    }
+
+    clear_nested_ids(&mut payload);
+
+    Some(Value::Object(payload))
+}
+
+/// Clears IDs from nested collections so defaults create fresh child rows.
+fn clear_nested_ids(payload: &mut Map<String, Value>) {
+    clear_array_object_ids(payload, "discount_codes", &["event_discount_code_id"]);
+    clear_array_object_ids(payload, "ticket_types", &["event_ticket_type_id"]);
+    if let Some(Value::Array(ticket_types)) = payload.get_mut("ticket_types") {
+        for ticket_type in ticket_types {
+            if let Value::Object(ticket_type) = ticket_type {
+                clear_array_object_ids(
+                    ticket_type,
+                    "price_windows",
+                    &["event_ticket_price_window_id"],
+                );
+            }
+        }
+    }
+    clear_array_object_ids(payload, "cfs_labels", &["event_cfs_label_id"]);
+}
+
+/// Removes identifier keys from each object in an array field.
+fn clear_array_object_ids(payload: &mut Map<String, Value>, field: &str, keys: &[&str]) {
+    let Some(Value::Array(items)) = payload.get_mut(field) else {
+        return;
+    };
+
+    for item in items {
+        if let Value::Object(item) = item {
+            for key in keys {
+                item.remove(*key);
+            }
+        }
+    }
 }
 
 /// Builds a `HashMap` of meeting provider to max participants from config.

--- a/ocg-server/src/handlers/dashboard/group/events/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/events/tests.rs
@@ -8,7 +8,7 @@ use axum::{
 };
 use axum_login::tower_sessions::session;
 use chrono::Utc;
-use serde_json::{from_slice, from_value, to_value};
+use serde_json::{from_slice, from_value, json, to_value};
 use tower::ServiceExt;
 use uuid::Uuid;
 
@@ -54,6 +54,52 @@ fn test_build_meetings_max_participants_includes_google_meet() {
         max_participants.get(&MeetingProvider::GoogleMeet),
         Some(&250)
     );
+}
+
+#[test]
+fn test_sanitize_event_defaults_removes_volatile_fields() {
+    let defaults = super::sanitize_event_defaults(json!({
+        "name": "Monthly Meetup",
+        "kind": "hybrid",
+        "category_name": "Meetup",
+        "starts_at": 1_725_000_000,
+        "ends_at": 1_725_003_600,
+        "registration_starts_at": 1_724_000_000,
+        "registration_ends_at": 1_724_900_000,
+        "sessions": [{"session_id": "4ab3cf32-27f4-49dc-93c9-bbbcd753cf34"}],
+        "meeting_requested": true,
+        "meeting_provider": "google_meet",
+        "meeting_join_url": "https://meet.google.com/generated",
+        "meeting_recording_url": "https://youtube.test/generated",
+        "ticket_types": [{
+            "event_ticket_type_id": "89177d43-0e3e-471a-8b99-3a55911ed1f8",
+            "title": "General",
+            "price_windows": [{
+                "event_ticket_price_window_id": "db8d9572-2836-4ca4-b78f-f5772e25d72e",
+                "amount_minor": 1000
+            }]
+        }],
+        "discount_codes": [{
+            "event_discount_code_id": "9cc0aa3d-b108-40ab-b0a9-e117be762af0",
+            "code": "COMMUNITY"
+        }]
+    }))
+    .expect("defaults payload");
+
+    assert_eq!(defaults["name"], json!("Monthly Meetup"));
+    assert_eq!(defaults["meeting_requested"], json!(true));
+    assert_eq!(defaults["meeting_provider"], json!("google_meet"));
+    assert!(defaults.get("starts_at").is_none());
+    assert!(defaults.get("sessions").is_none());
+    assert!(defaults.get("meeting_join_url").is_none());
+    assert!(defaults.get("meeting_recording_url").is_none());
+    assert!(defaults["ticket_types"][0].get("event_ticket_type_id").is_none());
+    assert!(
+        defaults["ticket_types"][0]["price_windows"][0]
+            .get("event_ticket_price_window_id")
+            .is_none()
+    );
+    assert!(defaults["discount_codes"][0].get("event_discount_code_id").is_none());
 }
 
 #[tokio::test]
@@ -113,6 +159,10 @@ async fn test_add_page_success() {
     db.expect_list_event_kinds()
         .times(1)
         .returning(move || Ok(vec![kind.clone()]));
+    db.expect_get_group_event_defaults()
+        .times(1)
+        .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)
+        .returning(move |_, _| Ok(None));
     db.expect_list_payment_currency_codes()
         .times(1)
         .returning(move || Ok(payment_currency_codes.clone()));

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -358,6 +358,10 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             put(dashboard::group::events::publish),
         )
         .route(
+            "/events/{event_id}/defaults",
+            put(dashboard::group::events::set_group_defaults),
+        )
+        .route(
             "/events/{event_id}/submissions/{cfs_submission_id}",
             put(dashboard::group::submissions::update),
         )

--- a/ocg-server/src/templates/dashboard/group/events.rs
+++ b/ocg-server/src/templates/dashboard/group/events.rs
@@ -47,6 +47,8 @@ pub(crate) struct AddPage {
     pub categories: Vec<EventCategory>,
     /// List of available event kinds.
     pub event_kinds: Vec<EventKindSummary>,
+    /// Default event payload configured for this group.
+    pub event_defaults: Option<Value>,
     /// Group identifier.
     pub group_id: Uuid,
     /// Flag indicating if meetings functionality is enabled.

--- a/ocg-server/src/types/group.rs
+++ b/ocg-server/src/types/group.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use serde_with::skip_serializing_none;
 use uuid::Uuid;
 
@@ -153,6 +154,8 @@ pub struct GroupFull {
     pub description: Option<String>,
     /// Short group description text.
     pub description_short: Option<String>,
+    /// Default payload applied when creating new events for this group.
+    pub event_defaults: Option<Value>,
     /// Additional links as key-value pairs.
     pub extra_links: Option<BTreeMap<String, String>>,
     /// Facebook profile URL.

--- a/ocg-server/static/js/common/online-event-details.js
+++ b/ocg-server/static/js/common/online-event-details.js
@@ -819,6 +819,38 @@ export class OnlineEventDetails extends LitWrapper {
   }
 
   /**
+   * Applies automatic meeting fields after clearing generated meeting access details.
+   * @param {object} fields Automatic meeting field values.
+   * @param {string} [fields.meeting_join_instructions] Join instructions.
+   * @param {string} [fields.meeting_provider_id] Provider identifier.
+   * @param {string} [fields.meeting_provider] Provider identifier alias.
+   * @param {Array<string>} [fields.meeting_hosts] Provider host emails.
+   * @param {boolean} [fields.meeting_recording_requested] Whether recordings should be requested.
+   * @param {boolean} [fields.meeting_recording_published] Whether recordings are public.
+   */
+  setAutomaticMeetingDetails({
+    meeting_join_instructions: joinInstructions = "",
+    meeting_provider_id: providerId = "",
+    meeting_provider: providerAlias = "",
+    meeting_hosts: hosts = [],
+    meeting_recording_requested: recordingRequested = true,
+    meeting_recording_published: recordingPublished = false,
+  }) {
+    this._mode = "automatic";
+    this._joinInstructions = joinInstructions || "";
+    this._joinUrl = "";
+    this._recordingUrl = "";
+    this._recordingRequested = recordingRequested !== false;
+    this._recordingPublished = recordingPublished === true;
+    this._createMeeting = true;
+    this._providerId = this._normalizeProviderId(providerId || providerAlias);
+    this._hosts = Array.isArray(hosts) ? [...hosts] : [];
+    this.meetingJoinInstructions = this._joinInstructions;
+    this.meetingJoinUrl = "";
+    this.requestUpdate();
+  }
+
+  /**
    * Renders hidden inputs for form submission.
    * @returns {import('lit').TemplateResult} Hidden input elements
    */

--- a/ocg-server/static/js/dashboard/group/event-add.js
+++ b/ocg-server/static/js/dashboard/group/event-add.js
@@ -7,6 +7,7 @@ import {
   initializeOnReadyAndHtmxLoad,
   setElementHidden,
 } from "/static/js/common/dom.js";
+import { parseJsonAttribute } from "/static/js/common/utils.js";
 import {
   attachEventSaveAfterRequest,
   attachEventSaveBeforeRequestValidation,
@@ -17,6 +18,7 @@ import {
   initializeSharedEventPageControls,
   resolveSharedEventPageControls,
 } from "/static/js/dashboard/group/event-page-shared.js";
+import { applyEventDefaults } from "/static/js/dashboard/group/event-selector/copy.js";
 import { initializeSectionTabs } from "/static/js/dashboard/group/page-form-state.js";
 
 const EVENT_ADD_PAGE_SELECTOR = '[data-event-page="add"]';
@@ -198,6 +200,13 @@ export const initializeEventAddPage = (root = document) => {
     recurrencePatternSelect,
     startsAtInput,
   });
+
+  const eventDefaults = parseJsonAttribute(pageRoot.dataset?.eventDefaults, null);
+  if (eventDefaults && typeof eventDefaults === "object") {
+    void applyEventDefaults(eventDefaults).then(() => {
+      setElementHidden(getElementById(pageRoot, "event-defaults-applied-alert"), false);
+    });
+  }
 
   initializeEventPagePendingChanges({
     pageRoot,

--- a/ocg-server/static/js/dashboard/group/event-selector/copy.js
+++ b/ocg-server/static/js/dashboard/group/event-selector/copy.js
@@ -58,17 +58,34 @@ const copyManualMeetingFields = (details) => {
 };
 
 /**
- * Applies copied event details into the event form.
+ * Copies automatic meeting defaults into the event form.
  * @param {object} details Event details payload
+ */
+const copyAutomaticMeetingFields = (details) => {
+  if (details.meeting_requested !== true) {
+    return;
+  }
+
+  const meetingDetails = getOnlineEventDetails();
+  if (meetingDetails && typeof meetingDetails.setAutomaticMeetingDetails === "function") {
+    meetingDetails.setAutomaticMeetingDetails(details);
+  }
+};
+
+/**
+ * Applies event details into the event form.
+ * @param {object} details Event details payload
+ * @param {object} [options] Apply options
+ * @param {boolean} [options.appendNameSuffix] Whether to append copy suffix to the event name
  * @returns {Promise<void>}
  */
-export const applyCopiedEventDetails = async (details) => {
+const applyEventDetails = async (details, { appendNameSuffix = false } = {}) => {
   if (!details || typeof details !== "object") {
     return;
   }
 
   resetCopiedMeetingFields();
-  setTextValue("name", appendCopySuffix(details.name));
+  setTextValue("name", appendNameSuffix ? appendCopySuffix(details.name) : details.name);
   setTextValue("registration_ends_at", "");
   setTextValue("registration_starts_at", "");
   setCategoryValue(details);
@@ -97,8 +114,27 @@ export const applyCopiedEventDetails = async (details) => {
   setTextValue("venue_address", details.venue_address);
   setTextValue("venue_city", details.venue_city);
   setTextValue("venue_zip_code", details.venue_zip_code);
+  copyAutomaticMeetingFields(details);
   copyManualMeetingFields(details);
   setHosts(details.hosts);
   setSponsors(details.sponsors);
   setSessions([]);
+};
+
+/**
+ * Applies copied event details into the event form.
+ * @param {object} details Event details payload
+ * @returns {Promise<void>}
+ */
+export const applyCopiedEventDetails = async (details) => {
+  await applyEventDetails(details, { appendNameSuffix: true });
+};
+
+/**
+ * Applies group event defaults into the event form.
+ * @param {object} details Group event defaults payload
+ * @returns {Promise<void>}
+ */
+export const applyEventDefaults = async (details) => {
+  await applyEventDetails(details);
 };

--- a/ocg-server/static/js/dashboard/group/event-update.js
+++ b/ocg-server/static/js/dashboard/group/event-update.js
@@ -1,4 +1,4 @@
-import { showConfirmAlert } from "/static/js/common/alerts.js";
+import { bindHtmxResponseAlert, showConfirmAlert } from "/static/js/common/alerts.js";
 import {
   getElementById,
   initializeMatchingRoots,
@@ -58,6 +58,7 @@ export const initializeEventUpdatePage = (root = document) => {
     onlineEventDetails,
   } = controls;
   const updateEventButton = getElementById(pageRoot, "update-event-button");
+  const setEventDefaultsButton = getElementById(pageRoot, "set-event-defaults-button");
   const locationSearchField = queryOne("location-search-field");
   const inertForm = queryOne(".inert-form");
   const capacityInput = getElementById(pageRoot, "capacity");
@@ -187,6 +188,11 @@ export const initializeEventUpdatePage = (root = document) => {
 
   initializeEventPreview({
     pageRoot,
+  });
+
+  bindHtmxResponseAlert(setEventDefaultsButton, {
+    successMessage: "Group event defaults updated.",
+    errorMessage: "Something went wrong updating group event defaults. Please try again later.",
   });
 
   if (!updateEventButton) {

--- a/ocg-server/templates/dashboard/group/events_add.html
+++ b/ocg-server/templates/dashboard/group/events_add.html
@@ -3,7 +3,15 @@
 {% import "macros/form_fields.html" as form_fields -%}
 
 {# Events form -#}
-<div class="space-y-12" data-event-page="add" hx-history="false">
+{% let event_defaults_json -%}{%- if let Some(event_defaults) = &event_defaults -%}{{ event_defaults|json }}{%- else -%}null{%- endif -%}{%- endlet %}
+<div class="space-y-12"
+     data-event-page="add"
+     data-event-defaults="{{ event_defaults_json }}"
+     hx-history="false">
+  <div id="event-defaults-applied-alert"
+       class="hidden rounded-md border border-primary-200 bg-primary-50 px-4 py-3 text-sm text-primary-900">
+    Group event defaults have been applied. You can still edit any field before saving.
+  </div>
   <div class="space-y-3 w-full">
     <div class="flex flex-wrap items-center justify-between gap-3">
       <label for="copy-event-selector" class="form-label m-0">

--- a/ocg-server/templates/dashboard/group/events_update.html
+++ b/ocg-server/templates/dashboard/group/events_update.html
@@ -72,6 +72,21 @@
         </svg>
         <span>Preview</span>
       </button>
+      <button id="set-event-defaults-button"
+              type="button"
+              hx-put="/dashboard/group/events/{{ event.event_id }}/defaults"
+              hx-target="this"
+              hx-swap="none"
+              hx-indicator="#dashboard-spinner"
+              class="group btn-primary-outline btn-mini inline-flex h-7 min-w-28 items-center justify-center gap-2 whitespace-nowrap disabled:cursor-not-allowed disabled:opacity-50"
+              {% if !can_manage_events -%}
+                disabled title="Your role cannot update event defaults."
+              {% else -%}
+                title="Use this event as the default template for new group events."
+              {% endif -%}>
+        <div class="svg-icon size-3 icon-copy shrink-0"></div>
+        <span>Use as defaults</span>
+      </button>
       {% if event_public_url_enabled -%}
         <a id="event-public-page-link"
            href="{{ event_public_url }}"


### PR DESCRIPTION
## Summary
- Add group-level `event_defaults` storage and read/write support.
- Let organizers save an existing event as the group default template from the event update page.
- Apply stored defaults automatically on the new event page while stripping dates, generated meeting links, sessions, and copied child IDs.

## Test plan
- `cargo test -p ocg-server handlers::dashboard::group::events::tests`
- `cargo check -p ocg-server`
