### PR TITLE
Polish public site page layouts

### DIFF
--- a/ocg-server/src/types/group.rs
+++ b/ocg-server/src/types/group.rs
@@ -130,6 +130,7 @@ pub struct GroupFull {
     /// Total number of group members.
     pub members_count: i64,
     /// Whether new members must be approved by group admins.
+    #[serde(default)]
     pub membership_approval_required: bool,
     /// Group name.
     pub name: String,

--- a/ocg-server/src/types/search.rs
+++ b/ocg-server/src/types/search.rs
@@ -1,5 +1,7 @@
 //! Shared search filter types and helpers used across the application.
 
+use std::borrow::Cow;
+
 use anyhow::Result;
 use axum::http::HeaderMap;
 use chrono::{Datelike, Months, NaiveDate, Utc};
@@ -112,7 +114,19 @@ impl SearchEventsFilters {
     /// Create a new `SearchEventsFilters` instance from the raw query string and headers.
     #[instrument(err)]
     pub(crate) fn new(headers: &HeaderMap, raw_query: &str) -> Result<Self, FilterError> {
-        let mut filters: SearchEventsFilters = serde_qs_config().deserialize_str(raw_query)?;
+        let normalized_query = strip_empty_scalar_vec_filters(
+            raw_query,
+            &[
+                "alliance",
+                "event_category",
+                "group",
+                "group_category",
+                "kind",
+                "region",
+            ],
+        );
+        let mut filters: SearchEventsFilters =
+            serde_qs_config().deserialize_str(&normalized_query)?;
         filters.validate()?;
 
         // Clean up entries that are empty strings
@@ -290,7 +304,10 @@ impl SearchGroupsFilters {
     /// provided.
     #[instrument(err)]
     pub(crate) fn new(headers: &HeaderMap, raw_query: &str) -> Result<Self, FilterError> {
-        let mut filters: SearchGroupsFilters = serde_qs_config().deserialize_str(raw_query)?;
+        let normalized_query =
+            strip_empty_scalar_vec_filters(raw_query, &["alliance", "group_category", "region"]);
+        let mut filters: SearchGroupsFilters =
+            serde_qs_config().deserialize_str(&normalized_query)?;
         filters.validate()?;
 
         // Clean up entries that are empty strings
@@ -395,6 +412,35 @@ fn default_offset() -> Option<usize> {
 }
 
 // Helpers.
+
+/// Removes empty scalar values for fields represented as vectors.
+///
+/// Search forms can submit an unselected multi-select as `field=`, while
+/// `serde_qs` expects vector fields to use bracket notation. Dropping only
+/// empty scalar values lets old/shared links keep working without changing
+/// non-empty scalar values into ambiguous one-item arrays.
+fn strip_empty_scalar_vec_filters<'a>(raw_query: &'a str, fields: &[&str]) -> Cow<'a, str> {
+    if raw_query.is_empty() {
+        return Cow::Borrowed(raw_query);
+    }
+
+    let mut changed = false;
+    let parts = raw_query
+        .split('&')
+        .filter(|part| {
+            let (key, value) = part.split_once('=').unwrap_or((*part, ""));
+            let should_strip = value.is_empty() && fields.contains(&key);
+            changed |= should_strip;
+            !should_strip
+        })
+        .collect::<Vec<_>>();
+
+    if changed {
+        Cow::Owned(parts.join("&"))
+    } else {
+        Cow::Borrowed(raw_query)
+    }
+}
 
 /// Extract geolocation coordinates from request headers.
 fn extract_location(headers: &HeaderMap) -> (Option<f64>, Option<f64>) {

--- a/ocg-server/src/types/search/tests.rs
+++ b/ocg-server/src/types/search/tests.rs
@@ -284,6 +284,27 @@ fn test_groups_filters_new_list_cleans_empty_entries() {
 }
 
 #[test]
+fn test_groups_filters_new_list_ignores_empty_scalar_vec_filters() {
+    let raw_query = [
+        "alliance[0]=goup",
+        "group_category=",
+        "region=",
+        "limit=10",
+        "offset=0",
+    ]
+    .join("&");
+
+    let filters =
+        SearchGroupsFilters::new(&HeaderMap::new(), &raw_query).expect("filters to be created");
+
+    assert_eq!(filters.alliance, vec!["goup".to_string()]);
+    assert!(filters.group_category.is_empty());
+    assert!(filters.region.is_empty());
+    assert_eq!(filters.limit, Some(10));
+    assert_eq!(filters.offset, Some(0));
+}
+
+#[test]
 fn test_groups_filters_new_list_extracts_location_from_headers() {
     // Prepare headers and raw query
     let mut headers = HeaderMap::new();

--- a/ocg-server/templates/site/jobs/page.html
+++ b/ocg-server/templates/site/jobs/page.html
@@ -2,17 +2,21 @@
 {% import "macros/pagination.html" as pagination -%}
 
 {% block jumbotron -%}
-  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-8 sm:px-6 lg:px-8 lg:pt-16">
-    <div class="relative max-w-4xl rounded-[2.25rem] border border-stone-200 bg-white/90 p-6 shadow-xl shadow-stone-200/50 backdrop-blur sm:p-8 lg:p-10">
-      <p class="mb-4 inline-flex rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
-        Jobs
-      </p>
-      <h1 class="mb-4 text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
-        Find your next builder role
-      </h1>
-      <p class="max-w-2xl text-base/7 font-medium text-stone-600">
-        Explore opportunities from GOUP members, partners, and open-source teams.
-      </p>
+  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-6 sm:px-6 lg:px-8 lg:pt-16 lg:pb-8">
+    <div class="relative overflow-hidden rounded-[2.25rem] border border-stone-200 bg-white/95 p-6 shadow-xl shadow-stone-200/60 backdrop-blur sm:p-8 lg:p-10">
+      <div class="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-linear-to-l from-stone-50 to-transparent">
+      </div>
+      <div class="relative max-w-4xl">
+        <p class="mb-4 inline-flex rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
+          Jobs
+        </p>
+        <h1 class="mb-4 text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
+          Find your next builder role
+        </h1>
+        <p class="max-w-2xl text-base/7 font-medium text-stone-600">
+          Explore opportunities from GOUP members, partners, and open-source teams.
+        </p>
+      </div>
     </div>
   </section>
 {% endblock jumbotron -%}
@@ -25,23 +29,23 @@
           hx-target="body"
           hx-push-url="true"
           hx-trigger="submit, search from:#jobs-query, change from:#jobs-location, change from:#jobs-remote"
-          class="mb-8 grid gap-3 rounded-[2rem] border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_240px_auto_auto]">
+          class="mb-8 grid gap-3 rounded-[1.75rem] border border-stone-200 bg-white/95 p-3 shadow-lg shadow-stone-200/50 md:grid-cols-[minmax(0,1fr)_240px_auto_auto] md:items-center">
       <label class="sr-only" for="jobs-query">Search jobs</label>
       <input id="jobs-query"
              name="query"
              type="search"
              value="{{ filters.query.as_deref().unwrap_or("") }}"
-             class="input"
+             class="input h-11 border-stone-200 bg-stone-50/70 px-4 focus:bg-white"
              placeholder="Search title, company, summary, or tags" />
 
       <label class="sr-only" for="jobs-location">Location</label>
       <input id="jobs-location"
              name="location"
              value="{{ filters.location.as_deref().unwrap_or("") }}"
-             class="input"
+             class="input h-11 border-stone-200 bg-stone-50/70 px-4 focus:bg-white"
              placeholder="Location" />
 
-      <label class="inline-flex items-center gap-2 rounded-lg border border-stone-200 px-3 text-sm text-stone-700">
+      <label class="inline-flex h-11 items-center justify-center gap-2 rounded-xl border border-stone-200 bg-stone-50/70 px-4 text-sm font-medium text-stone-700">
         <input id="jobs-remote"
                type="checkbox"
                name="remote"
@@ -51,7 +55,7 @@
         Remote
       </label>
 
-      <button class="inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white shadow-sm transition hover:bg-stone-800"
+      <button class="inline-flex h-11 items-center justify-center rounded-full bg-stone-950 px-6 text-sm font-bold text-white shadow-sm transition hover:bg-stone-800"
               type="submit">Search</button>
     </form>
 

--- a/ocg-server/templates/site/landscape/page.html
+++ b/ocg-server/templates/site/landscape/page.html
@@ -2,17 +2,21 @@
 {% import "macros/pagination.html" as pagination -%}
 
 {% block jumbotron -%}
-  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-8 sm:px-6 lg:px-8 lg:pt-16">
-    <div class="relative w-full rounded-[2.25rem] border border-stone-200 bg-white/90 p-6 shadow-xl shadow-stone-200/50 backdrop-blur sm:p-8 lg:p-10">
-      <p class="mb-4 inline-flex rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
-        Landscape
-      </p>
-      <h1 class="mb-4 text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
-        Ecosystem landscape
-      </h1>
-      <p class="max-w-2xl text-base/7 font-medium text-stone-600">
-        Browse alliance startups, GitHub projects, partner communities, investors, podcast leads, tools, and community-built products.
-      </p>
+  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-6 sm:px-6 lg:px-8 lg:pt-16 lg:pb-8">
+    <div class="relative overflow-hidden rounded-[2.25rem] border border-stone-200 bg-white/95 p-6 shadow-xl shadow-stone-200/60 backdrop-blur sm:p-8 lg:p-10">
+      <div class="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-linear-to-l from-stone-50 to-transparent">
+      </div>
+      <div class="relative max-w-4xl">
+        <p class="mb-4 inline-flex rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
+          Landscape
+        </p>
+        <h1 class="mb-4 text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
+          Ecosystem landscape
+        </h1>
+        <p class="max-w-2xl text-base/7 font-medium text-stone-600">
+          Browse alliance startups, GitHub projects, partner communities, investors, podcast leads, tools, and community-built products.
+        </p>
+      </div>
     </div>
   </section>
 {% endblock jumbotron -%}
@@ -95,7 +99,7 @@
           hx-target="body"
           hx-push-url="true"
           hx-trigger="submit, search from:#landscape-query, change from:#landscape-category, change from:#landscape-kind"
-          class="mb-8 grid gap-3 rounded-[2rem] border border-stone-200 bg-white p-4 shadow-sm md:grid-cols-[1fr_180px_220px_auto]">
+          class="mb-8 grid gap-3 rounded-[1.75rem] border border-stone-200 bg-white/95 p-3 shadow-lg shadow-stone-200/50 md:grid-cols-[minmax(0,1fr)_180px_220px_auto] md:items-center">
       <input type="hidden"
              name="github_sort"
              value="{{ filters.github_sort.as_deref().unwrap_or("stars") }}" />
@@ -104,11 +108,13 @@
              name="query"
              type="search"
              value="{{ filters.query.as_deref().unwrap_or("") }}"
-             class="input"
+             class="input h-11 border-stone-200 bg-stone-50/70 px-4 focus:bg-white"
              placeholder="Search startups, GitHub projects, communities, investors, podcasts, categories, or tags" />
 
       <label class="sr-only" for="landscape-kind">Kind</label>
-      <select id="landscape-kind" name="kind" class="input">
+      <select id="landscape-kind"
+              name="kind"
+              class="input h-11 border-stone-200 bg-stone-50/70 px-4 focus:bg-white">
         <option value="">All kinds</option>
         <option value="startup"
                 {% if filters.kind.as_deref() == Some("startup") %}selected{% endif %}>Startups</option>
@@ -126,10 +132,10 @@
       <input id="landscape-category"
              name="category"
              value="{{ filters.category.as_deref().unwrap_or("") }}"
-             class="input"
+             class="input h-11 border-stone-200 bg-stone-50/70 px-4 focus:bg-white"
              placeholder="Category" />
 
-      <button class="inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white shadow-sm transition hover:bg-stone-800"
+      <button class="inline-flex h-11 items-center justify-center rounded-full bg-stone-950 px-6 text-sm font-bold text-white shadow-sm transition hover:bg-stone-800"
               type="submit">Search</button>
     </form>
 

--- a/ocg-server/templates/site/sponsor/page.html
+++ b/ocg-server/templates/site/sponsor/page.html
@@ -3,23 +3,27 @@
 {% block jumbotron -%}
   <div class="relative overflow-hidden">
     <div class="absolute inset-x-0 top-0 h-72 bg-linear-to-b from-white to-transparent"></div>
-    <section class="relative container mx-auto max-w-7xl px-4 pt-10 pb-12 sm:px-6 lg:px-8 lg:pt-16 lg:pb-20">
-      <div class="max-w-4xl rounded-[2.25rem] border border-stone-200 bg-white/90 p-6 shadow-xl shadow-stone-200/50 backdrop-blur sm:p-8 lg:p-10">
-        <div class="mb-6 inline-flex items-center rounded-full border border-stone-200 bg-stone-50 px-4 py-2 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
-          Sponsor GOUP
+    <section class="relative container mx-auto max-w-7xl px-4 pt-10 pb-8 sm:px-6 lg:px-8 lg:pt-16 lg:pb-10">
+      <div class="relative overflow-hidden rounded-[2.25rem] border border-stone-200 bg-white/95 p-6 shadow-xl shadow-stone-200/60 backdrop-blur sm:p-8 lg:p-10">
+        <div class="pointer-events-none absolute inset-y-0 right-0 w-1/2 bg-linear-to-l from-stone-50 to-transparent">
         </div>
-        <h1 class="text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
-          Support the builder community
-        </h1>
-        <p class="mt-6 max-w-2xl text-lg/8 font-medium text-stone-600">
-          Partner with GOUP to support events, hackathons, community programs, and useful
-          opportunities for builders.
-        </p>
-        <p class="mt-4 max-w-2xl text-base/7 text-stone-600">
-          Sponsorship helps keep GOUP warm, practical, and accessible: more rooms for builders to meet,
-          more projects discovered, more jobs shared, and more community programs that turn introductions
-          into real momentum.
-        </p>
+        <div class="relative max-w-4xl">
+          <div class="mb-4 inline-flex items-center rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
+            Sponsor GOUP
+          </div>
+          <h1 class="text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
+            Support the builder community
+          </h1>
+          <p class="mt-4 max-w-2xl text-base/7 font-medium text-stone-600">
+            Partner with GOUP to support events, hackathons, community programs, and useful
+            opportunities for builders.
+          </p>
+          <p class="mt-4 max-w-2xl text-sm/7 text-stone-600 sm:text-base/7">
+            Sponsorship helps keep GOUP warm, practical, and accessible: more rooms for builders to meet,
+            more projects discovered, more jobs shared, and more community programs that turn introductions
+            into real momentum.
+          </p>
+        </div>
       </div>
     </section>
   </div>
@@ -27,8 +31,8 @@
 
 {% block content -%}
   <div class="container mx-auto max-w-7xl px-4 pb-14 sm:px-6 lg:px-8 lg:pb-20">
-    <div class="grid gap-8 lg:grid-cols-[0.8fr_1.2fr]">
-      <aside class="rounded-[2rem] border border-[#d8c7b2] bg-[#f5efe7] p-6 text-stone-950 shadow-sm sm:p-8">
+    <div class="grid gap-6 lg:grid-cols-[0.8fr_1.2fr] lg:items-start">
+      <aside class="rounded-[2rem] border border-[#d8c7b2] bg-[#fffaf5] p-6 text-stone-950 shadow-lg shadow-[#d8c7b2]/30 sm:p-8">
         <h2 class="text-2xl font-black tracking-tight">Why sponsor?</h2>
         <div class="mt-6 grid gap-4 text-sm/6 text-stone-700">
           <p>Reach a trusted network of founders, engineers, researchers, creators, and community leaders.</p>
@@ -37,20 +41,20 @@
             Help members find collaborators, talent, sponsors, and opportunities without turning the community into noise.
           </p>
         </div>
-        <div class="mt-8 rounded-3xl border border-[#d8c7b2] bg-white/60 p-5 text-sm/6 text-stone-700">
+        <div class="mt-8 rounded-3xl border border-[#d8c7b2] bg-white/75 p-5 text-sm/6 text-stone-700">
           <div class="font-bold text-stone-950">Members-first sponsorship</div>
           <p class="mt-2">
             We prioritize useful support: community calls, member spotlights, event support, project visibility,
             and jobs that help builders move forward.
           </p>
         </div>
-        <div class="mt-8 rounded-3xl border border-[#d8c7b2] bg-white/60 p-5 text-sm/6 text-stone-700">
+        <div class="mt-8 rounded-3xl border border-[#d8c7b2] bg-white/75 p-5 text-sm/6 text-stone-700">
           We’ll reply from <a href="mailto:{{ crate::templates::site::sponsor::SPONSOR_INQUIRY_RECIPIENT }}"
     class="font-bold text-stone-950 underline decoration-[#d8c7b2] underline-offset-4">{{ crate::templates::site::sponsor::SPONSOR_INQUIRY_RECIPIENT }}</a>.
         </div>
       </aside>
 
-      <section class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+      <section class="rounded-[2rem] border border-stone-200 bg-white/95 p-6 shadow-lg shadow-stone-200/50 sm:p-8 lg:p-10">
         {% if submitted -%}
           <div class="rounded-3xl border border-stone-200 bg-stone-50 p-6">
             <h2 class="text-2xl font-black tracking-tight text-stone-950">Thanks for reaching out.</h2>
@@ -163,7 +167,7 @@
       </section>
     </div>
 
-    <section class="mt-10 rounded-[2rem] border border-stone-200 bg-white p-6 shadow-sm sm:p-8 lg:p-10">
+    <section class="mt-8 rounded-[2rem] border border-stone-200 bg-white/95 p-6 shadow-lg shadow-stone-200/50 sm:p-8 lg:p-10">
       <div class="max-w-3xl">
         <h2 class="text-2xl font-black tracking-tight text-stone-950">Memberships to suit your organization</h2>
         <p class="mt-3 text-sm/6 text-stone-600">


### PR DESCRIPTION
## Summary
- Align the landscape, jobs, and sponsor page hero sections with a shared full-width card treatment.
- Polish search/filter bars on landscape and jobs with consistent height, spacing, and shadow.
- Bring sponsor content cards closer to the same visual rhythm as the other public pages.

## Test plan
- uvx --from djlint==1.39.2 djlint --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/site/landscape/page.html ocg-server/templates/site/jobs/page.html ocg-server/templates/site/sponsor/page.html
- cargo check --manifest-path ocg-server/Cargo.toml


Made with [Cursor](https://cursor.com)