### PR TITLE
Add group gamification analytics

### DIFF
--- a/database/migrations/functions/dashboard-group/get_group_stats.sql
+++ b/database/migrations/functions/dashboard-group/get_group_stats.sql
@@ -80,6 +80,7 @@ events_with_start as (
 attendees as (
     select
         ea.user_id,
+        ea.checked_in,
         ea.created_at,
         timezone('UTC', date_trunc('month', ea.created_at at time zone 'UTC')) as created_month
     from event_attendee ea
@@ -94,6 +95,151 @@ leaders as (
     from group_team gt
     join filtered_group fg on fg.group_id = gt.group_id
     where gt.accepted = true
+),
+member_profiles as (
+    select
+        u.user_id,
+        u.username,
+        u.name,
+        u.photo_url,
+        m.created_at as joined_at
+    from members m
+    join "user" u using (user_id)
+),
+event_roles as (
+    select eh.user_id, eh.created_at
+    from event_host eh
+    join events e using (event_id)
+
+    union all
+
+    select eo.user_id, e.created_at
+    from event_organizer eo
+    join event e using (event_id)
+    join filtered_group fg on fg.group_id = e.group_id
+    where e.published = true
+        and e.canceled = false
+        and e.deleted = false
+        and e.test_event = false
+
+    union all
+
+    select es.user_id, es.created_at
+    from event_speaker es
+    join events e using (event_id)
+),
+mentorship_received as (
+    select
+        mr.mentor_user_id as user_id,
+        mr.created_at
+    from mentorship_request mr
+    join members m on m.user_id = mr.mentor_user_id
+),
+member_contributions as (
+    select
+        mp.user_id,
+        mp.username,
+        mp.name,
+        mp.photo_url,
+        1 as joined_count,
+        coalesce(attendance.confirmed_count, 0)::int as attendance_count,
+        coalesce(attendance.checked_in_count, 0)::int as checked_in_count,
+        coalesce(roles.role_count, 0)::int as event_role_count,
+        case when l.user_id is null then 0 else 1 end as leader_count,
+        coalesce(mentorship.mentorship_count, 0)::int as mentorship_count,
+        greatest(
+            mp.joined_at,
+            coalesce(attendance.latest_at, mp.joined_at),
+            coalesce(roles.latest_at, mp.joined_at),
+            coalesce(l.created_at, mp.joined_at),
+            coalesce(mentorship.latest_at, mp.joined_at)
+        ) as latest_activity_at,
+        (
+            10
+            + coalesce(attendance.confirmed_count, 0) * 15
+            + coalesce(attendance.checked_in_count, 0) * 25
+            + coalesce(roles.role_count, 0) * 40
+            + case when l.user_id is null then 0 else 50 end
+            + coalesce(mentorship.mentorship_count, 0) * 20
+        )::int as points
+    from member_profiles mp
+    left join (
+        select
+            user_id,
+            count(*)::int as confirmed_count,
+            count(*) filter (where checked_in)::int as checked_in_count,
+            max(created_at) as latest_at
+        from attendees
+        group by user_id
+    ) attendance using (user_id)
+    left join (
+        select
+            user_id,
+            count(*)::int as role_count,
+            max(created_at) as latest_at
+        from event_roles
+        group by user_id
+    ) roles using (user_id)
+    left join leaders l using (user_id)
+    left join (
+        select
+            user_id,
+            count(*)::int as mentorship_count,
+            max(created_at) as latest_at
+        from mentorship_received
+        group by user_id
+    ) mentorship using (user_id)
+),
+gamification_leaderboard as (
+    select
+        row_number() over (order by points desc, latest_activity_at desc, lower(coalesce(name, username)), user_id) as rank,
+        user_id,
+        username,
+        name,
+        photo_url,
+        points,
+        (
+            attendance_count
+            + checked_in_count
+            + event_role_count
+            + leader_count
+            + mentorship_count
+        )::int as recent_activity_count,
+        json_build_object(
+            'joined', joined_count,
+            'attended_events', attendance_count,
+            'checked_in_events', checked_in_count,
+            'event_roles', event_role_count,
+            'leader_roles', leader_count,
+            'mentorship_requests', mentorship_count,
+            'chats', 0,
+            'posts', 0,
+            'polls', 0
+        ) as contributions,
+        array_remove(array[
+            case when joined_count > 0 then 'Getting Started' end,
+            case when attendance_count >= 3 then 'Event Regular' end,
+            case when checked_in_count >= 1 then 'Checked In' end,
+            case when leader_count >= 1 then 'Community Leader' end,
+            case when event_role_count >= 1 then 'Event Builder' end,
+            case when row_number() over (order by points desc, latest_activity_at desc, lower(coalesce(name, username)), user_id) <= 3 then 'Top Contributor' end
+        ], null) as badges
+    from member_contributions
+),
+gamification_rules as (
+    select *
+    from (
+        values
+            ('join_group', 'Join the group', 10, true),
+            ('attend_event', 'Attend or RSVP to an event', 15, true),
+            ('check_in_event', 'Check in at an event', 25, true),
+            ('event_role', 'Host, organize, or speak at an event', 40, true),
+            ('leader_role', 'Serve as an accepted group lead', 50, true),
+            ('mentorship_request', 'Receive a mentorship request', 20, true),
+            ('chat', 'Helpful chats', 5, false),
+            ('post', 'Helpful posts', 10, false),
+            ('poll', 'Poll participation', 5, false)
+    ) as rules(source, label, points, active)
 ),
 event_views_data as (
     select
@@ -375,6 +521,43 @@ select json_strip_nulls(json_build_object(
                 join event_categories ec on ec.event_category_id = stats.event_category_id
             ), '[]'::json)
         )
+    ),
+    'gamification', json_build_object(
+        'total_points', coalesce((select sum(points)::int from member_contributions), 0),
+        'active_contributors', coalesce((select count(*)::int from member_contributions where points > 0), 0),
+        'badges_awarded', coalesce((
+            select sum(cardinality(badges))::int
+            from gamification_leaderboard
+        ), 0),
+        'leaderboard', coalesce((
+            select json_agg(json_build_object(
+                'rank', rank,
+                'user_id', user_id,
+                'username', username,
+                'name', name,
+                'photo_url', photo_url,
+                'points', points,
+                'recent_activity_count', recent_activity_count,
+                'contributions', contributions,
+                'badges', badges
+            ) order by rank)
+            from (
+                select *
+                from gamification_leaderboard
+                order by rank
+                limit 10
+            ) ranked
+        ), '[]'::json),
+        'rules', coalesce((
+            select json_agg(json_build_object(
+                'source', source,
+                'label', label,
+                'points', points,
+                'active', active
+            ) order by active desc, points desc, label)
+            from gamification_rules
+        ), '[]'::json),
+        'future_sources', json_build_array('chats', 'posts', 'polls')
     ),
     'page_views', json_build_object(
         'total_views', (select total_views from page_view_total_counts where scope = 'total'),

--- a/database/tests/functions/dashboard-group/get_group_stats.sql
+++ b/database/tests/functions/dashboard-group/get_group_stats.sql
@@ -3,7 +3,7 @@
 -- ============================================================================
 
 begin;
-select plan(4);
+select plan(6);
 
 -- ============================================================================
 -- VARIABLES
@@ -202,7 +202,7 @@ insert into event_views (day, event_id, total) values
 
 -- Should return complete accurate JSON for seeded group
 select is(
-    get_group_stats(:'allianceID'::uuid, :'group1ID'::uuid)::jsonb - 'reports',
+    get_group_stats(:'allianceID'::uuid, :'group1ID'::uuid)::jsonb - 'reports' - 'gamification',
     (
         with
         -- Define the months used in test data relative to current_timestamp at UTC
@@ -299,7 +299,7 @@ select is(
 
 -- Should return empty stats for unknown group
 select is(
-    get_group_stats(:'allianceID'::uuid, :'nonExistentGroupID'::uuid)::jsonb - 'reports',
+    get_group_stats(:'allianceID'::uuid, :'nonExistentGroupID'::uuid)::jsonb - 'reports' - 'gamification',
     $$
     {
         "members": {
@@ -355,6 +355,20 @@ select is(
     get_group_stats(:'allianceID'::uuid, :'group1ID'::uuid)::jsonb->'reports'->'events'->'by_kind',
     '[["in-person", 1]]'::jsonb,
     'Should include event kind counts in group reports'
+);
+
+-- Should compute gamification points from existing group activity
+select is(
+    (get_group_stats(:'allianceID'::uuid, :'group1ID'::uuid)::jsonb->'gamification'->>'total_points')::int,
+    50,
+    'Should compute gamification points from member and attendee activity'
+);
+
+-- Should include future gamification sources without awarding fake activity
+select is(
+    get_group_stats(:'allianceID'::uuid, :'group1ID'::uuid)::jsonb->'gamification'->'future_sources',
+    '["chats", "posts", "polls"]'::jsonb,
+    'Should include future gamification sources'
 );
 
 -- ============================================================================

--- a/ocg-server/src/db/contract_tests.rs
+++ b/ocg-server/src/db/contract_tests.rs
@@ -570,6 +570,8 @@ async fn db_contracts_get_group_stats_deserializes() -> Result<()> {
         2
     );
     assert_eq!(stats.reports.members.leaders_total, 1);
+    assert!(stats.gamification.total_points >= 10);
+    assert!(!stats.gamification.rules.is_empty());
 
     Ok(())
 }

--- a/ocg-server/src/handlers/dashboard/group/analytics/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/analytics/tests.rs
@@ -135,4 +135,8 @@ async fn test_page_success() {
     assert!(body.contains("Membership growth"));
     assert!(body.contains("Chapter leader growth"));
     assert!(body.contains("Hosted and upcoming"));
+    assert!(body.contains("See gamification in action"));
+    assert!(body.contains("Climb the leaderboard"));
+    assert!(body.contains("Group Leader"));
+    assert!(body.contains("Earn points & badges"));
 }

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -48,7 +48,9 @@ use crate::{
             audit::{AuditLogRecord, AuditLogsOutput},
             group::{
                 analytics::{
-                    GroupAttendeesStats, GroupDashboardStats, GroupEventsStats, GroupMembersStats,
+                    GroupAttendeesStats, GroupDashboardStats, GroupEventsStats,
+                    GroupGamificationContributions, GroupGamificationLeaderboardEntry,
+                    GroupGamificationRule, GroupGamificationStats, GroupMembersStats,
                     GroupPageViewsStats, GroupReports, PageViewsStats as GroupPageViewsEntry,
                 },
                 attendees::Attendee,
@@ -911,6 +913,55 @@ pub(crate) fn sample_group_stats() -> GroupDashboardStats {
             per_month: vec![("2024-01".to_string(), 2)],
             running_total: vec![(1, 2)],
             total: 2,
+        },
+        gamification: GroupGamificationStats {
+            total_points: 120,
+            active_contributors: 1,
+            badges_awarded: 3,
+            leaderboard: vec![GroupGamificationLeaderboardEntry {
+                rank: 1,
+                user_id: Uuid::new_v4().to_string(),
+                username: "leader".to_string(),
+                name: Some("Group Leader".to_string()),
+                photo_url: Some("https://example.test/avatar.png".to_string()),
+                points: 120,
+                recent_activity_count: 4,
+                contributions: GroupGamificationContributions {
+                    joined: 1,
+                    attended_events: 1,
+                    checked_in_events: 0,
+                    event_roles: 1,
+                    leader_roles: 1,
+                    mentorship_requests: 0,
+                    chats: 0,
+                    posts: 0,
+                    polls: 0,
+                },
+                badges: vec![
+                    "Getting Started".to_string(),
+                    "Community Leader".to_string(),
+                    "Top Contributor".to_string(),
+                ],
+            }],
+            rules: vec![
+                GroupGamificationRule {
+                    source: "join_group".to_string(),
+                    label: "Join the group".to_string(),
+                    points: 10,
+                    active: true,
+                },
+                GroupGamificationRule {
+                    source: "post".to_string(),
+                    label: "Helpful posts".to_string(),
+                    points: 10,
+                    active: false,
+                },
+            ],
+            future_sources: vec![
+                "chats".to_string(),
+                "posts".to_string(),
+                "polls".to_string(),
+            ],
         },
         page_views: GroupPageViewsStats {
             events: GroupPageViewsEntry {

--- a/ocg-server/src/templates/dashboard/group/analytics.rs
+++ b/ocg-server/src/templates/dashboard/group/analytics.rs
@@ -25,6 +25,9 @@ pub(crate) struct GroupDashboardStats {
     pub events: GroupEventsStats,
     /// Members statistics.
     pub members: GroupMembersStats,
+    /// Gamification and recognition stats.
+    #[serde(default)]
+    pub gamification: GroupGamificationStats,
     /// Page views statistics.
     pub page_views: GroupPageViewsStats,
     /// Reporting summaries.
@@ -63,6 +66,87 @@ pub(crate) struct GroupMembersStats {
     pub running_total: Vec<(i64, i64)>,
     /// Total members.
     pub total: i64,
+}
+
+/// Gamification stats for member recognition.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct GroupGamificationStats {
+    /// Total points earned by group members.
+    pub total_points: i64,
+    /// Members with any contribution points.
+    pub active_contributors: i64,
+    /// Total badges awarded across leaderboard members.
+    pub badges_awarded: i64,
+    /// Ranked top contributors.
+    #[serde(default)]
+    pub leaderboard: Vec<GroupGamificationLeaderboardEntry>,
+    /// Point rules shown to admins and leads.
+    #[serde(default)]
+    pub rules: Vec<GroupGamificationRule>,
+    /// Future contribution sources that are not active yet.
+    #[serde(default)]
+    pub future_sources: Vec<String>,
+}
+
+/// One member in the gamification leaderboard.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct GroupGamificationLeaderboardEntry {
+    /// Rank within this group.
+    pub rank: i64,
+    /// User identifier.
+    pub user_id: String,
+    /// Username.
+    pub username: String,
+    /// Full name.
+    pub name: Option<String>,
+    /// Avatar URL.
+    pub photo_url: Option<String>,
+    /// Total points.
+    pub points: i64,
+    /// Count of recent contribution signals.
+    pub recent_activity_count: i64,
+    /// Contribution source counts.
+    #[serde(default)]
+    pub contributions: GroupGamificationContributions,
+    /// Badges earned by this member.
+    #[serde(default)]
+    pub badges: Vec<String>,
+}
+
+/// Contribution counts used to compute member points.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct GroupGamificationContributions {
+    /// Group join contribution.
+    pub joined: i64,
+    /// Confirmed event attendances.
+    pub attended_events: i64,
+    /// Checked-in event attendances.
+    pub checked_in_events: i64,
+    /// Host, organizer, or speaker roles.
+    pub event_roles: i64,
+    /// Accepted group lead roles.
+    pub leader_roles: i64,
+    /// Mentorship requests received.
+    pub mentorship_requests: i64,
+    /// Future chat contributions.
+    pub chats: i64,
+    /// Future post contributions.
+    pub posts: i64,
+    /// Future poll contributions.
+    pub polls: i64,
+}
+
+/// A visible point rule for member contributions.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct GroupGamificationRule {
+    /// Stable source key.
+    pub source: String,
+    /// Display label.
+    pub label: String,
+    /// Points awarded for the source.
+    pub points: i64,
+    /// Whether the source is active today.
+    pub active: bool,
 }
 
 /// Group-scoped reporting summaries.

--- a/ocg-server/templates/dashboard/group/analytics.html
+++ b/ocg-server/templates/dashboard/group/analytics.html
@@ -39,6 +39,137 @@ description = "Group statistics and growth trends. Analytics are cached for a fe
 </div>
 {# End summary stat cards #}
 
+{# Gamification section #}
+<div class="mt-10 overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
+  <div class="border-b border-stone-200 bg-stone-50/80 p-6">
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+      <div>
+        <p class="text-xs font-bold uppercase tracking-[0.2em] text-stone-500">Gamification</p>
+        <h2 class="mt-2 text-2xl font-black tracking-tight text-stone-950">See gamification in action</h2>
+        <p class="mt-2 max-w-3xl text-sm/6 text-stone-600">
+          Watch how member activity turns into visible recognition with points, streaks, and badges.
+        </p>
+      </div>
+      <div class="grid grid-cols-3 gap-3 text-center">
+        <div class="rounded-2xl bg-white px-4 py-3 ring-1 ring-stone-200">
+          <div class="text-2xl font-black text-stone-950">{{ stats.gamification.total_points|num_fmt }}</div>
+          <div class="mt-1 text-[0.68rem] font-bold uppercase tracking-wide text-stone-500">Points</div>
+        </div>
+        <div class="rounded-2xl bg-white px-4 py-3 ring-1 ring-stone-200">
+          <div class="text-2xl font-black text-stone-950">{{ stats.gamification.active_contributors|num_fmt }}</div>
+          <div class="mt-1 text-[0.68rem] font-bold uppercase tracking-wide text-stone-500">Contributors</div>
+        </div>
+        <div class="rounded-2xl bg-white px-4 py-3 ring-1 ring-stone-200">
+          <div class="text-2xl font-black text-stone-950">{{ stats.gamification.badges_awarded|num_fmt }}</div>
+          <div class="mt-1 text-[0.68rem] font-bold uppercase tracking-wide text-stone-500">Badges</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid gap-6 p-6 xl:grid-cols-[1.25fr_0.75fr]">
+    <div class="space-y-6">
+      <div class="grid gap-4 md:grid-cols-3">
+        <section class="rounded-2xl border border-stone-200 bg-stone-50 p-5">
+          <h3 class="text-base font-black text-stone-950">More repeat visitors</h3>
+          <p class="mt-2 text-sm/6 text-stone-600">Users come back to climb the ranks.</p>
+        </section>
+        <section class="rounded-2xl border border-stone-200 bg-stone-50 p-5">
+          <h3 class="text-base font-black text-stone-950">More high-quality contributions</h3>
+          <p class="mt-2 text-sm/6 text-stone-600">Leaderboards encourage helpful posts.</p>
+        </section>
+        <section class="rounded-2xl border border-stone-200 bg-stone-50 p-5">
+          <h3 class="text-base font-black text-stone-950">More recognition, less churn</h3>
+          <p class="mt-2 text-sm/6 text-stone-600">Let every member know they matter.</p>
+        </section>
+      </div>
+
+      <section>
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <h3 class="text-lg font-black text-stone-950">Climb the leaderboard</h3>
+            <p class="mt-1 text-sm/6 text-stone-600">Highlight top contributors every day.</p>
+          </div>
+        </div>
+        <div class="mt-4 overflow-hidden rounded-2xl border border-stone-200">
+          {% if stats.gamification.leaderboard.is_empty() -%}
+            <div class="bg-stone-50 px-5 py-8 text-center text-sm text-stone-500">
+              Member recognition will appear once this group has activity.
+            </div>
+          {% else -%}
+            <div class="divide-y divide-stone-200 bg-white">
+              {% for entry in stats.gamification.leaderboard -%}
+                <article class="grid gap-4 p-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:items-center">
+                  <div class="flex items-center gap-3">
+                    <div class="flex size-10 items-center justify-center rounded-full bg-stone-950 text-sm font-black text-white">
+                      #{{ entry.rank }}
+                    </div>
+                    <logo-image
+                    {% if let Some(photo_url) = &entry.photo_url -%} image-url="{{ photo_url }}" {% endif -%}
+                    size="size-12" placeholder="{{ crate::templates::helpers::user_initials(entry.name.as_deref() , entry.username.as_str()) }}">
+                    </logo-image>
+                  </div>
+                  <div class="min-w-0">
+                    <div class="truncate text-sm font-black text-stone-950">
+                      {{ entry.name.as_deref().unwrap_or(&entry.username) }}
+                    </div>
+                    <div class="mt-0.5 truncate text-xs font-medium text-stone-500">@{{ entry.username }}</div>
+                    {% if !entry.badges.is_empty() -%}
+                      <div class="mt-2 flex flex-wrap gap-1.5">
+                        {% for badge in entry.badges -%}
+                          <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-bold text-primary-700 ring-1 ring-inset ring-primary-100">{{ badge }}</span>
+                        {% endfor -%}
+                      </div>
+                    {% endif -%}
+                  </div>
+                  <div class="text-start md:text-end">
+                    <div class="text-2xl font-black text-stone-950">{{ entry.points|num_fmt }}</div>
+                    <div class="text-xs font-bold uppercase tracking-wide text-stone-500">points</div>
+                    <div class="mt-2 text-xs text-stone-500">{{ entry.recent_activity_count|num_fmt }} contribution signals</div>
+                  </div>
+                </article>
+              {% endfor -%}
+            </div>
+          {% endif -%}
+        </div>
+      </section>
+    </div>
+
+    <aside class="space-y-6">
+      <section class="rounded-2xl border border-stone-200 bg-stone-50 p-5">
+        <h3 class="text-lg font-black text-stone-950">Earn points & badges</h3>
+        <p class="mt-2 text-sm/6 text-stone-600">For events, chats, posts, polls & more.</p>
+        <div class="mt-4 space-y-2">
+          {% for rule in stats.gamification.rules -%}
+            <div class="flex items-center justify-between gap-3 rounded-xl bg-white px-3 py-2 ring-1 ring-stone-200">
+              <div class="min-w-0">
+                <div class="truncate text-sm font-semibold text-stone-800">{{ rule.label }}</div>
+                {% if !rule.active -%}
+                  <div class="mt-0.5 text-xs font-medium text-stone-400">Coming soon</div>
+                {% endif -%}
+              </div>
+              <span class="shrink-0 rounded-full bg-stone-950 px-2.5 py-1 text-xs font-black text-white">
+                +{{ rule.points }}
+              </span>
+            </div>
+          {% endfor -%}
+        </div>
+      </section>
+
+      <section class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+        <h3 class="text-lg font-black text-stone-950">Track progress with clarity</h3>
+        <p class="mt-2 text-sm/6 text-stone-600">Clear dashboards track user activity.</p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          {% for source in stats.gamification.future_sources -%}
+            <span class="rounded-full bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-wide text-stone-500 ring-1 ring-inset ring-stone-200">{{ source }}</span>
+          {% endfor -%}
+        </div>
+      </section>
+    </aside>
+  </div>
+</div>
+{# End gamification section #}
+
 {# Reporting overview #}
 <div class="mt-10 space-y-6">
   <div class="grid gap-4 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- Adds computed group gamification stats to the group analytics payload, including points, badges, contributor leaderboard, active rules, and future sources.
- Renders a new Gamification section on the group analytics dashboard using the requested recognition and contribution copy.
- Updates Rust fixtures, handler assertions, contract coverage, and pgTAP expectations for the new payload.

## Test plan
- cargo fmt --package ocg-server
- cargo check --package ocg-server
- cargo test --package ocg-server dashboard::group::analytics
- uvx --python 3.12 djlint==1.39.2 --check --configuration ocg-server/templates/.djlintrc ocg-server/templates/dashboard/group/analytics.html
- git diff --check

Note: local pgTAP was not run because pg_prove is not installed in this shell; database expectations were updated for CI.