### PR TITLE
Fix CoffeeMeet timestamp JSON

### DIFF
--- a/database/migrations/functions/dashboard-group/list_group_coffee_meet_subscribers.sql
+++ b/database/migrations/functions/dashboard-group/list_group_coffee_meet_subscribers.sql
@@ -7,8 +7,8 @@ returns json as $$
         'name', u.name,
         'photo_url', u.photo_url,
         'frequency', cms.frequency,
-        'next_suggestion_at', cms.next_suggestion_at,
-        'last_suggestion_at', cms.last_suggestion_at,
+        'next_suggestion_at', extract(epoch from cms.next_suggestion_at)::bigint,
+        'last_suggestion_at', extract(epoch from cms.last_suggestion_at)::bigint,
         'suggestions_total', coalesce(suggestion_counts.total, 0)
     ) order by cms.next_suggestion_at asc, lower(coalesce(u.name, u.username))), '[]'::json)
     from coffee_meet_subscription cms

--- a/database/migrations/functions/dashboard-user/list_user_coffee_meet_subscriptions.sql
+++ b/database/migrations/functions/dashboard-user/list_user_coffee_meet_subscriptions.sql
@@ -9,8 +9,8 @@ returns json as $$
         'alliance_display_name', a.display_name,
         'frequency', cms.frequency,
         'active', coalesce(cms.active, false),
-        'next_suggestion_at', cms.next_suggestion_at,
-        'last_suggestion_at', cms.last_suggestion_at,
+        'next_suggestion_at', extract(epoch from cms.next_suggestion_at)::bigint,
+        'last_suggestion_at', extract(epoch from cms.last_suggestion_at)::bigint,
         'last_suggested_name', suggested.name,
         'last_suggested_username', suggested.username
     ) order by lower(a.display_name), lower(g.name)), '[]'::json)


### PR DESCRIPTION
## Summary
- Return CoffeeMeet suggestion timestamps as Unix seconds from dashboard JSON functions.
- Keeps the JSON shape aligned with existing Rust `chrono::serde::ts_seconds(_option)` fields and fixes the dashboard deserialization error.

## Test plan
- `cargo test -p ocg-server coffee_meet`
- `git diff --check origin/main...HEAD`

Made with [Cursor](https://cursor.com)