### PR TITLE
Fix CoffeeMeet settings toggles

### DIFF
--- a/ocg-server/static/js/dashboard/group/settings-form.js
+++ b/ocg-server/static/js/dashboard/group/settings-form.js
@@ -1,0 +1,27 @@
+import { getElementById, initializeOnReadyAndHtmxLoad, markDatasetReady } from "/static/js/common/dom.js";
+import { bindBooleanToggle } from "/static/js/dashboard/group/page-form-state.js";
+
+const GROUPS_FORM_ID = "groups-form";
+const COFFEE_MEET_TOGGLE_ID = "toggle_coffee_meet_enabled";
+const COFFEE_MEET_INPUT_ID = "coffee_meet_enabled";
+const GROUP_SETTINGS_BOUND_KEY = "groupSettingsBound";
+
+/**
+ * Initializes group settings form behavior.
+ * @param {Document|Element} root - Root element to search from.
+ * @returns {void}
+ */
+export const initializeGroupSettings = (root = document) => {
+  const groupsForm = getElementById(root, GROUPS_FORM_ID);
+  if (!markDatasetReady(groupsForm, GROUP_SETTINGS_BOUND_KEY)) {
+    return;
+  }
+
+  bindBooleanToggle({
+    toggle: getElementById(root, COFFEE_MEET_TOGGLE_ID),
+    hiddenInput: getElementById(root, COFFEE_MEET_INPUT_ID),
+    syncOnInit: true,
+  });
+};
+
+initializeOnReadyAndHtmxLoad(initializeGroupSettings);

--- a/ocg-server/templates/dashboard/group/home.html
+++ b/ocg-server/templates/dashboard/group/home.html
@@ -26,6 +26,7 @@
   <script type="module" src="/static/js/dashboard/group/event-add.js"></script>
   <script type="module" src="/static/js/dashboard/group/event-update.js"></script>
   <script type="module" src="/static/js/dashboard/group/events-list.js"></script>
+  <script type="module" src="/static/js/dashboard/group/settings-form.js"></script>
   <script type="module" src="/static/js/dashboard/group/members.js"></script>
   <script type="module" src="/static/js/dashboard/group/sponsors.js"></script>
   <script type="module" src="/static/js/dashboard/location-clear.js"></script>

--- a/ocg-server/templates/dashboard/group/settings_update.html
+++ b/ocg-server/templates/dashboard/group/settings_update.html
@@ -6,6 +6,7 @@
 <form id="groups-form"
       hx-put="/dashboard/group/settings/update"
       hx-ext="no-empty-vals"
+      hx-exclude="input[type='checkbox'][name^='toggle_']"
       hx-target="#dashboard-content"
       hx-indicator="#dashboard-spinner, #group-settings-update-spinner"
       hx-disabled-elt="button[type=submit], #cancel-button"
@@ -193,10 +194,14 @@
 
           {# CoffeeMeet availability -#}
           <div class="col-span-full rounded-xl border border-stone-200 bg-stone-50 p-4">
-            <label for="coffee_meet_enabled"
+            <label for="toggle_coffee_meet_enabled"
                    class="flex cursor-pointer items-start gap-3">
               <input id="coffee_meet_enabled"
                      name="coffee_meet_enabled"
+                     type="hidden"
+                     value="{{ group.coffee_meet_enabled }}">
+              <input id="toggle_coffee_meet_enabled"
+                     name="toggle_coffee_meet_enabled"
                      type="checkbox"
                      value="true"
                      class="mt-1 size-4 rounded border-stone-300 text-primary-600 focus:ring-primary-500"

--- a/tests/unit/dashboard/alliance/settings-form.test.js
+++ b/tests/unit/dashboard/alliance/settings-form.test.js
@@ -20,6 +20,18 @@ describe("dashboard alliance settings page", () => {
           type="hidden"
           value="stale"
         >
+        <input
+          id="toggle_coffee_meet_enabled"
+          name="toggle_coffee_meet_enabled"
+          type="checkbox"
+          ${checked ? "checked" : ""}
+        >
+        <input
+          id="coffee_meet_enabled"
+          name="coffee_meet_enabled"
+          type="hidden"
+          value="stale"
+        >
       </form>
     `;
   };
@@ -51,6 +63,27 @@ describe("dashboard alliance settings page", () => {
     toggle.dispatchEvent(new Event("change", { bubbles: true }));
 
     // Verify the hidden input changes once with the toggle state.
+    expect(hiddenInput.value).to.equal("false");
+  });
+
+  it("syncs the CoffeeMeet value on init and change", () => {
+    // Prepare the settings form with CoffeeMeet enabled.
+    renderSettingsForm({ checked: true });
+
+    // Initialize settings behavior.
+    initializeAllianceSettings();
+
+    const toggle = document.getElementById("toggle_coffee_meet_enabled");
+    const hiddenInput = document.getElementById("coffee_meet_enabled");
+
+    // Verify initialization mirrors the toggle state.
+    expect(hiddenInput.value).to.equal("true");
+
+    // Disable the toggle.
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // Verify the submitted hidden field carries the disabled value.
     expect(hiddenInput.value).to.equal("false");
   });
 

--- a/tests/unit/dashboard/group/settings-form.test.js
+++ b/tests/unit/dashboard/group/settings-form.test.js
@@ -1,0 +1,62 @@
+import { expect } from "@open-wc/testing";
+
+import { initializeGroupSettings } from "/static/js/dashboard/group/settings-form.js";
+import { dispatchHtmxLoad } from "/tests/unit/test-utils/htmx.js";
+import { resetDom } from "/tests/unit/test-utils/dom.js";
+
+describe("dashboard group settings page", () => {
+  const renderSettingsForm = ({ checked = false } = {}) => {
+    document.body.innerHTML = `
+      <form id="groups-form">
+        <input
+          id="coffee_meet_enabled"
+          name="coffee_meet_enabled"
+          type="hidden"
+          value="stale"
+        >
+        <input
+          id="toggle_coffee_meet_enabled"
+          name="toggle_coffee_meet_enabled"
+          type="checkbox"
+          ${checked ? "checked" : ""}
+        >
+      </form>
+    `;
+  };
+
+  afterEach(() => {
+    resetDom();
+  });
+
+  it("syncs the CoffeeMeet value on init and change", () => {
+    // Prepare the group settings form with CoffeeMeet enabled.
+    renderSettingsForm({ checked: true });
+
+    // Initialize settings behavior.
+    initializeGroupSettings();
+
+    const toggle = document.getElementById("toggle_coffee_meet_enabled");
+    const hiddenInput = document.getElementById("coffee_meet_enabled");
+
+    // Verify initialization mirrors the toggle state.
+    expect(hiddenInput.value).to.equal("true");
+
+    // Disable the toggle.
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // Verify the submitted hidden field carries the disabled value.
+    expect(hiddenInput.value).to.equal("false");
+  });
+
+  it("initializes swapped settings content on htmx load", () => {
+    // Prepare the group settings form as swapped dashboard content.
+    renderSettingsForm({ checked: true });
+
+    // Dispatch the lifecycle event used by swapped dashboard content.
+    dispatchHtmxLoad(document.body);
+
+    // Verify the hidden input is synced from the swapped form state.
+    expect(document.getElementById("coffee_meet_enabled").value).to.equal("true");
+  });
+});


### PR DESCRIPTION
## Summary
- Ensure the group-level CoffeeMeet setting submits an explicit false value when disabled.
- Add group settings toggle sync wiring loaded by the group dashboard.
- Add unit coverage for alliance and group CoffeeMeet toggle syncing.

## Test plan
- cargo check
- git diff --check
- ReadLints on edited templates/scripts/tests
- Attempted focused JS tests, but Playwright Chromium install hung after download in this environment.


Made with [Cursor](https://cursor.com)