### PR TITLE
Add landscape logo strip

### DIFF
--- a/ocg-server/src/handlers/site/landscape.rs
+++ b/ocg-server/src/handlers/site/landscape.rs
@@ -27,6 +27,7 @@ use crate::{
         },
     },
     types::{landscape::LandscapeFilters, pagination::NavigationLinks},
+    validation::MAX_PAGINATION_LIMIT,
 };
 
 const LANDSCAPE_URL: &str = "/landscape";
@@ -46,8 +47,10 @@ pub(crate) async fn page(
 ) -> Result<impl IntoResponse, HandlerError> {
     let filters = parse_filters(raw_query.as_deref().unwrap_or_default())?;
     let github_filters = github_leaderboard_filters(&filters);
-    let (output, github_output, site_settings) = tokio::try_join!(
+    let logo_filters = logo_strip_filters(&filters);
+    let (output, logo_output, github_output, site_settings) = tokio::try_join!(
         db.search_landscape_entries(&filters),
+        db.search_landscape_entries(&logo_filters),
         db.search_landscape_entries(&github_filters),
         db.get_site_settings()
     )?;
@@ -66,6 +69,7 @@ pub(crate) async fn page(
         user: User::from_session(auth_session).await?,
         filters,
         github_leaderboard,
+        logo_entries: logo_output.entries,
         entries: output.entries,
         total: output.total,
         navigation_links,
@@ -91,6 +95,14 @@ fn github_leaderboard_filters(filters: &LandscapeFilters) -> LandscapeFilters {
     LandscapeFilters {
         kind: Some(GITHUB_PROJECT_KIND.to_string()),
         limit: Some(GITHUB_LEADERBOARD_LIMIT),
+        offset: Some(0),
+        ..filters.clone()
+    }
+}
+
+fn logo_strip_filters(filters: &LandscapeFilters) -> LandscapeFilters {
+    LandscapeFilters {
+        limit: Some(MAX_PAGINATION_LIMIT),
         offset: Some(0),
         ..filters.clone()
     }

--- a/ocg-server/src/templates/site/landscape.rs
+++ b/ocg-server/src/templates/site/landscape.rs
@@ -28,6 +28,8 @@ pub(crate) struct Page {
     pub filters: LandscapeFilters,
     /// GitHub projects ranked by live repository metrics.
     pub github_leaderboard: GitHubLeaderboard,
+    /// Landscape entries shown in the top logo strip.
+    pub logo_entries: Vec<LandscapeEntry>,
     /// Matching landscape entries.
     pub entries: Vec<LandscapeEntry>,
     /// Total matching entries.

--- a/ocg-server/templates/site/landscape/page.html
+++ b/ocg-server/templates/site/landscape/page.html
@@ -3,7 +3,7 @@
 
 {% block jumbotron -%}
   <section class="container mx-auto max-w-7xl px-4 pt-10 pb-8 sm:px-6 lg:px-8 lg:pt-16">
-    <div class="relative max-w-4xl rounded-[2.25rem] border border-stone-200 bg-white/90 p-6 shadow-xl shadow-stone-200/50 backdrop-blur sm:p-8 lg:p-10">
+    <div class="relative w-full rounded-[2.25rem] border border-stone-200 bg-white/90 p-6 shadow-xl shadow-stone-200/50 backdrop-blur sm:p-8 lg:p-10">
       <p class="mb-4 inline-flex rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">Landscape</p>
       <h1 class="mb-4 text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
         Ecosystem landscape
@@ -17,6 +17,76 @@
 
 {% block content -%}
   <div class="container mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8 lg:pb-16">
+    {% if !logo_entries.is_empty() -%}
+      <section class="mb-8 rounded-[2rem] border border-stone-200 bg-white p-4 shadow-sm sm:p-5">
+        <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p class="text-xs font-bold uppercase tracking-[0.2em] text-stone-500">Landscape logos</p>
+            <h2 class="mt-1 text-2xl font-black tracking-tight text-stone-950">Explore the ecosystem</h2>
+          </div>
+          <p class="text-sm font-medium text-stone-500">{{ logo_entries.len() }} shown</p>
+        </div>
+        <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 xl:grid-cols-8">
+          {% for entry in logo_entries -%}
+            {% if let Some(website_url) = &entry.website_url -%}
+              <a class="group flex h-28 flex-col items-center justify-center gap-3 rounded-2xl border border-stone-200 bg-stone-50 p-3 text-center transition hover:-translate-y-0.5 hover:border-stone-950 hover:bg-white hover:shadow-md"
+                 href="{{ website_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 title="{{ entry.name }}"
+                 hx-boost="false">
+                <div class="flex size-14 items-center justify-center overflow-hidden rounded-2xl bg-white ring-1 ring-inset ring-stone-200">
+                  {% if let Some(logo_url) = &entry.logo_url -%}
+                    <img src="{{ logo_url }}"
+                         alt="{{ entry.name }} logo"
+                         class="h-full w-full object-contain p-2"
+                         loading="lazy" />
+                  {% else -%}
+                    <div class="svg-icon size-7 icon-buildings bg-stone-700"></div>
+                  {% endif -%}
+                </div>
+                <span class="line-clamp-2 text-xs font-bold text-stone-700 group-hover:text-stone-950">{{ entry.name }}</span>
+              </a>
+            {% else if let Some(github_url) = &entry.github_url -%}
+              <a class="group flex h-28 flex-col items-center justify-center gap-3 rounded-2xl border border-stone-200 bg-stone-50 p-3 text-center transition hover:-translate-y-0.5 hover:border-stone-950 hover:bg-white hover:shadow-md"
+                 href="{{ github_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 title="{{ entry.name }}"
+                 hx-boost="false">
+                <div class="flex size-14 items-center justify-center overflow-hidden rounded-2xl bg-white ring-1 ring-inset ring-stone-200">
+                  {% if let Some(logo_url) = &entry.logo_url -%}
+                    <img src="{{ logo_url }}"
+                         alt="{{ entry.name }} logo"
+                         class="h-full w-full object-contain p-2"
+                         loading="lazy" />
+                  {% else -%}
+                    <div class="svg-icon size-7 icon-buildings bg-stone-700"></div>
+                  {% endif -%}
+                </div>
+                <span class="line-clamp-2 text-xs font-bold text-stone-700 group-hover:text-stone-950">{{ entry.name }}</span>
+              </a>
+            {% else -%}
+              <div class="flex h-28 flex-col items-center justify-center gap-3 rounded-2xl border border-stone-200 bg-stone-50 p-3 text-center"
+                   title="{{ entry.name }}">
+                <div class="flex size-14 items-center justify-center overflow-hidden rounded-2xl bg-white ring-1 ring-inset ring-stone-200">
+                  {% if let Some(logo_url) = &entry.logo_url -%}
+                    <img src="{{ logo_url }}"
+                         alt="{{ entry.name }} logo"
+                         class="h-full w-full object-contain p-2"
+                         loading="lazy" />
+                  {% else -%}
+                    <div class="svg-icon size-7 icon-buildings bg-stone-700"></div>
+                  {% endif -%}
+                </div>
+                <span class="line-clamp-2 text-xs font-bold text-stone-700">{{ entry.name }}</span>
+              </div>
+            {% endif -%}
+          {% endfor -%}
+        </div>
+      </section>
+    {% endif -%}
+
     <form method="get"
           action="/landscape"
           hx-get="/landscape"


### PR DESCRIPTION
## Summary
- Add a clickable logo grid above the public landscape filters.
- Fetch a capped logo set separately from paginated landscape cards.
- Expand the landscape hero card to the full page container width.

## Test plan
- `cargo check -p ocg-server`


Made with [Cursor](https://cursor.com)