### PR TITLE
Add public dashboard reports

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -103,6 +103,7 @@
 {{ template "dashboard-alliance/list_regions.sql" }}
 {{ template "dashboard-alliance/list_user_alliances.sql" }}
 {{ template "dashboard-alliance/update_alliance.sql" }}
+{{ template "dashboard-alliance/update_alliance_report_public_enabled.sql" }}
 {{ template "dashboard-alliance/update_alliance_team_member_role.sql" }}
 {{ template "dashboard-alliance/update_event_category.sql" }}
 {{ template "dashboard-alliance/update_group_category.sql" }}
@@ -186,6 +187,7 @@
 {{ template "dashboard-group/update_cfs_submission.sql" }}
 {{ template "dashboard-group/validate_update_event_dates.sql" }} -- Dependency for update_event
 {{ template "dashboard-group/update_group_event_defaults.sql" }}
+{{ template "dashboard-group/update_group_report_public_enabled.sql" }}
 {{ template "dashboard-group/update_group_sponsor.sql" }}
 {{ template "dashboard-group/update_group_sponsor_featured.sql" }}
 {{ template "dashboard-group/update_group_team_member_role.sql" }}

--- a/database/migrations/functions/common/get_alliance_full.sql
+++ b/database/migrations/functions/common/get_alliance_full.sql
@@ -30,6 +30,7 @@ returns json as $$
         'new_group_details', new_group_details,
         'og_image_url', og_image_url,
         'photos_urls', photos_urls,
+        'report_public_enabled', report_public_enabled,
         'slack_url', slack_url,
         'twitter_url', twitter_url,
         'website_url', website_url,

--- a/database/migrations/functions/common/get_group_full.sql
+++ b/database/migrations/functions/common/get_group_full.sql
@@ -58,6 +58,7 @@ returns json as $$
                 'order', r.order
             )
         else null end,
+        'report_public_enabled', g.report_public_enabled,
         'slack_url', g.slack_url,
         'slug_pretty', g.slug_pretty,
         'state', g.state,

--- a/database/migrations/functions/dashboard-alliance/update_alliance_report_public_enabled.sql
+++ b/database/migrations/functions/dashboard-alliance/update_alliance_report_public_enabled.sql
@@ -1,0 +1,24 @@
+-- Updates whether an alliance report is visible publicly.
+create or replace function update_alliance_report_public_enabled(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_enabled boolean
+) returns void as $$
+begin
+    update alliance
+    set report_public_enabled = p_enabled
+    where alliance_id = p_alliance_id;
+
+    if not found then
+        raise exception 'alliance not found';
+    end if;
+
+    perform insert_audit_log(
+        case when p_enabled then 'alliance_report_published' else 'alliance_report_unpublished' end,
+        p_actor_user_id,
+        'alliance',
+        p_alliance_id,
+        p_alliance_id
+    );
+end;
+$$ language plpgsql;

--- a/database/migrations/functions/dashboard-group/update_group_report_public_enabled.sql
+++ b/database/migrations/functions/dashboard-group/update_group_report_public_enabled.sql
@@ -1,0 +1,28 @@
+-- Updates whether a group report is visible publicly.
+create or replace function update_group_report_public_enabled(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_group_id uuid,
+    p_enabled boolean
+) returns void as $$
+begin
+    update "group"
+    set report_public_enabled = p_enabled
+    where group_id = p_group_id
+    and alliance_id = p_alliance_id
+    and deleted = false;
+
+    if not found then
+        raise exception 'group not found';
+    end if;
+
+    perform insert_audit_log(
+        case when p_enabled then 'group_report_published' else 'group_report_unpublished' end,
+        p_actor_user_id,
+        'group',
+        p_group_id,
+        p_alliance_id,
+        p_group_id
+    );
+end;
+$$ language plpgsql;

--- a/database/migrations/schema/0036_public_reports.sql
+++ b/database/migrations/schema/0036_public_reports.sql
@@ -1,0 +1,5 @@
+alter table alliance
+add column if not exists report_public_enabled boolean default false not null;
+
+alter table "group"
+add column if not exists report_public_enabled boolean default false not null;

--- a/ocg-server/src/db/dashboard/alliance.rs
+++ b/ocg-server/src/db/dashboard/alliance.rs
@@ -168,6 +168,14 @@ pub(crate) trait DBDashboardAlliance {
         alliance: &AllianceUpdate,
     ) -> Result<()>;
 
+    /// Updates whether a alliance report is public.
+    async fn update_alliance_report_public_enabled(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        enabled: bool,
+    ) -> Result<()>;
+
     /// Updates a alliance team member role.
     async fn update_alliance_team_member_role(
         &self,
@@ -503,6 +511,21 @@ where
         self.execute(
             "select update_alliance($1::uuid, $2::uuid, $3::jsonb)",
             &[&actor_user_id, &alliance_id, &Json(alliance)],
+        )
+        .await
+    }
+
+    /// [`DBDashboardAlliance::update_alliance_report_public_enabled`]
+    #[instrument(skip(self), err)]
+    async fn update_alliance_report_public_enabled(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        enabled: bool,
+    ) -> Result<()> {
+        self.execute(
+            "select update_alliance_report_public_enabled($1::uuid, $2::uuid, $3::bool)",
+            &[&actor_user_id, &alliance_id, &enabled],
         )
         .await
     }

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -250,6 +250,15 @@ pub(crate) trait DBDashboardGroup {
         group_id: Uuid,
     ) -> Result<GroupDashboardStats>;
 
+    /// Updates whether a group report is public.
+    async fn update_group_report_public_enabled(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        group_id: Uuid,
+        enabled: bool,
+    ) -> Result<()>;
+
     /// Creates an organizer-created event invitation.
     async fn invite_event_attendee(
         &self,
@@ -1812,6 +1821,22 @@ where
         self.execute(
             "select update_group_event_defaults($1::uuid, $2::uuid, $3::jsonb)",
             &[&actor_user_id, &group_id, &Json(&event_defaults)],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::update_group_report_public_enabled`]
+    #[instrument(skip(self), err)]
+    async fn update_group_report_public_enabled(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        group_id: Uuid,
+        enabled: bool,
+    ) -> Result<()> {
+        self.execute(
+            "select update_group_report_public_enabled($1::uuid, $2::uuid, $3::uuid, $4::bool)",
+            &[&actor_user_id, &alliance_id, &group_id, &enabled],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -335,6 +335,12 @@ mock! {
             alliance_id: Uuid,
             alliance: &crate::templates::dashboard::alliance::settings::AllianceUpdate,
         ) -> Result<()>;
+        async fn update_alliance_report_public_enabled(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            enabled: bool,
+        ) -> Result<()>;
         async fn update_alliance_team_member_role(
             &self,
             actor_user_id: Uuid,
@@ -515,6 +521,13 @@ mock! {
             alliance_id: Uuid,
             group_id: Uuid,
         ) -> Result<crate::templates::dashboard::group::analytics::GroupDashboardStats>;
+        async fn update_group_report_public_enabled(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            group_id: Uuid,
+            enabled: bool,
+        ) -> Result<()>;
         async fn invite_event_attendee(
             &self,
             actor_user_id: Uuid,

--- a/ocg-server/src/handlers/alliance.rs
+++ b/ocg-server/src/handlers/alliance.rs
@@ -119,6 +119,44 @@ pub(crate) async fn brand_page(
     Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
 }
 
+/// Handler that renders the public alliance report page.
+#[instrument(skip_all, err)]
+pub(crate) async fn report_page(
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path(alliance_name): Path<String>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let (mut alliance, stats) = tokio::try_join!(
+        db.get_alliance_full(alliance_id),
+        db.get_alliance_stats(alliance_id)
+    )?;
+    if !alliance.report_public_enabled {
+        return not_found::render(site_settings);
+    }
+
+    trim_public_gallery_images(&mut alliance.photos_urls);
+    let template = alliance::ReportPage {
+        base_url: server_cfg.base_url,
+        alliance,
+        page_id: PageId::Alliance,
+        path: uri.path().to_string(),
+        site_settings,
+        stats,
+        user: User::default(),
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
+}
+
 /// Handler that renders the logged-in alliance member directory.
 #[instrument(skip_all, err)]
 pub(crate) async fn members_page(

--- a/ocg-server/src/handlers/dashboard/alliance/analytics.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/analytics.rs
@@ -3,13 +3,17 @@
 use askama::Template;
 use axum::{
     extract::State,
+    http::StatusCode,
     response::{Html, IntoResponse},
 };
 use tracing::instrument;
 
 use crate::{
     db::DynDB,
-    handlers::{error::HandlerError, extractors::SelectedAllianceId},
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId},
+    },
     templates::dashboard::alliance::analytics,
 };
 
@@ -24,8 +28,37 @@ pub(crate) async fn page(
     SelectedAllianceId(alliance_id): SelectedAllianceId,
     State(db): State<DynDB>,
 ) -> Result<impl IntoResponse, HandlerError> {
-    let stats = db.get_alliance_stats(alliance_id).await?;
-    let page = analytics::Page { stats };
+    let (alliance, stats) = tokio::try_join!(
+        db.get_alliance_full(alliance_id),
+        db.get_alliance_stats(alliance_id)
+    )?;
+    let page = analytics::Page { alliance, stats };
 
     Ok(Html(page.render()?))
+}
+
+/// Publishes the alliance report to the public alliance page.
+#[instrument(skip_all, err)]
+pub(crate) async fn publish_report(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_alliance_report_public_enabled(user.user_id, alliance_id, true)
+        .await?;
+
+    Ok((StatusCode::NO_CONTENT, [("HX-Refresh", "true")]))
+}
+
+/// Unpublishes the alliance report from the public alliance page.
+#[instrument(skip_all, err)]
+pub(crate) async fn unpublish_report(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_alliance_report_public_enabled(user.user_id, alliance_id, false)
+        .await?;
+
+    Ok((StatusCode::NO_CONTENT, [("HX-Refresh", "true")]))
 }

--- a/ocg-server/src/handlers/dashboard/alliance/analytics/tests.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/analytics/tests.rs
@@ -41,6 +41,10 @@ async fn test_page_db_error() {
             *cid == alliance_id && *uid == user_id && permission == AlliancePermission::Read
         })
         .returning(|_, _, _| Ok(true));
+    db.expect_get_alliance_full()
+        .times(1)
+        .withf(move |cid| *cid == alliance_id)
+        .returning(move |_| Ok(sample_alliance_full(alliance_id)));
     db.expect_get_alliance_stats()
         .times(1)
         .withf(move |cid| *cid == alliance_id)
@@ -94,6 +98,10 @@ async fn test_page_success() {
             *cid == alliance_id && *uid == user_id && permission == AlliancePermission::Read
         })
         .returning(|_, _, _| Ok(true));
+    db.expect_get_alliance_full()
+        .times(1)
+        .withf(move |cid| *cid == alliance_id)
+        .returning(move |_| Ok(sample_alliance_full(alliance_id)));
     db.expect_get_alliance_stats()
         .times(1)
         .withf(move |cid| *cid == alliance_id)

--- a/ocg-server/src/handlers/dashboard/alliance/home.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/home.rs
@@ -65,7 +65,10 @@ pub(crate) async fn page(
     let content = match tab {
         Tab::Analytics => {
             let stats = db.get_alliance_stats(alliance_id).await?;
-            Content::Analytics(Box::new(analytics::Page { stats }))
+            Content::Analytics(Box::new(analytics::Page {
+                alliance: alliance.clone(),
+                stats,
+            }))
         }
         Tab::CreateAlliance => {
             if !auth_session.user.as_ref().is_some_and(|user| user.platform_admin) {

--- a/ocg-server/src/handlers/dashboard/group/analytics.rs
+++ b/ocg-server/src/handlers/dashboard/group/analytics.rs
@@ -3,6 +3,7 @@
 use askama::Template;
 use axum::{
     extract::State,
+    http::StatusCode,
     response::{Html, IntoResponse},
 };
 use tracing::instrument;
@@ -11,7 +12,7 @@ use crate::{
     db::DynDB,
     handlers::{
         error::HandlerError,
-        extractors::{SelectedAllianceId, SelectedGroupId},
+        extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId},
     },
     templates::dashboard::group::analytics,
 };
@@ -28,8 +29,39 @@ pub(crate) async fn page(
     SelectedGroupId(group_id): SelectedGroupId,
     State(db): State<DynDB>,
 ) -> Result<impl IntoResponse, HandlerError> {
-    let stats = db.get_group_stats(alliance_id, group_id).await?;
-    let page = analytics::Page { stats };
+    let (group, stats) = tokio::try_join!(
+        db.get_group_full(alliance_id, group_id),
+        db.get_group_stats(alliance_id, group_id)
+    )?;
+    let page = analytics::Page { group, stats };
 
     Ok(Html(page.render()?))
+}
+
+/// Publishes the group report to the public group page.
+#[instrument(skip_all, err)]
+pub(crate) async fn publish_report(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_group_report_public_enabled(user.user_id, alliance_id, group_id, true)
+        .await?;
+
+    Ok((StatusCode::NO_CONTENT, [("HX-Refresh", "true")]))
+}
+
+/// Unpublishes the group report from the public group page.
+#[instrument(skip_all, err)]
+pub(crate) async fn unpublish_report(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_group_report_public_enabled(user.user_id, alliance_id, group_id, false)
+        .await?;
+
+    Ok((StatusCode::NO_CONTENT, [("HX-Refresh", "true")]))
 }

--- a/ocg-server/src/handlers/dashboard/group/analytics/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/analytics/tests.rs
@@ -46,6 +46,10 @@ async fn test_page_db_error() {
             *cid == alliance_id && *gid == group_id && *uid == user_id
         })
         .returning(|_, _, _, _| Ok(true));
+    db.expect_get_group_full()
+        .times(1)
+        .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)
+        .returning(move |_, _| Ok(sample_group_full(alliance_id, group_id)));
     db.expect_get_group_stats()
         .times(1)
         .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)
@@ -104,6 +108,10 @@ async fn test_page_success() {
             *cid == alliance_id && *gid == group_id && *uid == user_id
         })
         .returning(|_, _, _, _| Ok(true));
+    db.expect_get_group_full()
+        .times(1)
+        .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)
+        .returning(move |_, _| Ok(sample_group_full(alliance_id, group_id)));
     db.expect_get_group_stats()
         .times(1)
         .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)

--- a/ocg-server/src/handlers/dashboard/group/home.rs
+++ b/ocg-server/src/handlers/dashboard/group/home.rs
@@ -68,8 +68,11 @@ pub(crate) async fn page(
     // Prepare content for the selected tab
     let content = match tab {
         Tab::Analytics => {
-            let stats = db.get_group_stats(alliance_id, group_id).await?;
-            Content::Analytics(Box::new(analytics::Page { stats }))
+            let (group, stats) = tokio::try_join!(
+                db.get_group_full(alliance_id, group_id),
+                db.get_group_stats(alliance_id, group_id)
+            )?;
+            Content::Analytics(Box::new(analytics::Page { group, stats }))
         }
         Tab::Events => {
             let (_, template) = events::prepare_list_page(

--- a/ocg-server/src/handlers/dashboard/group/home/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/home/tests.rs
@@ -55,6 +55,10 @@ async fn test_page_analytics_tab_success() {
         .times(1)
         .withf(move |uid| uid == &user_id)
         .returning(move |_| Ok(groups.clone()));
+    db.expect_get_group_full()
+        .times(1)
+        .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)
+        .returning(move |_, _| Ok(sample_group_full(alliance_id, group_id)));
     db.expect_get_group_stats()
         .times(1)
         .withf(move |cid, gid| *cid == alliance_id && *gid == group_id)

--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -26,7 +26,7 @@ use crate::{
         PageId,
         auth::User,
         dashboard::group::members::GroupMembersFilters,
-        group::{self, MembersPage, Page, SpotlightsPage, StorePage},
+        group::{self, MembersPage, Page, ReportPage, SpotlightsPage, StorePage},
         notifications::GroupWelcome,
     },
     types::{
@@ -146,6 +146,45 @@ pub(crate) async fn spotlights_page(
     };
 
     Ok(Html(template.render()?).into_response())
+}
+
+/// Handler that renders the public group report page.
+#[instrument(skip_all)]
+pub(crate) async fn report_page(
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((alliance_name, group_slug)): Path<(String, String)>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let Some(mut group) = db.get_group_full_by_slug(alliance_id, &group_slug).await? else {
+        return not_found::render(site_settings);
+    };
+    if !group.report_public_enabled {
+        return not_found::render(site_settings);
+    }
+
+    trim_public_gallery_images(&mut group.photos_urls);
+    group.sponsors.clear();
+    let stats = db.get_group_stats(alliance_id, group.group_id).await?;
+    let template = ReportPage {
+        base_url: server_cfg.base_url,
+        group,
+        page_id: PageId::Group,
+        path: uri.path().to_string(),
+        site_settings,
+        stats,
+        user: User::default(),
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
 }
 
 /// Handler that renders a logged-in group member directory.

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -333,10 +333,15 @@ pub(crate) async fn setup(
         // Alliance-prefixed public routes
         .route("/{alliance}/brand", get(alliance::brand_page))
         .route("/{alliance}/members", get(alliance::members_page))
+        .route("/{alliance}/reports", get(alliance::report_page))
         .route("/{alliance}", get(alliance::page))
         .route(
             "/{alliance}/group/{group_slug}/store",
             get(group::store_page),
+        )
+        .route(
+            "/{alliance}/group/{group_slug}/reports",
+            get(group::report_page),
         )
         .route("/{alliance}/group/{group_slug}", get(group::page))
         .route(

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -145,6 +145,11 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
     // Alliance settings management endpoints
     let settings_management = Router::new()
         .route(
+            "/analytics/report/public",
+            put(dashboard::alliance::analytics::publish_report)
+                .delete(dashboard::alliance::analytics::unpublish_report),
+        )
+        .route(
             "/email-templates",
             put(dashboard::alliance::email_templates::update),
         )
@@ -427,6 +432,11 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
 
     // Group settings management endpoints
     let settings_management = Router::new()
+        .route(
+            "/analytics/report/public",
+            put(dashboard::group::analytics::publish_report)
+                .delete(dashboard::group::analytics::unpublish_report),
+        )
         .route("/settings/update", put(dashboard::group::settings::update))
         .route_layer(check_selected_group_permission(
             GroupPermission::SettingsWrite,

--- a/ocg-server/src/templates/alliance.rs
+++ b/ocg-server/src/templates/alliance.rs
@@ -12,7 +12,8 @@ use crate::{
     templates::{
         PageId,
         auth::User,
-        dashboard, filters,
+        dashboard::{self, alliance::analytics::AllianceDashboardStats},
+        filters,
         helpers::{self, user_initials},
     },
     types::{
@@ -126,6 +127,26 @@ pub(crate) struct MembersPage {
     pub user: User,
 }
 
+/// Template for the public alliance report page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "alliance/report.html")]
+pub(crate) struct ReportPage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Alliance information.
+    pub alliance: AllianceFull,
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current request path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Alliance dashboard statistics.
+    pub stats: AllianceDashboardStats,
+    /// Authenticated user information.
+    pub user: User,
+}
+
 impl MembersPage {
     /// Returns the canonical public URL for the alliance members page.
     pub(crate) fn canonical_url(&self) -> String {
@@ -149,6 +170,34 @@ impl MembersPage {
     pub(crate) fn preview_description(&self) -> String {
         format!(
             "Browse member cards across {} groups.",
+            self.alliance.display_name
+        )
+    }
+}
+
+impl ReportPage {
+    /// Returns the canonical public URL for the alliance report page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(&self.base_url, &format!("/{}/reports", self.alliance.name))
+    }
+
+    /// Returns the Open Graph image URL for the alliance report page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.alliance
+            .og_image_url
+            .as_deref()
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+
+    /// Returns the preview title for the alliance report page.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} report", self.alliance.display_name)
+    }
+
+    /// Returns the preview description for the alliance report page.
+    pub(crate) fn preview_description(&self) -> String {
+        format!(
+            "Public growth and activity report for {}.",
             self.alliance.display_name
         )
     }

--- a/ocg-server/src/templates/dashboard/alliance/analytics.rs
+++ b/ocg-server/src/templates/dashboard/alliance/analytics.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use crate::templates::filters;
+use crate::types::alliance::AllianceFull;
 use askama::Template;
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +13,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "dashboard/alliance/analytics.html")]
 pub(crate) struct Page {
+    /// Current alliance.
+    pub alliance: AllianceFull,
     /// Statistics to render.
     pub stats: AllianceDashboardStats,
 }

--- a/ocg-server/src/templates/dashboard/group/analytics.rs
+++ b/ocg-server/src/templates/dashboard/group/analytics.rs
@@ -1,6 +1,6 @@
 //! Templates and data types for the analytics page in the group dashboard.
 
-use crate::templates::filters;
+use crate::{templates::filters, types::group::GroupFull};
 use askama::Template;
 use serde::{Deserialize, Serialize};
 
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "dashboard/group/analytics.html")]
 pub(crate) struct Page {
+    /// Current group.
+    pub group: GroupFull,
     /// Statistics to render.
     pub stats: GroupDashboardStats,
 }

--- a/ocg-server/src/templates/group.rs
+++ b/ocg-server/src/templates/group.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     templates::dashboard::group::{
-        members::GroupMember, spotlights::GroupMemberSpotlight, store::GroupStoreItem,
+        analytics::GroupDashboardStats, members::GroupMember, spotlights::GroupMemberSpotlight,
+        store::GroupStoreItem,
     },
     templates::{
         PageId,
@@ -93,6 +94,26 @@ pub(crate) struct MembersPage {
     pub site_settings: SiteSettings,
     /// Total number of members in the group.
     pub total: usize,
+    /// Authenticated user information.
+    pub user: User,
+}
+
+/// Public group report page.
+#[derive(Debug, Clone, Template)]
+#[template(path = "group/report.html")]
+pub(crate) struct ReportPage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Detailed information about the group.
+    pub group: GroupFull,
+    /// Identifier for the current page.
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Group dashboard statistics.
+    pub stats: GroupDashboardStats,
     /// Authenticated user information.
     pub user: User,
 }
@@ -210,6 +231,39 @@ impl MembersPage {
     }
 
     /// Returns the `OpenGraph` image URL for the group members page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.group
+            .og_image_url
+            .as_deref()
+            .or(self.group.alliance.og_image_url.as_deref())
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+}
+
+impl ReportPage {
+    /// Returns the canonical URL for the group report page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!(
+                "/{}/group/{}/reports",
+                self.group.alliance.name,
+                self.group.public_slug()
+            ),
+        )
+    }
+
+    /// Returns the preview title.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} report", self.group.name)
+    }
+
+    /// Returns the preview description.
+    pub(crate) fn preview_description(&self) -> String {
+        format!("Public growth and activity report for {}.", self.group.name)
+    }
+
+    /// Returns the `OpenGraph` image URL for the group report page.
     pub(crate) fn open_graph_image_url(&self) -> Option<String> {
         self.group
             .og_image_url

--- a/ocg-server/src/types/alliance.rs
+++ b/ocg-server/src/types/alliance.rs
@@ -67,6 +67,9 @@ pub struct AllianceFull {
     pub twitter_url: Option<String>,
     /// Link to the alliance's main website.
     pub website_url: Option<String>,
+    /// Whether the alliance report is visible on the public alliance page.
+    #[serde(default)]
+    pub report_public_enabled: bool,
     /// Link to the alliance's `WeChat` account or QR code.
     pub wechat_url: Option<String>,
     /// Link to the alliance's `YouTube` channel.

--- a/ocg-server/src/types/group.rs
+++ b/ocg-server/src/types/group.rs
@@ -190,6 +190,9 @@ pub struct GroupFull {
     pub photos_urls: Option<Vec<String>>,
     /// Geographic region this group belongs to.
     pub region: Option<GroupRegion>,
+    /// Whether the group report is visible on the public group page.
+    #[serde(default)]
+    pub report_public_enabled: bool,
     /// Slack workspace URL.
     pub slack_url: Option<String>,
     /// Admin-managed URL slug of the group.

--- a/ocg-server/templates/alliance/page.html
+++ b/ocg-server/templates/alliance/page.html
@@ -123,6 +123,12 @@
                hx-boost="true"
                hx-target="body"
                class="btn-secondary-anchor text-md lg:text-lg px-8 font-semibold">Member directory</a>
+            {% if alliance.report_public_enabled -%}
+              <a href="/{{ alliance.name }}/reports"
+                 hx-boost="true"
+                 hx-target="body"
+                 class="btn-secondary-anchor text-md lg:text-lg px-8 font-semibold">Alliance report</a>
+            {% endif -%}
           </div>
         </div>
         {# End about this alliance -#}

--- a/ocg-server/templates/alliance/report.html
+++ b/ocg-server/templates/alliance/report.html
@@ -1,0 +1,158 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &alliance.display_name) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block scripts -%}
+  <script>
+    if (new URLSearchParams(window.location.search).get("print") === "1") {
+      window.addEventListener("load", () => window.print());
+    }
+  </script>
+{% endblock scripts -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8 print:px-0">
+    <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between print:hidden">
+      <a href="/{{ alliance.name }}" class="btn-secondary-anchor">Back to alliance</a>
+      <button type="button" class="btn-primary" onclick="window.print()">Download PDF</button>
+    </div>
+
+    <article class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-xl shadow-stone-200/50 sm:p-10 print:border-0 print:p-0 print:shadow-none">
+      <header class="border-b border-stone-200 pb-8">
+        <div class="flex items-center gap-4">
+          <img src="{{ alliance.logo_url }}"
+               alt="{{ alliance.display_name }} logo"
+               class="size-16 rounded-2xl object-contain ring-1 ring-stone-200" />
+          <div>
+            <p class="text-xs font-black uppercase tracking-[0.2em] text-stone-500">Alliance report</p>
+            <h1 class="mt-2 text-3xl font-black tracking-tight text-stone-950 sm:text-4xl">{{ alliance.display_name }}</h1>
+          </div>
+        </div>
+        <p class="mt-5 max-w-3xl text-sm/6 text-stone-600">
+          Public summary of alliance growth, chapter activity, member distribution, and event momentum.
+        </p>
+      </header>
+
+      <section class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Groups</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.groups.total|num_fmt }}</div>
+        </div>
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Members</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.members.total|num_fmt }}</div>
+        </div>
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Events</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.events.total|num_fmt }}</div>
+        </div>
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Attendees</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.attendees.total|num_fmt }}</div>
+        </div>
+      </section>
+
+      <section class="mt-8 grid gap-5 lg:grid-cols-3">
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-stone-500">Members</p>
+          <h2 class="mt-2 text-xl font-black text-stone-950">90-day growth</h2>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Latest</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.recent_growth|num_fmt }}</div>
+            </div>
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Prior</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.previous_growth|num_fmt }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-stone-500">Leaders</p>
+          <h2 class="mt-2 text-xl font-black text-stone-950">Chapter leaders</h2>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Total</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.leaders_total|num_fmt }}</div>
+            </div>
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">90-day growth</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.leaders_recent_growth|num_fmt }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-stone-500">Events</p>
+          <h2 class="mt-2 text-xl font-black text-stone-950">Hosted and upcoming</h2>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Hosted</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.events.hosted_total|num_fmt }}</div>
+            </div>
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Upcoming</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.events.upcoming_total|num_fmt }}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="mt-8 rounded-2xl border border-stone-200 p-5">
+        <h2 class="text-xl font-black text-stone-950">Top chapters</h2>
+        {% if stats.reports.chapters.rankings.len() > 0 -%}
+          <div class="mt-4 overflow-x-auto">
+            <table class="min-w-full text-sm">
+              <thead class="text-left text-xs font-bold uppercase tracking-[0.14em] text-stone-500">
+                <tr>
+                  <th class="py-2 pe-4">Chapter</th>
+                  <th class="py-2 pe-4">Region</th>
+                  <th class="py-2 pe-4 text-right">Members</th>
+                  <th class="py-2 pe-4 text-right">90d growth</th>
+                  <th class="py-2 text-right">Events</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-stone-100">
+                {% for chapter in stats.reports.chapters.rankings -%}
+                  <tr>
+                    <td class="py-3 pe-4 font-bold text-stone-900">{{ chapter.name }}</td>
+                    <td class="py-3 pe-4 text-stone-600">{{ chapter.region }}</td>
+                    <td class="py-3 pe-4 text-right font-semibold">{{ chapter.members_total|num_fmt }}</td>
+                    <td class="py-3 pe-4 text-right font-semibold">{{ chapter.members_recent|num_fmt }}</td>
+                    <td class="py-3 text-right font-semibold">{{ chapter.events_total|num_fmt }}</td>
+                  </tr>
+                {% endfor -%}
+              </tbody>
+            </table>
+          </div>
+        {% else -%}
+          <p class="mt-4 rounded-xl bg-stone-50 p-4 text-sm text-stone-500">Chapter reporting will appear once chapters have activity.</p>
+        {% endif -%}
+      </section>
+    </article>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/dashboard/alliance/analytics.html
+++ b/ocg-server/templates/dashboard/alliance/analytics.html
@@ -6,6 +6,41 @@
 description = "Alliance statistics and growth trends. Analytics are cached for a few minutes and may not display up to date information.") }}
 {# End page title #}
 
+<div class="mt-6 rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Public report</div>
+      <h2 class="mt-2 text-lg font-black text-stone-950">Share alliance performance</h2>
+      <p class="mt-1 text-sm/6 text-stone-600">
+        Generate a PDF-ready report and publish it on the alliance public page when it is ready.
+      </p>
+      {% if alliance.report_public_enabled -%}
+        <a href="/{{ alliance.name }}/reports"
+           class="mt-3 inline-flex text-sm font-semibold text-primary-700 hover:text-primary-800"
+           target="_blank"
+           rel="noopener noreferrer">/{{ alliance.name }}/reports</a>
+      {% endif -%}
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <a href="/{{ alliance.name }}/reports?print=1"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="btn-secondary-anchor">Generate PDF</a>
+      {% if alliance.report_public_enabled -%}
+        <form hx-delete="/dashboard/alliance/analytics/report/public"
+              hx-swap="none">
+          <button type="submit" class="btn-secondary">Unpublish</button>
+        </form>
+      {% else -%}
+        <form hx-put="/dashboard/alliance/analytics/report/public"
+              hx-swap="none">
+          <button type="submit" class="btn-primary">Publish to public page</button>
+        </form>
+      {% endif -%}
+    </div>
+  </div>
+</div>
+
 {# Summary stat cards #}
 <div class="grid grid-cols-2 xl:grid-cols-5 gap-4 mt-10">
   <button type="button"

--- a/ocg-server/templates/dashboard/group/analytics.html
+++ b/ocg-server/templates/dashboard/group/analytics.html
@@ -6,6 +6,41 @@
 description = "Group statistics and growth trends. Analytics are cached for a few minutes and may not display up to date information.") }}
 {# End page title #}
 
+<div class="mt-6 rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+  <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+    <div>
+      <div class="text-xs font-bold uppercase tracking-[0.18em] text-stone-500">Public report</div>
+      <h2 class="mt-2 text-lg font-black text-stone-950">Share group performance</h2>
+      <p class="mt-1 text-sm/6 text-stone-600">
+        Generate a PDF-ready report and publish it on the group public page when it is ready.
+      </p>
+      {% if group.report_public_enabled -%}
+        <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/reports"
+           class="mt-3 inline-flex text-sm font-semibold text-primary-700 hover:text-primary-800"
+           target="_blank"
+           rel="noopener noreferrer">/{{ group.alliance.name }}/group/{{ group.public_slug() }}/reports</a>
+      {% endif -%}
+    </div>
+    <div class="flex flex-wrap gap-2">
+      <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/reports?print=1"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="btn-secondary-anchor">Generate PDF</a>
+      {% if group.report_public_enabled -%}
+        <form hx-delete="/dashboard/group/analytics/report/public"
+              hx-swap="none">
+          <button type="submit" class="btn-secondary">Unpublish</button>
+        </form>
+      {% else -%}
+        <form hx-put="/dashboard/group/analytics/report/public"
+              hx-swap="none">
+          <button type="submit" class="btn-primary">Publish to public page</button>
+        </form>
+      {% endif -%}
+    </div>
+  </div>
+</div>
+
 {# Summary stat cards #}
 <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4 mt-10">
   <div class="bg-white border border-stone-200 text-start rounded-lg p-5">

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -155,6 +155,13 @@
                     <div class="svg-icon size-4 icon-shopping-bag bg-stone-600"></div>
                     Store
                   </a>
+                  {% if group.report_public_enabled -%}
+                    <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/reports"
+                       class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
+                      <div class="svg-icon size-4 icon-link bg-stone-600"></div>
+                      Group report
+                    </a>
+                  {% endif -%}
                   <share-modal trigger-variant="menu-item" title="{{ group.name }}" url="/{{ group.alliance.name }}/group/{{ group.public_slug() }}">
                   </share-modal>
                 </div>

--- a/ocg-server/templates/group/report.html
+++ b/ocg-server/templates/group/report.html
@@ -1,0 +1,152 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &group.name) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block scripts -%}
+  <script>
+    if (new URLSearchParams(window.location.search).get("print") === "1") {
+      window.addEventListener("load", () => window.print());
+    }
+  </script>
+{% endblock scripts -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8 print:px-0">
+    <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between print:hidden">
+      <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}" class="btn-secondary-anchor">Back to group</a>
+      <button type="button" class="btn-primary" onclick="window.print()">Download PDF</button>
+    </div>
+
+    <article class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-xl shadow-stone-200/50 sm:p-10 print:border-0 print:p-0 print:shadow-none">
+      <header class="border-b border-stone-200 pb-8">
+        <div class="flex items-center gap-4">
+          <img src="{{ group.logo_url }}"
+               alt="{{ group.name }} logo"
+               class="size-16 rounded-2xl object-contain ring-1 ring-stone-200" />
+          <div>
+            <p class="text-xs font-black uppercase tracking-[0.2em] text-stone-500">Group report</p>
+            <h1 class="mt-2 text-3xl font-black tracking-tight text-stone-950 sm:text-4xl">{{ group.name }}</h1>
+            <p class="mt-1 text-sm font-semibold text-stone-500">{{ group.alliance.display_name }}</p>
+          </div>
+        </div>
+        <p class="mt-5 max-w-3xl text-sm/6 text-stone-600">
+          Public summary of group membership growth, event activity, member recognition, and page reach.
+        </p>
+      </header>
+
+      <section class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Members</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.members.total|num_fmt }}</div>
+        </div>
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Events</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.events.total|num_fmt }}</div>
+        </div>
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Attendees</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.attendees.total|num_fmt }}</div>
+        </div>
+        <div class="rounded-2xl bg-stone-50 p-5">
+          <div class="text-sm font-semibold text-stone-500">Page views</div>
+          <div class="mt-2 text-3xl font-black text-stone-950">{{ stats.page_views.total_views|num_fmt }}</div>
+        </div>
+      </section>
+
+      <section class="mt-8 grid gap-5 lg:grid-cols-3">
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-stone-500">Members</p>
+          <h2 class="mt-2 text-xl font-black text-stone-950">Membership growth</h2>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Latest 90 days</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.recent_growth|num_fmt }}</div>
+            </div>
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Prior 90 days</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.previous_growth|num_fmt }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-stone-500">Leaders</p>
+          <h2 class="mt-2 text-xl font-black text-stone-950">Group leaders</h2>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Total</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.leaders_total|num_fmt }}</div>
+            </div>
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">90-day growth</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.members.leaders_recent_growth|num_fmt }}</div>
+            </div>
+          </div>
+        </div>
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <p class="text-xs font-black uppercase tracking-[0.18em] text-stone-500">Events</p>
+          <h2 class="mt-2 text-xl font-black text-stone-950">Hosted and upcoming</h2>
+          <div class="mt-5 grid grid-cols-2 gap-3">
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Hosted</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.events.hosted_total|num_fmt }}</div>
+            </div>
+            <div class="rounded-xl bg-stone-50 p-3">
+              <div class="text-xs font-semibold text-stone-500">Upcoming</div>
+              <div class="mt-1 text-2xl font-black">{{ stats.reports.events.upcoming_total|num_fmt }}</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="mt-8 grid gap-5 lg:grid-cols-2">
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <h2 class="text-xl font-black text-stone-950">Events by city</h2>
+          <div class="mt-4 space-y-2">
+            {% for (label, count) in stats.reports.events.by_city -%}
+              <div class="flex items-center justify-between gap-3 rounded-xl bg-stone-50 px-3 py-2">
+                <span class="truncate text-sm font-semibold text-stone-700">{{ label }}</span>
+                <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+              </div>
+            {% endfor -%}
+          </div>
+        </div>
+        <div class="rounded-2xl border border-stone-200 p-5">
+          <h2 class="text-xl font-black text-stone-950">Events by kind</h2>
+          <div class="mt-4 space-y-2">
+            {% for (label, count) in stats.reports.events.by_kind -%}
+              <div class="flex items-center justify-between gap-3 rounded-xl bg-stone-50 px-3 py-2">
+                <span class="truncate text-sm font-semibold text-stone-700">{{ label }}</span>
+                <span class="text-sm font-black text-stone-950">{{ count|num_fmt }}</span>
+              </div>
+            {% endfor -%}
+          </div>
+        </div>
+      </section>
+    </article>
+  </div>
+{% endblock content -%}


### PR DESCRIPTION
## Summary
- Add printable public report pages for alliance and group dashboards, with dashboard controls to generate PDF-ready output.
- Add publish/unpublish controls and persisted visibility flags so reports appear on alliance/group public pages only when enabled.
- Wire database migration/function support for report visibility and public report rendering.

## Test plan
- cargo fmt
- cargo test -p ocg-server

