### PR TITLE
Add mock interviews MVP

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -63,6 +63,17 @@
 {{ template "jobs/update_job.sql" }}
 {{ template "jobs/update_job_published.sql" }}
 
+{{ template "mock_interviews/mock_interview_profile_json.sql" }}
+{{ template "mock_interviews/get_mock_interview_profile.sql" }}
+{{ template "mock_interviews/upsert_mock_interview_profile.sql" }}
+{{ template "mock_interviews/mock_interview_request_json.sql" }}
+{{ template "mock_interviews/search_mock_interview_matches.sql" }}
+{{ template "mock_interviews/list_mock_interview_requests.sql" }}
+{{ template "mock_interviews/add_mock_interview_request.sql" }}
+{{ template "mock_interviews/respond_mock_interview_request.sql" }}
+{{ template "mock_interviews/get_mock_interview_session.sql" }}
+{{ template "mock_interviews/add_mock_interview_feedback.sql" }}
+
 {{ template "landscape/landscape_entry_json.sql" }}
 {{ template "landscape/add_landscape_entry.sql" }}
 {{ template "landscape/delete_landscape_entry.sql" }}

--- a/database/migrations/functions/mock_interviews/add_mock_interview_feedback.sql
+++ b/database/migrations/functions/mock_interviews/add_mock_interview_feedback.sql
@@ -1,0 +1,126 @@
+create or replace function add_mock_interview_feedback(
+    p_reviewer_user_id uuid,
+    p_session_id uuid,
+    p_input jsonb
+)
+returns jsonb language plpgsql as $$
+declare
+    v_session mock_interview_session;
+    v_request mock_interview_request;
+    v_reviewer_role text;
+    v_reviewee_user_id uuid;
+    v_feedback mock_interview_feedback;
+    v_good_reviews int;
+    v_avg_score numeric;
+begin
+    select * into v_session
+    from mock_interview_session s
+    where s.mock_interview_session_id = p_session_id
+    for update;
+
+    if v_session.mock_interview_session_id is null then
+        raise exception 'session not found';
+    end if;
+
+    select * into v_request
+    from mock_interview_request r
+    where r.mock_interview_request_id = v_session.mock_interview_request_id;
+
+    if v_request.interviewer_user_id = p_reviewer_user_id then
+        v_reviewer_role := 'interviewer';
+        v_reviewee_user_id := v_request.interviewee_user_id;
+    elsif v_request.interviewee_user_id = p_reviewer_user_id then
+        v_reviewer_role := 'interviewee';
+        v_reviewee_user_id := v_request.interviewer_user_id;
+    else
+        raise exception 'not a session participant';
+    end if;
+
+    insert into mock_interview_feedback (
+        mock_interview_session_id,
+        reviewer_user_id,
+        reviewee_user_id,
+        reviewer_role,
+        communication,
+        technical_depth,
+        problem_solving,
+        role_readiness,
+        helpfulness,
+        feedback_quality,
+        would_recommend,
+        suggested_next_steps
+    ) values (
+        p_session_id,
+        p_reviewer_user_id,
+        v_reviewee_user_id,
+        v_reviewer_role,
+        (p_input->>'communication')::smallint,
+        (p_input->>'technical_depth')::smallint,
+        (p_input->>'problem_solving')::smallint,
+        (p_input->>'role_readiness')::smallint,
+        (p_input->>'helpfulness')::smallint,
+        (p_input->>'feedback_quality')::smallint,
+        (p_input->>'would_recommend')::boolean,
+        nullif(trim(p_input->>'suggested_next_steps'), '')
+    )
+    on conflict (mock_interview_session_id, reviewer_user_id) do update set
+        communication = excluded.communication,
+        technical_depth = excluded.technical_depth,
+        problem_solving = excluded.problem_solving,
+        role_readiness = excluded.role_readiness,
+        helpfulness = excluded.helpfulness,
+        feedback_quality = excluded.feedback_quality,
+        would_recommend = excluded.would_recommend,
+        suggested_next_steps = excluded.suggested_next_steps
+    returning * into v_feedback;
+
+    if not exists (
+        select 1
+        from mock_interview_feedback f
+        where f.mock_interview_session_id = p_session_id
+        and f.reviewer_role = 'interviewer'
+    ) or not exists (
+        select 1
+        from mock_interview_feedback f
+        where f.mock_interview_session_id = p_session_id
+        and f.reviewer_role = 'interviewee'
+    ) then
+        return jsonb_build_object('feedback_id', v_feedback.mock_interview_feedback_id);
+    end if;
+
+    update mock_interview_session
+    set status = 'completed',
+        completed_at = current_timestamp
+    where mock_interview_session_id = p_session_id;
+
+    update mock_interview_request
+    set status = 'completed'
+    where mock_interview_request_id = v_request.mock_interview_request_id;
+
+    update mock_interview_profile
+    set completed_sessions = completed_sessions + 1,
+        updated_at = current_timestamp
+    where user_id in (v_request.interviewee_user_id, v_request.interviewer_user_id);
+
+    select count(*)::int,
+        avg(
+            coalesce(f.helpfulness, f.feedback_quality, f.communication)::numeric
+        )
+    into v_good_reviews, v_avg_score
+    from mock_interview_feedback f
+    where f.reviewee_user_id = v_request.interviewer_user_id
+    and f.reviewer_role = 'interviewee'
+    and coalesce(f.would_recommend, false) = true;
+
+    update mock_interview_profile
+    set reputation_score = coalesce(v_avg_score, reputation_score),
+        interviewer_badge = (v_good_reviews >= 3 and coalesce(v_avg_score, 0) >= 4),
+        updated_at = current_timestamp
+    where user_id = v_request.interviewer_user_id;
+
+    return jsonb_build_object(
+        'feedback_id', v_feedback.mock_interview_feedback_id,
+        'session_completed', true
+    );
+end;
+$$;

--- a/database/migrations/functions/mock_interviews/add_mock_interview_request.sql
+++ b/database/migrations/functions/mock_interviews/add_mock_interview_request.sql
@@ -1,0 +1,59 @@
+create or replace function add_mock_interview_request(
+    p_interviewee_user_id uuid,
+    p_input jsonb
+)
+returns jsonb language plpgsql as $$
+declare
+    v_request mock_interview_request;
+    v_interviewer_user_id uuid := (p_input->>'interviewer_user_id')::uuid;
+    v_interview_type text := nullif(trim(p_input->>'interview_type'), '');
+begin
+    if v_interviewer_user_id is null then
+        raise exception 'interviewer_user_id is required';
+    end if;
+
+    if v_interview_type is null then
+        raise exception 'interview_type is required';
+    end if;
+
+    if v_interviewer_user_id = p_interviewee_user_id then
+        raise exception 'cannot request yourself';
+    end if;
+
+    if not exists (
+        select 1
+        from mock_interview_profile p
+        where p.user_id = p_interviewee_user_id
+        and p.enabled = true
+        and p.role_intent in ('interviewee', 'both')
+    ) then
+        raise exception 'interviewee profile required';
+    end if;
+
+    if not exists (
+        select 1
+        from mock_interview_profile p
+        where p.user_id = v_interviewer_user_id
+        and p.enabled = true
+        and p.role_intent in ('interviewer', 'both')
+        and v_interview_type = any (p.interview_types)
+    ) then
+        raise exception 'interviewer not available for this interview type';
+    end if;
+
+    insert into mock_interview_request (
+        interviewee_user_id,
+        interviewer_user_id,
+        interview_type,
+        message
+    ) values (
+        p_interviewee_user_id,
+        v_interviewer_user_id,
+        v_interview_type,
+        nullif(trim(p_input->>'message'), '')
+    )
+    returning * into v_request;
+
+    return mock_interview_request_json(v_request);
+end;
+$$;

--- a/database/migrations/functions/mock_interviews/get_mock_interview_profile.sql
+++ b/database/migrations/functions/mock_interviews/get_mock_interview_profile.sql
@@ -1,0 +1,6 @@
+create or replace function get_mock_interview_profile(p_user_id uuid)
+returns jsonb language sql stable as $$
+    select mock_interview_profile_json(p)
+    from mock_interview_profile p
+    where p.user_id = p_user_id;
+$$;

--- a/database/migrations/functions/mock_interviews/get_mock_interview_session.sql
+++ b/database/migrations/functions/mock_interviews/get_mock_interview_session.sql
@@ -1,0 +1,70 @@
+create or replace function mock_interview_session_json(p_session mock_interview_session)
+returns jsonb language sql stable as $$
+    select jsonb_build_object(
+        'mock_interview_session_id', p_session.mock_interview_session_id,
+        'mock_interview_request_id', p_session.mock_interview_request_id,
+        'meeting_url', p_session.meeting_url,
+        'scheduled_at', case
+            when p_session.scheduled_at is null then null
+            else extract(epoch from p_session.scheduled_at)::bigint
+        end,
+        'status', p_session.status,
+        'created_at', extract(epoch from p_session.created_at)::bigint,
+        'completed_at', case
+            when p_session.completed_at is null then null
+            else extract(epoch from p_session.completed_at)::bigint
+        end,
+        'request', mock_interview_request_json(r)
+    )
+    from mock_interview_request r
+    where r.mock_interview_request_id = p_session.mock_interview_request_id;
+$$;
+
+create or replace function get_mock_interview_session(
+    p_user_id uuid,
+    p_session_id uuid
+)
+returns jsonb language plpgsql stable as $$
+declare
+    v_session mock_interview_session;
+    v_feedback jsonb;
+begin
+    select s.* into v_session
+    from mock_interview_session s
+    join mock_interview_request r on r.mock_interview_request_id = s.mock_interview_request_id
+    where s.mock_interview_session_id = p_session_id
+    and (r.interviewee_user_id = p_user_id or r.interviewer_user_id = p_user_id);
+
+    if v_session.mock_interview_session_id is null then
+        return null;
+    end if;
+
+    select coalesce(
+        jsonb_agg(
+            jsonb_build_object(
+                'mock_interview_feedback_id', f.mock_interview_feedback_id,
+                'reviewer_user_id', f.reviewer_user_id,
+                'reviewee_user_id', f.reviewee_user_id,
+                'reviewer_role', f.reviewer_role,
+                'communication', f.communication,
+                'technical_depth', f.technical_depth,
+                'problem_solving', f.problem_solving,
+                'role_readiness', f.role_readiness,
+                'helpfulness', f.helpfulness,
+                'feedback_quality', f.feedback_quality,
+                'would_recommend', f.would_recommend,
+                'suggested_next_steps', f.suggested_next_steps,
+                'created_at', extract(epoch from f.created_at)::bigint
+            )
+            order by f.created_at asc
+        ),
+        '[]'::jsonb
+    )
+    into v_feedback
+    from mock_interview_feedback f
+    where f.mock_interview_session_id = p_session_id;
+
+    return mock_interview_session_json(v_session)
+        || jsonb_build_object('feedback', v_feedback);
+end;
+$$;

--- a/database/migrations/functions/mock_interviews/list_mock_interview_requests.sql
+++ b/database/migrations/functions/mock_interviews/list_mock_interview_requests.sql
@@ -1,0 +1,13 @@
+create or replace function list_mock_interview_requests(p_user_id uuid)
+returns jsonb language sql stable as $$
+    select coalesce(
+        jsonb_agg(
+            mock_interview_request_json(r)
+            order by r.created_at desc
+        ),
+        '[]'::jsonb
+    )
+    from mock_interview_request r
+    where r.interviewee_user_id = p_user_id
+    or r.interviewer_user_id = p_user_id;
+$$;

--- a/database/migrations/functions/mock_interviews/mock_interview_profile_json.sql
+++ b/database/migrations/functions/mock_interviews/mock_interview_profile_json.sql
@@ -1,0 +1,42 @@
+create or replace function mock_interview_seniority_rank(p_seniority text)
+returns int language sql immutable as $$
+    select case p_seniority
+        when 'junior' then 1
+        when 'mid' then 2
+        when 'senior' then 3
+        when 'staff_plus' then 4
+        else 0
+    end;
+$$;
+
+create or replace function mock_interview_profile_json(p_profile mock_interview_profile)
+returns jsonb language sql stable as $$
+    select jsonb_build_object(
+        'user_id', p_profile.user_id,
+        'role_intent', p_profile.role_intent,
+        'timezone_region', p_profile.timezone_region,
+        'seniority', p_profile.seniority,
+        'interview_types', p_profile.interview_types,
+        'target_company_types', p_profile.target_company_types,
+        'availability_slots', p_profile.availability_slots,
+        'linkedin_url', p_profile.linkedin_url,
+        'github_url', p_profile.github_url,
+        'resume_url', p_profile.resume_url,
+        'enabled', p_profile.enabled,
+        'reputation_score', p_profile.reputation_score,
+        'completed_sessions', p_profile.completed_sessions,
+        'interviewer_badge', p_profile.interviewer_badge,
+        'username', u.username,
+        'name', u.name,
+        'photo_url', u.photo_url,
+        'title', u.title,
+        'company', u.company,
+        'created_at', extract(epoch from p_profile.created_at)::bigint,
+        'updated_at', case
+            when p_profile.updated_at is null then null
+            else extract(epoch from p_profile.updated_at)::bigint
+        end
+    )
+    from "user" u
+    where u.user_id = p_profile.user_id;
+$$;

--- a/database/migrations/functions/mock_interviews/mock_interview_request_json.sql
+++ b/database/migrations/functions/mock_interviews/mock_interview_request_json.sql
@@ -1,0 +1,28 @@
+create or replace function mock_interview_request_json(p_request mock_interview_request)
+returns jsonb language sql stable as $$
+    select jsonb_build_object(
+        'mock_interview_request_id', p_request.mock_interview_request_id,
+        'interviewee_user_id', p_request.interviewee_user_id,
+        'interviewer_user_id', p_request.interviewer_user_id,
+        'interview_type', p_request.interview_type,
+        'message', p_request.message,
+        'status', p_request.status,
+        'created_at', extract(epoch from p_request.created_at)::bigint,
+        'responded_at', case
+            when p_request.responded_at is null then null
+            else extract(epoch from p_request.responded_at)::bigint
+        end,
+        'interviewee_username', ie.username,
+        'interviewee_name', ie.name,
+        'interviewee_photo_url', ie.photo_url,
+        'interviewer_username', ir.username,
+        'interviewer_name', ir.name,
+        'interviewer_photo_url', ir.photo_url,
+        'mock_interview_session_id', s.mock_interview_session_id
+    )
+    from "user" ie
+    join "user" ir on ir.user_id = p_request.interviewer_user_id
+    left join mock_interview_session s
+        on s.mock_interview_request_id = p_request.mock_interview_request_id
+    where ie.user_id = p_request.interviewee_user_id;
+$$;

--- a/database/migrations/functions/mock_interviews/respond_mock_interview_request.sql
+++ b/database/migrations/functions/mock_interviews/respond_mock_interview_request.sql
@@ -1,0 +1,88 @@
+create or replace function respond_mock_interview_request(
+    p_actor_user_id uuid,
+    p_request_id uuid,
+    p_action text,
+    p_meeting_url text default null
+)
+returns jsonb language plpgsql as $$
+declare
+    v_request mock_interview_request;
+    v_session mock_interview_session;
+begin
+    select * into v_request
+    from mock_interview_request
+    where mock_interview_request_id = p_request_id
+    for update;
+
+    if v_request.mock_interview_request_id is null then
+        raise exception 'request not found';
+    end if;
+
+    if p_action = 'accept' then
+        if v_request.interviewer_user_id <> p_actor_user_id then
+            raise exception 'only the interviewer can accept';
+        end if;
+        if v_request.status <> 'pending' then
+            raise exception 'request is not pending';
+        end if;
+
+        update mock_interview_request
+        set status = 'accepted',
+            responded_at = current_timestamp
+        where mock_interview_request_id = p_request_id
+        returning * into v_request;
+
+        insert into mock_interview_session (
+            mock_interview_request_id,
+            meeting_url,
+            status
+        ) values (
+            p_request_id,
+            nullif(trim(p_meeting_url), ''),
+            'scheduled'
+        )
+        returning * into v_session;
+
+        return jsonb_build_object(
+            'request', mock_interview_request_json(v_request),
+            'session_id', v_session.mock_interview_session_id
+        );
+    elsif p_action = 'decline' then
+        if v_request.interviewer_user_id <> p_actor_user_id then
+            raise exception 'only the interviewer can decline';
+        end if;
+        if v_request.status <> 'pending' then
+            raise exception 'request is not pending';
+        end if;
+
+        update mock_interview_request
+        set status = 'declined',
+            responded_at = current_timestamp
+        where mock_interview_request_id = p_request_id
+        returning * into v_request;
+
+        return jsonb_build_object('request', mock_interview_request_json(v_request));
+    elsif p_action = 'cancel' then
+        if v_request.interviewee_user_id <> p_actor_user_id then
+            raise exception 'only the interviewee can cancel';
+        end if;
+        if v_request.status not in ('pending', 'accepted') then
+            raise exception 'request cannot be cancelled';
+        end if;
+
+        update mock_interview_request
+        set status = 'cancelled',
+            responded_at = current_timestamp
+        where mock_interview_request_id = p_request_id
+        returning * into v_request;
+
+        update mock_interview_session
+        set status = 'cancelled'
+        where mock_interview_request_id = p_request_id;
+
+        return jsonb_build_object('request', mock_interview_request_json(v_request));
+    else
+        raise exception 'unsupported action';
+    end if;
+end;
+$$;

--- a/database/migrations/functions/mock_interviews/search_mock_interview_matches.sql
+++ b/database/migrations/functions/mock_interviews/search_mock_interview_matches.sql
@@ -1,0 +1,88 @@
+create or replace function search_mock_interview_matches(
+    p_user_id uuid,
+    p_filters jsonb default '{}'::jsonb
+)
+returns jsonb language plpgsql stable as $$
+declare
+    v_limit int := least(coalesce((p_filters->>'limit')::int, 5), 10);
+    v_interview_type text := nullif(trim(p_filters->>'interview_type'), '');
+    v_viewer mock_interview_profile;
+    v_matches jsonb;
+begin
+    select * into v_viewer
+    from mock_interview_profile
+    where user_id = p_user_id
+    and enabled = true;
+
+    if v_viewer.user_id is null then
+        return jsonb_build_object('matches', '[]'::jsonb, 'total', 0);
+    end if;
+
+    with candidates as (
+        select
+            p.*,
+            u.username,
+            (
+                case when p.timezone_region = v_viewer.timezone_region then 30 else 0 end
+                + case
+                    when v_interview_type is not null
+                        and v_interview_type = any (p.interview_types) then 25
+                    when v_interview_type is null
+                        and p.interview_types && v_viewer.interview_types then 20
+                    else 0
+                  end
+                + case
+                    when p.target_company_types && v_viewer.target_company_types then 15
+                    else 0
+                  end
+                + case
+                    when mock_interview_seniority_rank(p.seniority)
+                        >= mock_interview_seniority_rank(v_viewer.seniority) then 20
+                    else 0
+                  end
+                + least(coalesce(p.reputation_score, 0), 5)::int * 2
+                + case when p.interviewer_badge then 5 else 0 end
+            )::int as match_score
+        from mock_interview_profile p
+        join "user" u on u.user_id = p.user_id
+        where p.enabled = true
+        and p.user_id <> p_user_id
+        and p.role_intent in ('interviewer', 'both')
+        and mock_interview_seniority_rank(p.seniority)
+            >= mock_interview_seniority_rank(v_viewer.seniority)
+        and (
+            v_interview_type is null
+            or v_interview_type = any (p.interview_types)
+        )
+        and not exists (
+            select 1
+            from mock_interview_request r
+            where r.interviewee_user_id = p_user_id
+            and r.interviewer_user_id = p.user_id
+            and r.status in ('pending', 'accepted')
+        )
+    ),
+    ranked as (
+        select *
+        from candidates
+        where match_score > 0
+        order by match_score desc, reputation_score desc, completed_sessions desc
+        limit v_limit
+    )
+    select coalesce(
+        jsonb_agg(
+            mock_interview_profile_json(ranked)
+            || jsonb_build_object('match_score', ranked.match_score)
+            order by ranked.match_score desc
+        ),
+        '[]'::jsonb
+    )
+    into v_matches
+    from ranked;
+
+    return jsonb_build_object(
+        'matches', coalesce(v_matches, '[]'::jsonb),
+        'total', coalesce(jsonb_array_length(v_matches), 0)
+    );
+end;
+$$;

--- a/database/migrations/functions/mock_interviews/upsert_mock_interview_profile.sql
+++ b/database/migrations/functions/mock_interviews/upsert_mock_interview_profile.sql
@@ -1,0 +1,67 @@
+create or replace function upsert_mock_interview_profile(
+    p_user_id uuid,
+    p_input jsonb
+)
+returns jsonb language plpgsql as $$
+declare
+    v_profile mock_interview_profile;
+    v_interview_types text[];
+    v_target_company_types text[];
+begin
+    v_interview_types := coalesce(
+        array(
+            select jsonb_array_elements_text(coalesce(p_input->'interview_types', '[]'::jsonb))
+        ),
+        '{}'::text[]
+    );
+    v_target_company_types := coalesce(
+        array(
+            select jsonb_array_elements_text(coalesce(p_input->'target_company_types', '[]'::jsonb))
+        ),
+        '{}'::text[]
+    );
+
+    insert into mock_interview_profile (
+        user_id,
+        role_intent,
+        timezone_region,
+        seniority,
+        interview_types,
+        target_company_types,
+        availability_slots,
+        linkedin_url,
+        github_url,
+        resume_url,
+        enabled,
+        updated_at
+    ) values (
+        p_user_id,
+        p_input->>'role_intent',
+        p_input->>'timezone_region',
+        p_input->>'seniority',
+        v_interview_types,
+        v_target_company_types,
+        coalesce(p_input->'availability_slots', '[]'::jsonb),
+        nullif(trim(p_input->>'linkedin_url'), ''),
+        nullif(trim(p_input->>'github_url'), ''),
+        nullif(trim(p_input->>'resume_url'), ''),
+        coalesce((p_input->>'enabled')::boolean, true),
+        current_timestamp
+    )
+    on conflict (user_id) do update set
+        role_intent = excluded.role_intent,
+        timezone_region = excluded.timezone_region,
+        seniority = excluded.seniority,
+        interview_types = excluded.interview_types,
+        target_company_types = excluded.target_company_types,
+        availability_slots = excluded.availability_slots,
+        linkedin_url = excluded.linkedin_url,
+        github_url = excluded.github_url,
+        resume_url = excluded.resume_url,
+        enabled = excluded.enabled,
+        updated_at = current_timestamp
+    returning * into v_profile;
+
+    return mock_interview_profile_json(v_profile);
+end;
+$$;

--- a/database/migrations/schema/0038_mock_interviews.sql
+++ b/database/migrations/schema/0038_mock_interviews.sql
@@ -1,0 +1,91 @@
+-- Mock interview practice matching for GOUP members.
+
+create table if not exists mock_interview_profile (
+    user_id uuid primary key references "user" (user_id) on delete cascade,
+    role_intent text not null check (role_intent in ('interviewee', 'interviewer', 'both')),
+    timezone_region text not null check (
+        timezone_region in ('aze', 'eu', 'usa_canada', 'asia', 'other')
+    ),
+    seniority text not null check (
+        seniority in ('junior', 'mid', 'senior', 'staff_plus')
+    ),
+    interview_types text[] default '{}'::text[] not null,
+    target_company_types text[] default '{}'::text[] not null,
+    availability_slots jsonb default '[]'::jsonb not null,
+    linkedin_url text,
+    github_url text,
+    resume_url text,
+    enabled boolean default true not null,
+    reputation_score numeric(4, 2) default 0 not null,
+    completed_sessions integer default 0 not null,
+    interviewer_badge boolean default false not null,
+    created_at timestamp with time zone default current_timestamp not null,
+    updated_at timestamp with time zone
+);
+
+create index if not exists mock_interview_profile_enabled_role_intent_idx
+on mock_interview_profile (enabled, role_intent)
+where enabled = true;
+
+create index if not exists mock_interview_profile_interview_types_idx
+on mock_interview_profile using gin (interview_types);
+
+create index if not exists mock_interview_profile_target_company_types_idx
+on mock_interview_profile using gin (target_company_types);
+
+create table if not exists mock_interview_request (
+    mock_interview_request_id uuid default gen_random_uuid() primary key,
+    interviewee_user_id uuid not null references "user" (user_id) on delete cascade,
+    interviewer_user_id uuid not null references "user" (user_id) on delete cascade,
+    interview_type text not null check (btrim(interview_type) <> ''),
+    message text,
+    status text not null default 'pending' check (
+        status in ('pending', 'accepted', 'declined', 'cancelled', 'completed', 'no_show')
+    ),
+    created_at timestamp with time zone default current_timestamp not null,
+    responded_at timestamp with time zone,
+    check (interviewee_user_id <> interviewer_user_id)
+);
+
+create index if not exists mock_interview_request_interviewee_created_at_idx
+on mock_interview_request (interviewee_user_id, created_at desc);
+
+create index if not exists mock_interview_request_interviewer_status_created_at_idx
+on mock_interview_request (interviewer_user_id, status, created_at desc);
+
+create table if not exists mock_interview_session (
+    mock_interview_session_id uuid default gen_random_uuid() primary key,
+    mock_interview_request_id uuid not null unique references mock_interview_request (
+        mock_interview_request_id
+    ) on delete cascade,
+    meeting_url text,
+    scheduled_at timestamp with time zone,
+    status text not null default 'scheduled' check (
+        status in ('scheduled', 'completed', 'cancelled')
+    ),
+    created_at timestamp with time zone default current_timestamp not null,
+    completed_at timestamp with time zone
+);
+
+create table if not exists mock_interview_feedback (
+    mock_interview_feedback_id uuid default gen_random_uuid() primary key,
+    mock_interview_session_id uuid not null references mock_interview_session (
+        mock_interview_session_id
+    ) on delete cascade,
+    reviewer_user_id uuid not null references "user" (user_id) on delete cascade,
+    reviewee_user_id uuid not null references "user" (user_id) on delete cascade,
+    reviewer_role text not null check (reviewer_role in ('interviewer', 'interviewee')),
+    communication smallint check (communication between 1 and 5),
+    technical_depth smallint check (technical_depth between 1 and 5),
+    problem_solving smallint check (problem_solving between 1 and 5),
+    role_readiness smallint check (role_readiness between 1 and 5),
+    helpfulness smallint check (helpfulness between 1 and 5),
+    feedback_quality smallint check (feedback_quality between 1 and 5),
+    would_recommend boolean,
+    suggested_next_steps text,
+    created_at timestamp with time zone default current_timestamp not null,
+    unique (mock_interview_session_id, reviewer_user_id)
+);
+
+create index if not exists mock_interview_feedback_reviewee_created_at_idx
+on mock_interview_feedback (reviewee_user_id, created_at desc);

--- a/ocg-server/src/db.rs
+++ b/ocg-server/src/db.rs
@@ -11,7 +11,8 @@ use tokio_postgres::types::{FromSql, Json, ToSql};
 use crate::db::{
     activity_tracker::DBActivityTracker, alliance::DBAlliance, auth::DBAuth, common::DBCommon,
     dashboard::DBDashboard, event::DBEvent, group::DBGroup, images::DBImages, jobs::DBJobs,
-    landscape::DBLandscape, meetings::DBMeetings, notifications::DBNotifications,
+    landscape::DBLandscape, meetings::DBMeetings, mock_interviews::DBMockInterviews,
+    notifications::DBNotifications,
     payments::DBPayments, site::DBSite,
 };
 
@@ -49,6 +50,9 @@ pub(crate) mod jobs;
 /// Module containing database functionality for landscape entries.
 pub(crate) mod landscape;
 
+/// Module containing database functionality for mock interviews.
+pub(crate) mod mock_interviews;
+
 /// Module containing database functionality for managing meetings.
 pub(crate) mod meetings;
 
@@ -80,6 +84,7 @@ pub(crate) trait DBOperations:
     + DBImages
     + DBJobs
     + DBLandscape
+    + DBMockInterviews
     + DBMeetings
     + DBNotifications
     + DBPayments
@@ -100,6 +105,7 @@ impl<T> DBOperations for T where
         + DBImages
         + DBJobs
         + DBLandscape
+        + DBMockInterviews
         + DBMeetings
         + DBNotifications
         + DBPayments

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -1099,6 +1099,57 @@ mock! {
     }
 
     #[async_trait]
+    impl crate::db::mock_interviews::DBMockInterviews for DB {
+        async fn get_mock_interview_profile(
+            &self,
+            user_id: Uuid,
+        ) -> Result<Option<crate::types::mock_interviews::MockInterviewProfile>>;
+        async fn upsert_mock_interview_profile(
+            &self,
+            user_id: Uuid,
+            input: &crate::types::mock_interviews::MockInterviewProfileInput,
+        ) -> Result<crate::types::mock_interviews::MockInterviewProfile>;
+        async fn search_mock_interview_matches(
+            &self,
+            user_id: Uuid,
+            filters: &crate::types::mock_interviews::MockInterviewMatchFilters,
+        ) -> Result<crate::types::mock_interviews::MockInterviewMatchesOutput>;
+        async fn list_mock_interview_requests(
+            &self,
+            user_id: Uuid,
+        ) -> Result<Vec<crate::types::mock_interviews::MockInterviewRequest>>;
+        async fn add_mock_interview_request(
+            &self,
+            user_id: Uuid,
+            input: &crate::types::mock_interviews::MockInterviewRequestInput,
+        ) -> Result<crate::types::mock_interviews::MockInterviewRequest>;
+        async fn respond_mock_interview_request(
+            &self,
+            user_id: Uuid,
+            request_id: Uuid,
+            action: &str,
+            meeting_url: Option<&str>,
+        ) -> Result<Option<Uuid>>;
+        async fn get_mock_interview_session(
+            &self,
+            user_id: Uuid,
+            session_id: Uuid,
+        ) -> Result<Option<crate::types::mock_interviews::MockInterviewSession>>;
+        async fn add_mock_interview_interviewer_feedback(
+            &self,
+            user_id: Uuid,
+            session_id: Uuid,
+            input: &crate::types::mock_interviews::MockInterviewInterviewerFeedbackInput,
+        ) -> Result<()>;
+        async fn add_mock_interview_interviewee_feedback(
+            &self,
+            user_id: Uuid,
+            session_id: Uuid,
+            input: &crate::types::mock_interviews::MockInterviewIntervieweeFeedbackInput,
+        ) -> Result<()>;
+    }
+
+    #[async_trait]
     impl crate::db::landscape::DBLandscape for DB {
         async fn search_landscape_entries(
             &self,

--- a/ocg-server/src/db/mock_interviews.rs
+++ b/ocg-server/src/db/mock_interviews.rs
@@ -1,0 +1,212 @@
+//! Database operations for mock interviews.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_postgres::types::Json;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::PgExecutor,
+    types::mock_interviews::{
+        MockInterviewIntervieweeFeedbackInput, MockInterviewInterviewerFeedbackInput,
+        MockInterviewMatchFilters, MockInterviewMatchesOutput, MockInterviewProfile,
+        MockInterviewProfileInput, MockInterviewRequest, MockInterviewRequestInput,
+        MockInterviewSession,
+    },
+};
+
+/// Database operations for mock interview practice.
+#[async_trait]
+pub(crate) trait DBMockInterviews {
+    /// Get a user's mock interview profile.
+    async fn get_mock_interview_profile(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Option<MockInterviewProfile>>;
+
+    /// Create or update a mock interview profile.
+    async fn upsert_mock_interview_profile(
+        &self,
+        user_id: Uuid,
+        input: &MockInterviewProfileInput,
+    ) -> Result<MockInterviewProfile>;
+
+    /// Search suggested interviewer matches.
+    async fn search_mock_interview_matches(
+        &self,
+        user_id: Uuid,
+        filters: &MockInterviewMatchFilters,
+    ) -> Result<MockInterviewMatchesOutput>;
+
+    /// List requests involving the user.
+    async fn list_mock_interview_requests(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<MockInterviewRequest>>;
+
+    /// Create a mock interview request.
+    async fn add_mock_interview_request(
+        &self,
+        user_id: Uuid,
+        input: &MockInterviewRequestInput,
+    ) -> Result<MockInterviewRequest>;
+
+    /// Accept, decline, or cancel a request.
+    async fn respond_mock_interview_request(
+        &self,
+        user_id: Uuid,
+        request_id: Uuid,
+        action: &str,
+        meeting_url: Option<&str>,
+    ) -> Result<Option<Uuid>>;
+
+    /// Get a session the user participates in.
+    async fn get_mock_interview_session(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> Result<Option<MockInterviewSession>>;
+
+    /// Submit interviewer feedback.
+    async fn add_mock_interview_interviewer_feedback(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        input: &MockInterviewInterviewerFeedbackInput,
+    ) -> Result<()>;
+
+    /// Submit interviewee feedback.
+    async fn add_mock_interview_interviewee_feedback(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        input: &MockInterviewIntervieweeFeedbackInput,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+impl<T> DBMockInterviews for T
+where
+    T: PgExecutor + Send + Sync,
+{
+    #[instrument(skip(self), err)]
+    async fn get_mock_interview_profile(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Option<MockInterviewProfile>> {
+        self.fetch_json_opt("select get_mock_interview_profile($1::uuid)", &[&user_id])
+            .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn upsert_mock_interview_profile(
+        &self,
+        user_id: Uuid,
+        input: &MockInterviewProfileInput,
+    ) -> Result<MockInterviewProfile> {
+        let payload = crate::types::mock_interviews::profile_input_to_json(input);
+        self.fetch_json_one(
+            "select upsert_mock_interview_profile($1::uuid, $2::jsonb)",
+            &[&user_id, &Json(payload)],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, filters), err)]
+    async fn search_mock_interview_matches(
+        &self,
+        user_id: Uuid,
+        filters: &MockInterviewMatchFilters,
+    ) -> Result<MockInterviewMatchesOutput> {
+        self.fetch_json_one(
+            "select search_mock_interview_matches($1::uuid, $2::jsonb)",
+            &[&user_id, &Json(filters)],
+        )
+        .await
+    }
+
+    #[instrument(skip(self), err)]
+    async fn list_mock_interview_requests(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Vec<MockInterviewRequest>> {
+        self.fetch_json_one("select list_mock_interview_requests($1::uuid)", &[&user_id])
+            .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_mock_interview_request(
+        &self,
+        user_id: Uuid,
+        input: &MockInterviewRequestInput,
+    ) -> Result<MockInterviewRequest> {
+        self.fetch_json_one(
+            "select add_mock_interview_request($1::uuid, $2::jsonb)",
+            &[&user_id, &Json(input)],
+        )
+        .await
+    }
+
+    #[instrument(skip(self), err)]
+    async fn respond_mock_interview_request(
+        &self,
+        user_id: Uuid,
+        request_id: Uuid,
+        action: &str,
+        meeting_url: Option<&str>,
+    ) -> Result<Option<Uuid>> {
+        let output: serde_json::Value = self.fetch_json_one(
+            "select respond_mock_interview_request($1::uuid, $2::uuid, $3::text, $4::text)",
+            &[&user_id, &request_id, &action, &meeting_url],
+        )
+        .await?;
+        Ok(output
+            .get("session_id")
+            .and_then(|value| value.as_str())
+            .and_then(|value| Uuid::parse_str(value).ok()))
+    }
+
+    #[instrument(skip(self), err)]
+    async fn get_mock_interview_session(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+    ) -> Result<Option<MockInterviewSession>> {
+        self.fetch_json_opt(
+            "select get_mock_interview_session($1::uuid, $2::uuid)",
+            &[&user_id, &session_id],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_mock_interview_interviewer_feedback(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        input: &MockInterviewInterviewerFeedbackInput,
+    ) -> Result<()> {
+        self.execute(
+            "select add_mock_interview_feedback($1::uuid, $2::uuid, $3::jsonb)",
+            &[&user_id, &session_id, &Json(input)],
+        )
+        .await?;
+        Ok(())
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_mock_interview_interviewee_feedback(
+        &self,
+        user_id: Uuid,
+        session_id: Uuid,
+        input: &MockInterviewIntervieweeFeedbackInput,
+    ) -> Result<()> {
+        self.execute(
+            "select add_mock_interview_feedback($1::uuid, $2::uuid, $3::jsonb)",
+            &[&user_id, &session_id, &Json(input)],
+        )
+        .await?;
+        Ok(())
+    }
+}

--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -6,6 +6,7 @@ pub(crate) mod explore;
 pub(crate) mod home;
 pub(crate) mod jobs;
 pub(crate) mod landscape;
+pub(crate) mod mock_interviews;
 pub(crate) mod not_found;
 pub(crate) mod privacy;
 pub(crate) mod profile;

--- a/ocg-server/src/handlers/site/mock_interviews.rs
+++ b/ocg-server/src/handlers/site/mock_interviews.rs
@@ -1,0 +1,275 @@
+//! HTTP handlers for mock interview practice pages.
+
+use askama::Template;
+use axum::{
+    extract::{Path, RawQuery, State},
+    http::{StatusCode, header::CACHE_CONTROL},
+    response::{Html, IntoResponse, Redirect},
+};
+use axum_messages::Messages;
+use garde::Validate;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    auth::AuthSession,
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, ValidatedForm},
+    },
+    router::{CACHE_CONTROL_PRIVATE_NO_STORE, serde_qs_config},
+    templates::{PageId, auth::User, site::mock_interviews},
+    types::mock_interviews::{
+        INTERVIEW_TYPES, MockInterviewIntervieweeFeedbackInput,
+        MockInterviewInterviewerFeedbackInput, MockInterviewMatchFilters, MockInterviewProfileInput,
+        MockInterviewRequestInput, MockInterviewRespondInput, TARGET_COMPANY_TYPES,
+    },
+};
+
+const BASE_URL: &str = "/mock-interviews";
+
+/// Render the mock interviews landing page.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    auth_session: AuthSession,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let site_settings = db.get_site_settings().await?;
+    let user = User::from_session(auth_session.clone()).await?;
+    let profile = if let Some(session_user) = auth_session.user.as_ref() {
+        db.get_mock_interview_profile(session_user.user_id).await?
+    } else {
+        None
+    };
+
+    let template = mock_interviews::Page {
+        page_id: PageId::SiteMockInterviews,
+        path: BASE_URL.to_string(),
+        site_settings,
+        user,
+        profile,
+    };
+
+    Ok((
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
+        Html(template.render()?),
+    ))
+}
+
+/// Render onboarding/profile setup.
+#[instrument(skip_all, err)]
+pub(crate) async fn onboarding_page(
+    auth_session: AuthSession,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let site_settings = db.get_site_settings().await?;
+    let auth_user = User::from_session(auth_session).await?;
+    let profile = db.get_mock_interview_profile(user.user_id).await?;
+
+    let template = mock_interviews::OnboardingPage {
+        page_id: PageId::SiteMockInterviews,
+        path: format!("{BASE_URL}/onboarding"),
+        site_settings,
+        user: auth_user,
+        profile,
+        interview_types: INTERVIEW_TYPES,
+        target_company_types: TARGET_COMPANY_TYPES,
+    };
+
+    Ok((
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
+        Html(template.render()?),
+    ))
+}
+
+/// Save onboarding profile.
+#[instrument(skip_all, err)]
+pub(crate) async fn save_onboarding(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<MockInterviewProfileInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.upsert_mock_interview_profile(user.user_id, &input).await?;
+    messages.success("Mock interview profile saved.");
+    Ok(Redirect::to(&format!("{BASE_URL}/matches")))
+}
+
+/// Render suggested matches.
+#[instrument(skip_all, err)]
+pub(crate) async fn matches_page(
+    auth_session: AuthSession,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, HandlerError> {
+    let site_settings = db.get_site_settings().await?;
+    let auth_user = User::from_session(auth_session).await?;
+
+    let filters = parse_match_filters(raw_query.as_deref().unwrap_or_default())?;
+    let profile = db.get_mock_interview_profile(user.user_id).await?;
+    let output = db
+        .search_mock_interview_matches(user.user_id, &filters)
+        .await?;
+
+    let template = mock_interviews::MatchesPage {
+        page_id: PageId::SiteMockInterviews,
+        path: format!("{BASE_URL}/matches"),
+        site_settings,
+        user: auth_user,
+        profile,
+        filters,
+        matches: output.matches,
+        total: output.total,
+        interview_types: INTERVIEW_TYPES,
+    };
+
+    Ok((
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
+        Html(template.render()?),
+    ))
+}
+
+/// Render requests dashboard.
+#[instrument(skip_all, err)]
+pub(crate) async fn requests_page(
+    auth_session: AuthSession,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let site_settings = db.get_site_settings().await?;
+    let auth_user = User::from_session(auth_session).await?;
+    let requests = db.list_mock_interview_requests(user.user_id).await?;
+
+    let template = mock_interviews::RequestsPage {
+        page_id: PageId::SiteMockInterviews,
+        path: format!("{BASE_URL}/requests"),
+        site_settings,
+        user: auth_user,
+        current_user_id: user.user_id,
+        requests,
+    };
+
+    Ok((
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
+        Html(template.render()?),
+    ))
+}
+
+/// Create a mock interview request.
+#[instrument(skip_all, err)]
+pub(crate) async fn create_request(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<MockInterviewRequestInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_mock_interview_request(user.user_id, &input).await?;
+    messages.success("Mock interview request sent.");
+    Ok(Redirect::to(&format!("{BASE_URL}/requests")))
+}
+
+/// Accept, decline, or cancel a request.
+#[instrument(skip_all, err)]
+pub(crate) async fn respond_request(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(request_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<MockInterviewRespondInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let session_id = db
+        .respond_mock_interview_request(
+            user.user_id,
+            request_id,
+            &input.action,
+            input.meeting_url.as_deref(),
+        )
+        .await?;
+
+    match input.action.as_str() {
+        "accept" => {
+            messages.success("Mock interview accepted.");
+            if let Some(session_id) = session_id {
+                return Ok(Redirect::to(&format!("{BASE_URL}/session/{session_id}")));
+            }
+        }
+        "decline" => messages.success("Request declined."),
+        "cancel" => messages.success("Request cancelled."),
+        _ => {}
+    }
+
+    Ok(Redirect::to(&format!("{BASE_URL}/requests")))
+}
+
+/// Render a session page.
+#[instrument(skip_all, err)]
+pub(crate) async fn session_page(
+    auth_session: AuthSession,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(session_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let site_settings = db.get_site_settings().await?;
+    let auth_user = User::from_session(auth_session).await?;
+    let session = db
+        .get_mock_interview_session(user.user_id, session_id)
+        .await?
+        .ok_or(HandlerError::NotFound)?;
+
+    let template = mock_interviews::SessionPage {
+        page_id: PageId::SiteMockInterviews,
+        path: format!("{BASE_URL}/session/{session_id}"),
+        site_settings,
+        user: auth_user,
+        current_user_id: user.user_id,
+        session,
+    };
+
+    Ok((
+        [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
+        Html(template.render()?),
+    ))
+}
+
+/// Submit session feedback.
+#[instrument(skip_all, err)]
+pub(crate) async fn submit_feedback(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(session_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<MockInterviewInterviewerFeedbackInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_mock_interview_interviewer_feedback(user.user_id, session_id, &input)
+        .await?;
+    messages.success("Feedback submitted.");
+    Ok(Redirect::to(&format!("{BASE_URL}/session/{session_id}")))
+}
+
+/// Submit interviewee feedback.
+#[instrument(skip_all, err)]
+pub(crate) async fn submit_interviewee_feedback(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(session_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<MockInterviewIntervieweeFeedbackInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_mock_interview_interviewee_feedback(user.user_id, session_id, &input)
+        .await?;
+    messages.success("Feedback submitted.");
+    Ok(Redirect::to(&format!("{BASE_URL}/session/{session_id}")))
+}
+
+fn parse_match_filters(raw_query: &str) -> Result<MockInterviewMatchFilters, HandlerError> {
+    let filters: MockInterviewMatchFilters = if raw_query.is_empty() {
+        MockInterviewMatchFilters::default()
+    } else {
+        serde_qs_config().deserialize_str(raw_query)?
+    };
+    filters.validate()?;
+    Ok(filters)
+}

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -233,6 +233,32 @@ pub(crate) async fn setup(
         )
         .route("/jobs/{job_id}/apply", post(site::jobs::apply))
         .route(
+            "/mock-interviews/onboarding",
+            get(site::mock_interviews::onboarding_page)
+                .post(site::mock_interviews::save_onboarding),
+        )
+        .route("/mock-interviews/matches", get(site::mock_interviews::matches_page))
+        .route(
+            "/mock-interviews/requests",
+            get(site::mock_interviews::requests_page).post(site::mock_interviews::create_request),
+        )
+        .route(
+            "/mock-interviews/requests/{request_id}",
+            post(site::mock_interviews::respond_request),
+        )
+        .route(
+            "/mock-interviews/session/{session_id}",
+            get(site::mock_interviews::session_page),
+        )
+        .route(
+            "/mock-interviews/session/{session_id}/feedback/interviewer",
+            post(site::mock_interviews::submit_feedback),
+        )
+        .route(
+            "/mock-interviews/session/{session_id}/feedback/interviewee",
+            post(site::mock_interviews::submit_interviewee_feedback),
+        )
+        .route(
             "/profiles/{username}/mentorship-requests",
             post(site::profile::request_mentorship),
         )
@@ -320,6 +346,7 @@ pub(crate) async fn setup(
         .route("/docs/{*doc_path}", get(site::docs::page))
         .route("/jobs", get(site::jobs::page))
         .route("/jobs/{slug}", get(site::jobs::details))
+        .route("/mock-interviews", get(site::mock_interviews::page))
         .route("/landscape", get(site::landscape::page))
         .route("/privacy", get(site::privacy::page))
         .route("/profiles/{username}", get(site::profile::page))

--- a/ocg-server/src/templates.rs
+++ b/ocg-server/src/templates.rs
@@ -43,6 +43,7 @@ pub(crate) enum PageId {
     SiteExplore,
     SiteHome,
     SiteJobs,
+    SiteMockInterviews,
     SiteLandscape,
     SiteNotFound,
     SitePrivacy,

--- a/ocg-server/src/templates/site.rs
+++ b/ocg-server/src/templates/site.rs
@@ -12,6 +12,8 @@ pub(crate) mod home;
 pub(crate) mod jobs;
 /// Templates for the landscape page.
 pub(crate) mod landscape;
+/// Templates for mock interview pages.
+pub(crate) mod mock_interviews;
 /// Templates for the not found page.
 pub(crate) mod not_found;
 /// Templates for the privacy policy page.

--- a/ocg-server/src/templates/site/mock_interviews.rs
+++ b/ocg-server/src/templates/site/mock_interviews.rs
@@ -1,0 +1,129 @@
+//! Templates for mock interview practice pages.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::{
+    templates::{PageId, auth::User},
+    types::{
+        mock_interviews::{
+            MockInterviewMatchFilters, MockInterviewProfile, MockInterviewRequest,
+            MockInterviewSession,
+        },
+        site::SiteSettings,
+    },
+};
+
+/// Landing page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/mock_interviews/page.html")]
+pub(crate) struct Page {
+    pub page_id: PageId,
+    pub path: String,
+    pub site_settings: SiteSettings,
+    pub user: User,
+    pub profile: Option<MockInterviewProfile>,
+}
+
+/// Onboarding page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/mock_interviews/onboarding.html")]
+pub(crate) struct OnboardingPage {
+    pub page_id: PageId,
+    pub path: String,
+    pub site_settings: SiteSettings,
+    pub user: User,
+    pub profile: Option<MockInterviewProfile>,
+    pub interview_types: &'static [&'static str],
+    pub target_company_types: &'static [&'static str],
+}
+
+impl OnboardingPage {
+    pub(crate) fn profile_role_intent(&self) -> &str {
+        self.profile.as_ref().map_or("interviewee", |profile| match profile.role_intent {
+            crate::types::mock_interviews::RoleIntent::Interviewee => "interviewee",
+            crate::types::mock_interviews::RoleIntent::Interviewer => "interviewer",
+            crate::types::mock_interviews::RoleIntent::Both => "both",
+        })
+    }
+
+    pub(crate) fn profile_timezone_region(&self) -> &str {
+        self.profile.as_ref().map_or("usa_canada", |profile| match profile.timezone_region {
+            crate::types::mock_interviews::TimezoneRegion::Aze => "aze",
+            crate::types::mock_interviews::TimezoneRegion::Eu => "eu",
+            crate::types::mock_interviews::TimezoneRegion::UsaCanada => "usa_canada",
+            crate::types::mock_interviews::TimezoneRegion::Asia => "asia",
+            crate::types::mock_interviews::TimezoneRegion::Other => "other",
+        })
+    }
+
+    pub(crate) fn profile_seniority(&self) -> &str {
+        self.profile.as_ref().map_or("mid", |profile| match profile.seniority {
+            crate::types::mock_interviews::Seniority::Junior => "junior",
+            crate::types::mock_interviews::Seniority::Mid => "mid",
+            crate::types::mock_interviews::Seniority::Senior => "senior",
+            crate::types::mock_interviews::Seniority::StaffPlus => "staff_plus",
+        })
+    }
+
+    pub(crate) fn profile_interview_types_csv(&self) -> String {
+        self.profile
+            .as_ref()
+            .map(|profile| profile.interview_types.join(", "))
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn profile_target_company_types_csv(&self) -> String {
+        self.profile
+            .as_ref()
+            .map(|profile| profile.target_company_types.join(", "))
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn profile_availability_slots_json(&self) -> String {
+        self.profile
+            .as_ref()
+            .map(|profile| profile.availability_slots.to_string())
+            .unwrap_or_else(|| "[]".to_string())
+    }
+}
+
+/// Matches page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/mock_interviews/matches.html")]
+pub(crate) struct MatchesPage {
+    pub page_id: PageId,
+    pub path: String,
+    pub site_settings: SiteSettings,
+    pub user: User,
+    pub profile: Option<MockInterviewProfile>,
+    pub filters: MockInterviewMatchFilters,
+    pub matches: Vec<MockInterviewProfile>,
+    pub total: usize,
+    pub interview_types: &'static [&'static str],
+}
+
+/// Requests page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/mock_interviews/requests.html")]
+pub(crate) struct RequestsPage {
+    pub page_id: PageId,
+    pub path: String,
+    pub site_settings: SiteSettings,
+    pub user: User,
+    pub current_user_id: Uuid,
+    pub requests: Vec<MockInterviewRequest>,
+}
+
+/// Session page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "site/mock_interviews/session.html")]
+pub(crate) struct SessionPage {
+    pub page_id: PageId,
+    pub path: String,
+    pub site_settings: SiteSettings,
+    pub user: User,
+    pub current_user_id: Uuid,
+    pub session: MockInterviewSession,
+}

--- a/ocg-server/src/types.rs
+++ b/ocg-server/src/types.rs
@@ -5,6 +5,7 @@ pub mod event;
 pub mod group;
 pub(crate) mod jobs;
 pub(crate) mod landscape;
+pub(crate) mod mock_interviews;
 pub mod location;
 pub mod pagination;
 pub mod payments;

--- a/ocg-server/src/types/mock_interviews.rs
+++ b/ocg-server/src/types/mock_interviews.rs
@@ -1,0 +1,342 @@
+//! Mock interview practice types.
+
+use chrono::{DateTime, Utc};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use serde_with::skip_serializing_none;
+use uuid::Uuid;
+
+use crate::validation::{
+    MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_M, trimmed_non_empty, trimmed_non_empty_opt,
+};
+
+/// User role intent for mock interviews.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RoleIntent {
+    Interviewee,
+    Interviewer,
+    Both,
+}
+
+/// Timezone region bucket.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum TimezoneRegion {
+    Aze,
+    Eu,
+    #[serde(rename = "usa_canada")]
+    UsaCanada,
+    Asia,
+    Other,
+}
+
+/// Seniority level.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Seniority {
+    Junior,
+    Mid,
+    Senior,
+    #[serde(rename = "staff_plus")]
+    StaffPlus,
+}
+
+/// Supported interview types.
+pub(crate) const INTERVIEW_TYPES: &[&str] = &[
+    "swe",
+    "ai_ml",
+    "pm",
+    "devops_cloud",
+    "startup_cofounder",
+    "behavioral",
+    "other",
+];
+
+/// Supported target company types.
+pub(crate) const TARGET_COMPANY_TYPES: &[&str] = &[
+    "ai_labs_faang",
+    "ai_startup",
+    "enterprise",
+    "remote_global",
+];
+
+/// Onboarding/profile form input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct MockInterviewProfileInput {
+    #[garde(skip)]
+    pub role_intent: RoleIntent,
+    #[garde(skip)]
+    pub timezone_region: TimezoneRegion,
+    #[garde(skip)]
+    pub seniority: Seniority,
+    #[garde(length(max = 500))]
+    pub interview_types: Option<String>,
+    #[garde(length(max = 500))]
+    pub target_company_types: Option<String>,
+    #[garde(length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub availability_slots: Option<String>,
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub linkedin_url: Option<String>,
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub github_url: Option<String>,
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub resume_url: Option<String>,
+    #[garde(skip)]
+    pub enabled: Option<bool>,
+}
+
+/// Parse comma-separated values from onboarding forms.
+pub(crate) fn parse_csv_values(input: Option<&str>) -> Vec<String> {
+    input
+        .unwrap_or_default()
+        .split(',')
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .take(12)
+        .map(str::to_owned)
+        .collect()
+}
+
+/// Build JSON payload for profile upsert SQL function.
+pub(crate) fn profile_input_to_json(input: &MockInterviewProfileInput) -> serde_json::Value {
+    let availability_slots = input
+        .availability_slots
+        .as_deref()
+        .and_then(|raw| serde_json::from_str(raw).ok())
+        .unwrap_or(serde_json::Value::Array(vec![]));
+
+    serde_json::json!({
+        "role_intent": input.role_intent,
+        "timezone_region": input.timezone_region,
+        "seniority": input.seniority,
+        "interview_types": parse_csv_values(input.interview_types.as_deref()),
+        "target_company_types": parse_csv_values(input.target_company_types.as_deref()),
+        "availability_slots": availability_slots,
+        "linkedin_url": input.linkedin_url,
+        "github_url": input.github_url,
+        "resume_url": input.resume_url,
+        "enabled": input.enabled.unwrap_or(true),
+    })
+}
+
+/// Match search filters.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate, Default)]
+pub(crate) struct MockInterviewMatchFilters {
+    #[garde(length(max = MAX_LEN_M))]
+    pub interview_type: Option<String>,
+    #[garde(range(max = 10))]
+    pub limit: Option<usize>,
+}
+
+/// Request creation input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct MockInterviewRequestInput {
+    #[garde(skip)]
+    pub interviewer_user_id: Uuid,
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub interview_type: String,
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub message: Option<String>,
+}
+
+/// Request response input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct MockInterviewRespondInput {
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_M))]
+    pub action: String,
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_M))]
+    pub meeting_url: Option<String>,
+}
+
+/// Interviewer feedback input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct MockInterviewInterviewerFeedbackInput {
+    #[garde(range(min = 1, max = 5))]
+    pub communication: i16,
+    #[garde(range(min = 1, max = 5))]
+    pub technical_depth: i16,
+    #[garde(range(min = 1, max = 5))]
+    pub problem_solving: i16,
+    #[garde(range(min = 1, max = 5))]
+    pub role_readiness: i16,
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub suggested_next_steps: Option<String>,
+}
+
+/// Interviewee feedback input.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct MockInterviewIntervieweeFeedbackInput {
+    #[garde(range(min = 1, max = 5))]
+    pub helpfulness: i16,
+    #[garde(range(min = 1, max = 5))]
+    pub feedback_quality: i16,
+    #[garde(skip)]
+    pub would_recommend: Option<bool>,
+}
+
+/// Member profile for mock interviews.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MockInterviewProfile {
+    pub user_id: Uuid,
+    pub role_intent: RoleIntent,
+    pub timezone_region: TimezoneRegion,
+    pub seniority: Seniority,
+    #[serde(default)]
+    pub interview_types: Vec<String>,
+    #[serde(default)]
+    pub target_company_types: Vec<String>,
+    #[serde(default)]
+    pub availability_slots: Value,
+    pub linkedin_url: Option<String>,
+    pub github_url: Option<String>,
+    pub resume_url: Option<String>,
+    pub enabled: bool,
+    #[serde(default)]
+    pub reputation_score: f64,
+    #[serde(default)]
+    pub completed_sessions: i32,
+    #[serde(default)]
+    pub interviewer_badge: bool,
+    pub username: String,
+    pub name: Option<String>,
+    pub photo_url: Option<String>,
+    pub title: Option<String>,
+    pub company: Option<String>,
+    #[serde(default)]
+    pub match_score: Option<i32>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Match search output.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct MockInterviewMatchesOutput {
+    #[serde(default)]
+    pub matches: Vec<MockInterviewProfile>,
+    #[serde(default)]
+    pub total: usize,
+}
+
+/// Mock interview request.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MockInterviewRequest {
+    pub mock_interview_request_id: Uuid,
+    pub interviewee_user_id: Uuid,
+    pub interviewer_user_id: Uuid,
+    pub interview_type: String,
+    pub message: Option<String>,
+    pub status: String,
+    pub interviewee_username: String,
+    pub interviewee_name: Option<String>,
+    pub interviewee_photo_url: Option<String>,
+    pub interviewer_username: String,
+    pub interviewer_name: Option<String>,
+    pub interviewer_photo_url: Option<String>,
+    #[serde(default)]
+    pub mock_interview_session_id: Option<Uuid>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub responded_at: Option<DateTime<Utc>>,
+}
+
+/// Session feedback record.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MockInterviewFeedback {
+    pub mock_interview_feedback_id: Uuid,
+    pub reviewer_user_id: Uuid,
+    pub reviewee_user_id: Uuid,
+    pub reviewer_role: String,
+    pub communication: Option<i16>,
+    pub technical_depth: Option<i16>,
+    pub problem_solving: Option<i16>,
+    pub role_readiness: Option<i16>,
+    pub helpfulness: Option<i16>,
+    pub feedback_quality: Option<i16>,
+    pub would_recommend: Option<bool>,
+    pub suggested_next_steps: Option<String>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
+/// Mock interview session details.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct MockInterviewSession {
+    pub mock_interview_session_id: Uuid,
+    pub mock_interview_request_id: Uuid,
+    pub meeting_url: Option<String>,
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub scheduled_at: Option<DateTime<Utc>>,
+    pub status: String,
+    pub request: MockInterviewRequest,
+    #[serde(default)]
+    pub feedback: Vec<MockInterviewFeedback>,
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Human-readable labels for UI.
+pub(crate) fn label_interview_type(value: &str) -> &str {
+    match value {
+        "swe" => "Software Engineering",
+        "ai_ml" => "AI / ML",
+        "pm" => "Product Management",
+        "devops_cloud" => "DevOps / Cloud",
+        "startup_cofounder" => "Startup / Co-founder",
+        "behavioral" => "Behavioral",
+        _ => "Other",
+    }
+}
+
+pub(crate) fn label_company_type(value: &str) -> &str {
+    match value {
+        "ai_labs_faang" => "AI Labs / FAANG",
+        "ai_startup" => "AI Startup",
+        "enterprise" => "Enterprise",
+        "remote_global" => "Remote / Global",
+        _ => value,
+    }
+}
+
+pub(crate) fn label_timezone(value: &TimezoneRegion) -> &'static str {
+    match value {
+        TimezoneRegion::Aze => "AZE",
+        TimezoneRegion::Eu => "EU",
+        TimezoneRegion::UsaCanada => "USA / Canada",
+        TimezoneRegion::Asia => "Asia",
+        TimezoneRegion::Other => "Other",
+    }
+}
+
+pub(crate) fn label_seniority(value: &Seniority) -> &'static str {
+    match value {
+        Seniority::Junior => "Junior",
+        Seniority::Mid => "Mid",
+        Seniority::Senior => "Senior",
+        Seniority::StaffPlus => "Staff+",
+    }
+}
+
+pub(crate) fn label_role_intent(value: &RoleIntent) -> &'static str {
+    match value {
+        RoleIntent::Interviewee => "Interviewee",
+        RoleIntent::Interviewer => "Interviewer",
+        RoleIntent::Both => "Both",
+    }
+}

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -46,6 +46,20 @@
                   Post a role
                   <span class="mt-1 block text-xs/5 font-medium text-stone-500">Share a job with the builder network.</span>
                 </a>
+                <a href="/mock-interviews"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-stone-900 transition hover:bg-stone-50">
+                  Mock interviews
+                  <span class="mt-1 block text-xs/5 font-medium text-stone-500">Practice interviews with verified GOUP members.</span>
+                </a>
+                <a href="/mock-interviews/onboarding"
+                   hx-boost="true"
+                   hx-target="body"
+                   class="block border-t border-stone-100 px-4 py-3 text-sm font-bold text-stone-900 transition hover:bg-stone-50">
+                  Mock interview setup
+                  <span class="mt-1 block text-xs/5 font-medium text-stone-500">Set your role, seniority, and availability.</span>
+                </a>
               {% else -%}
                 <a href="/log-in?next_url=/dashboard/jobs"
                    hx-boost="true"

--- a/ocg-server/templates/site/mock_interviews/matches.html
+++ b/ocg-server/templates/site/mock_interviews/matches.html
@@ -1,0 +1,61 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+    <h1 class="text-4xl font-black text-stone-950">Suggested interviewers</h1>
+    <p class="mt-3 text-stone-600">Matches are ranked by interview type, seniority fit, timezone overlap, and reputation.</p>
+  </section>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">
+    {% if profile.is_none() -%}
+      <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-center">
+        <p class="text-stone-600">Complete onboarding before viewing matches.</p>
+        <a href="/mock-interviews/onboarding" class="mt-4 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Set up profile</a>
+      </div>
+    {% else -%}
+      <form method="get" action="/mock-interviews/matches" class="mb-6 flex flex-wrap gap-3">
+        <select name="interview_type" class="input h-11">
+            <option value="">All interview types</option>
+          {% for interview_type in interview_types -%}
+            <option value="{{ interview_type }}">{{ interview_type }}</option>
+          {% endfor -%}
+        </select>
+        <button type="submit" class="inline-flex h-11 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Refresh matches</button>
+      </form>
+
+      {% if matches.is_empty() -%}
+        <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-center">
+          <p class="text-stone-600">No matches yet. Try another interview type or check back later.</p>
+        </div>
+      {% else -%}
+        <div class="grid gap-4">
+          {% for candidate in matches -%}
+            <article class="rounded-[1.5rem] border border-stone-200 bg-white p-5 shadow-sm">
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div>
+                  <h2 class="text-lg font-bold text-stone-950">{{ candidate.name.as_deref().unwrap_or(&candidate.username) }}</h2>
+                  <p class="text-sm text-stone-600">@{{ candidate.username }} · {{ candidate.seniority }} · {{ candidate.timezone_region }}</p>
+                  <p class="mt-2 text-sm text-stone-700">{{ candidate.interview_types|join:", " }}</p>
+                  {% if candidate.interviewer_badge -%}
+                    <span class="mt-2 inline-flex rounded-full bg-emerald-50 px-3 py-1 text-xs font-bold text-emerald-700">Verified interviewer</span>
+                  {% endif -%}
+                </div>
+                <div class="text-right text-sm text-stone-500">
+                  Match score: {{ candidate.match_score.unwrap_or(0) }}
+                </div>
+              </div>
+              <form method="post" action="/mock-interviews/requests" class="mt-4 grid gap-3 md:grid-cols-[1fr_auto]">
+                <input type="hidden" name="interviewer_user_id" value="{{ candidate.user_id }}" />
+                <input type="hidden" name="interview_type" value="{{ filters.interview_type.clone().unwrap_or_else(|| "swe".to_string()) }}" />
+                <input name="message" class="input h-11" placeholder="Optional note for the interviewer" />
+                <button type="submit" class="inline-flex h-11 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Request session</button>
+              </form>
+            </article>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    {% endif -%}
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/mock_interviews/onboarding.html
+++ b/ocg-server/templates/site/mock_interviews/onboarding.html
@@ -1,0 +1,83 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <section class="container mx-auto max-w-4xl px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+    <h1 class="text-4xl font-black text-stone-950">Mock interview onboarding</h1>
+    <p class="mt-3 text-stone-600">Tell us how you want to participate and what you are preparing for.</p>
+  </section>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-4xl px-4 pb-12 sm:px-6 lg:px-8">
+    <form method="post" action="/mock-interviews/onboarding" class="space-y-6 rounded-[1.75rem] border border-stone-200 bg-white p-6 shadow-lg">
+      <div>
+        <label class="block text-sm font-bold text-stone-900" for="role_intent">I want to be</label>
+        <select id="role_intent" name="role_intent" class="input mt-2 w-full" required>
+          <option value="interviewee" {% if self.profile_role_intent() == "interviewee" %}selected{% endif %}>Interviewee</option>
+          <option value="interviewer" {% if self.profile_role_intent() == "interviewer" %}selected{% endif %}>Interviewer</option>
+          <option value="both" {% if self.profile_role_intent() == "both" %}selected{% endif %}>Both</option>
+        </select>
+      </div>
+
+      <div class="grid gap-4 md:grid-cols-2">
+        <div>
+          <label class="block text-sm font-bold text-stone-900" for="timezone_region">Timezone region</label>
+          <select id="timezone_region" name="timezone_region" class="input mt-2 w-full" required>
+            <option value="aze" {% if self.profile_timezone_region() == "aze" %}selected{% endif %}>AZE</option>
+            <option value="eu" {% if self.profile_timezone_region() == "eu" %}selected{% endif %}>EU</option>
+            <option value="usa_canada" {% if self.profile_timezone_region() == "usa_canada" %}selected{% endif %}>USA / Canada</option>
+            <option value="asia" {% if self.profile_timezone_region() == "asia" %}selected{% endif %}>Asia</option>
+            <option value="other" {% if self.profile_timezone_region() == "other" %}selected{% endif %}>Other</option>
+          </select>
+        </div>
+        <div>
+          <label class="block text-sm font-bold text-stone-900" for="seniority">Seniority</label>
+          <select id="seniority" name="seniority" class="input mt-2 w-full" required>
+            <option value="junior" {% if self.profile_seniority() == "junior" %}selected{% endif %}>Junior</option>
+            <option value="mid" {% if self.profile_seniority() == "mid" %}selected{% endif %}>Mid</option>
+            <option value="senior" {% if self.profile_seniority() == "senior" %}selected{% endif %}>Senior</option>
+            <option value="staff_plus" {% if self.profile_seniority() == "staff_plus" %}selected{% endif %}>Staff+</option>
+          </select>
+        </div>
+      </div>
+
+      <div>
+        <label class="block text-sm font-bold text-stone-900" for="interview_types">Interview types (comma-separated)</label>
+        <input id="interview_types" name="interview_types" class="input mt-2 w-full" value="{{ self.profile_interview_types_csv() }}" placeholder="swe, ai_ml, behavioral" />
+        <p class="mt-1 text-xs text-stone-500">Options: {% for interview_type in interview_types %}{{ interview_type }}{% if !loop.last %}, {% endif %}{% endfor %}</p>
+      </div>
+
+      <div>
+        <label class="block text-sm font-bold text-stone-900" for="target_company_types">Target company types (comma-separated)</label>
+        <input id="target_company_types" name="target_company_types" class="input mt-2 w-full" value="{{ self.profile_target_company_types_csv() }}" placeholder="ai_labs_faang, ai_startup" />
+      </div>
+
+      <div>
+        <label class="block text-sm font-bold text-stone-900" for="availability_slots">Availability slots (JSON)</label>
+        <textarea id="availability_slots" name="availability_slots" rows="4" class="input mt-2 w-full font-mono text-sm">{{ self.profile_availability_slots_json() }}</textarea>
+      </div>
+
+      <div class="grid gap-4 md:grid-cols-3">
+        <div>
+          <label class="block text-sm font-bold text-stone-900" for="linkedin_url">LinkedIn URL</label>
+          <input id="linkedin_url" name="linkedin_url" type="url" class="input mt-2 w-full" value="{{ profile.as_ref().and_then(|p| p.linkedin_url.clone()).unwrap_or_default() }}" />
+        </div>
+        <div>
+          <label class="block text-sm font-bold text-stone-900" for="github_url">GitHub URL</label>
+          <input id="github_url" name="github_url" type="url" class="input mt-2 w-full" value="{{ profile.as_ref().and_then(|p| p.github_url.clone()).unwrap_or_default() }}" />
+        </div>
+        <div>
+          <label class="block text-sm font-bold text-stone-900" for="resume_url">Resume URL</label>
+          <input id="resume_url" name="resume_url" type="url" class="input mt-2 w-full" value="{{ profile.as_ref().and_then(|p| p.resume_url.clone()).unwrap_or_default() }}" />
+        </div>
+      </div>
+
+      <label class="inline-flex items-center gap-2 text-sm text-stone-700">
+        <input type="checkbox" name="enabled" value="true" checked class="rounded border-stone-300" />
+        Participate in mock interviews
+      </label>
+
+      <button type="submit" class="inline-flex h-11 items-center justify-center rounded-full bg-stone-950 px-6 text-sm font-bold text-white">Save profile</button>
+    </form>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/mock_interviews/page.html
+++ b/ocg-server/templates/site/mock_interviews/page.html
@@ -1,0 +1,49 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-6 sm:px-6 lg:px-8 lg:pt-16 lg:pb-8">
+    <div class="relative overflow-hidden rounded-[2.25rem] border border-stone-200 bg-white/95 p-6 shadow-xl shadow-stone-200/60 backdrop-blur sm:p-8 lg:p-10">
+      <div class="relative max-w-4xl">
+        <p class="mb-4 inline-flex rounded-full border border-stone-200 bg-stone-50 px-3 py-1 text-xs font-bold uppercase tracking-[0.22em] text-stone-700">
+          Mock Interviews
+        </p>
+        <h1 class="mb-4 text-balance text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl lg:text-6xl">
+          Practice interviews with GOUP members
+        </h1>
+        <p class="max-w-2xl text-base/7 font-medium text-stone-600">
+          Match with qualified interviewers, run realistic sessions, and get structured feedback from verified members.
+        </p>
+      </div>
+    </div>
+  </section>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8 lg:pb-16">
+    <div class="grid gap-6 lg:grid-cols-3">
+      <div class="rounded-[1.75rem] border border-stone-200 bg-white p-6 shadow-lg shadow-stone-200/50">
+        <h2 class="text-lg font-bold text-stone-950">1. Set your intent</h2>
+        <p class="mt-2 text-sm text-stone-600">Choose interviewee, interviewer, or both. Add timezone, seniority, and focus areas.</p>
+        {% if user.logged_in -%}
+          <a href="/mock-interviews/onboarding" class="mt-4 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Start onboarding</a>
+        {% else -%}
+          <a href="/log-in?next_url=/mock-interviews/onboarding" class="mt-4 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Log in to start</a>
+        {% endif -%}
+      </div>
+      <div class="rounded-[1.75rem] border border-stone-200 bg-white p-6 shadow-lg shadow-stone-200/50">
+        <h2 class="text-lg font-bold text-stone-950">2. Get matched</h2>
+        <p class="mt-2 text-sm text-stone-600">We suggest 3–5 interviewers based on interview type, seniority, timezone, and company targets.</p>
+        {% if profile.is_some() -%}
+          <a href="/mock-interviews/matches" class="mt-4 inline-flex h-10 items-center justify-center rounded-full border border-stone-200 px-5 text-sm font-bold text-stone-700">View matches</a>
+        {% endif -%}
+      </div>
+      <div class="rounded-[1.75rem] border border-stone-200 bg-white p-6 shadow-lg shadow-stone-200/50">
+        <h2 class="text-lg font-bold text-stone-950">3. Run sessions</h2>
+        <p class="mt-2 text-sm text-stone-600">Send requests, accept sessions, meet on Google Meet, and exchange structured feedback.</p>
+        {% if user.logged_in -%}
+          <a href="/mock-interviews/requests" class="mt-4 inline-flex h-10 items-center justify-center rounded-full border border-stone-200 px-5 text-sm font-bold text-stone-700">My requests</a>
+        {% endif -%}
+      </div>
+    </div>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/mock_interviews/requests.html
+++ b/ocg-server/templates/site/mock_interviews/requests.html
@@ -1,0 +1,62 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <section class="container mx-auto max-w-7xl px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+    <h1 class="text-4xl font-black text-stone-950">Mock interview requests</h1>
+  </section>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl px-4 pb-12 sm:px-6 lg:px-8">
+    {% if requests.is_empty() -%}
+      <div class="rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-6 py-10 text-center">
+        <p class="text-stone-600">No requests yet.</p>
+        <a href="/mock-interviews/matches" class="mt-4 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Find matches</a>
+      </div>
+    {% else -%}
+      <div class="grid gap-4">
+        {% for request in requests -%}
+          <article class="rounded-[1.5rem] border border-stone-200 bg-white p-5 shadow-sm">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p class="text-sm font-bold uppercase tracking-wide text-stone-500">{{ request.status }}</p>
+                <h2 class="text-lg font-bold text-stone-950">{{ request.interview_type }}</h2>
+                <p class="text-sm text-stone-600">
+                  Interviewee: {{ request.interviewee_name.as_deref().unwrap_or(&request.interviewee_username) }}
+                  · Interviewer: {{ request.interviewer_name.as_deref().unwrap_or(&request.interviewer_username) }}
+                </p>
+                {% if let Some(message) = request.message.as_ref() -%}
+                  <p class="mt-2 text-sm text-stone-700">{{ message }}</p>
+                {% endif -%}
+              </div>
+              <div class="flex flex-wrap gap-2">
+                {% if request.status == "pending" && request.interviewer_user_id == current_user_id -%}
+                  <form method="post" action="/mock-interviews/requests/{{ request.mock_interview_request_id }}" class="inline-flex flex-wrap items-center gap-2">
+                    <input type="hidden" name="action" value="accept" />
+                    <input name="meeting_url" class="input h-10 w-56" placeholder="Google Meet URL (optional)" />
+                    <button class="inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-4 text-sm font-bold text-white">Accept</button>
+                  </form>
+                  <form method="post" action="/mock-interviews/requests/{{ request.mock_interview_request_id }}">
+                    <input type="hidden" name="action" value="decline" />
+                    <button class="inline-flex h-10 items-center justify-center rounded-full border border-stone-200 px-4 text-sm font-bold text-stone-700">Decline</button>
+                  </form>
+                {% endif -%}
+                {% if request.status == "pending" && request.interviewee_user_id == current_user_id -%}
+                  <form method="post" action="/mock-interviews/requests/{{ request.mock_interview_request_id }}">
+                    <input type="hidden" name="action" value="cancel" />
+                    <button class="inline-flex h-10 items-center justify-center rounded-full border border-stone-200 px-4 text-sm font-bold text-stone-700">Cancel</button>
+                  </form>
+                {% endif -%}
+                {% if request.status == "accepted" -%}
+                  {% if let Some(session_id) = request.mock_interview_session_id -%}
+                    <a href="/mock-interviews/session/{{ session_id }}" class="inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-4 text-sm font-bold text-white">Open session</a>
+                  {% endif -%}
+                {% endif -%}
+              </div>
+            </div>
+          </article>
+        {% endfor -%}
+      </div>
+    {% endif -%}
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/site/mock_interviews/session.html
+++ b/ocg-server/templates/site/mock_interviews/session.html
@@ -1,0 +1,74 @@
+{% extends "common/base.html" -%}
+
+{% block jumbotron -%}
+  <section class="container mx-auto max-w-4xl px-4 pt-10 pb-6 sm:px-6 lg:px-8">
+    <h1 class="text-4xl font-black text-stone-950">Mock interview session</h1>
+    <p class="mt-3 text-stone-600">{{ session.request.interview_type }} · {{ session.status }}</p>
+  </section>
+{% endblock jumbotron -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-4xl px-4 pb-12 sm:px-6 lg:px-8 space-y-6">
+    <section class="rounded-[1.5rem] border border-stone-200 bg-white p-5 shadow-sm">
+      <h2 class="text-lg font-bold text-stone-950">Participants</h2>
+      <p class="mt-2 text-sm text-stone-600">
+        Interviewee: {{ session.request.interviewee_name.as_deref().unwrap_or(&session.request.interviewee_username) }}
+        · Interviewer: {{ session.request.interviewer_name.as_deref().unwrap_or(&session.request.interviewer_username) }}
+      </p>
+      {% if let Some(url) = session.meeting_url.as_ref() -%}
+        <a href="{{ url }}" class="mt-4 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white" target="_blank" rel="noopener">Join Google Meet</a>
+      {% else -%}
+        <p class="mt-4 text-sm text-stone-500">Meeting link will appear here once the interviewer adds it.</p>
+      {% endif -%}
+    </section>
+
+    {% if session.status != "completed" -%}
+      {% if session.request.interviewer_user_id == current_user_id -%}
+        <section class="rounded-[1.5rem] border border-stone-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-bold text-stone-950">Interviewer feedback</h2>
+          <form method="post" action="/mock-interviews/session/{{ session.mock_interview_session_id }}/feedback/interviewer" class="mt-4 grid gap-3 sm:grid-cols-2">
+            <label class="text-sm text-stone-700">Communication (1-5)<input class="input mt-1 w-full" type="number" min="1" max="5" name="communication" required /></label>
+            <label class="text-sm text-stone-700">Technical depth (1-5)<input class="input mt-1 w-full" type="number" min="1" max="5" name="technical_depth" required /></label>
+            <label class="text-sm text-stone-700">Problem solving (1-5)<input class="input mt-1 w-full" type="number" min="1" max="5" name="problem_solving" required /></label>
+            <label class="text-sm text-stone-700">Role readiness (1-5)<input class="input mt-1 w-full" type="number" min="1" max="5" name="role_readiness" required /></label>
+            <label class="sm:col-span-2 text-sm text-stone-700">Suggested next steps<textarea class="input mt-1 w-full" name="suggested_next_steps" rows="3"></textarea></label>
+            <button type="submit" class="sm:col-span-2 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Submit feedback</button>
+          </form>
+        </section>
+      {% endif -%}
+
+      {% if session.request.interviewee_user_id == current_user_id -%}
+        <section class="rounded-[1.5rem] border border-stone-200 bg-white p-5 shadow-sm">
+          <h2 class="text-lg font-bold text-stone-950">Interviewee feedback</h2>
+          <form method="post" action="/mock-interviews/session/{{ session.mock_interview_session_id }}/feedback/interviewee" class="mt-4 grid gap-3 sm:grid-cols-2">
+            <label class="text-sm text-stone-700">Helpfulness (1-5)<input class="input mt-1 w-full" type="number" min="1" max="5" name="helpfulness" required /></label>
+            <label class="text-sm text-stone-700">Feedback quality (1-5)<input class="input mt-1 w-full" type="number" min="1" max="5" name="feedback_quality" required /></label>
+            <label class="sm:col-span-2 inline-flex items-center gap-2 text-sm text-stone-700">
+              <input type="checkbox" name="would_recommend" value="true" checked class="rounded border-stone-300" />
+              Would recommend this interviewer
+            </label>
+            <button type="submit" class="sm:col-span-2 inline-flex h-10 items-center justify-center rounded-full bg-stone-950 px-5 text-sm font-bold text-white">Submit feedback</button>
+          </form>
+        </section>
+      {% endif -%}
+    {% else -%}
+      <section class="rounded-[1.5rem] border border-emerald-200 bg-emerald-50 p-5">
+        <p class="text-sm font-bold text-emerald-800">Session completed. Thanks for practicing together.</p>
+      </section>
+    {% endif -%}
+
+    {% if !session.feedback.is_empty() -%}
+      <section class="rounded-[1.5rem] border border-stone-200 bg-white p-5 shadow-sm">
+        <h2 class="text-lg font-bold text-stone-950">Submitted feedback</h2>
+        <ul class="mt-3 space-y-3">
+          {% for item in session.feedback -%}
+            <li class="rounded-xl border border-stone-100 bg-stone-50 p-4 text-sm text-stone-700">
+              {{ item.reviewer_role }}
+              {% if let Some(steps) = item.suggested_next_steps.as_ref() -%} · {{ steps }}{% endif -%}
+            </li>
+          {% endfor -%}
+        </ul>
+      </section>
+    {% endif -%}
+  </div>
+{% endblock content -%}


### PR DESCRIPTION
## Summary
- add the mock interviews MVP with onboarding, match suggestions, request handling, session pages, and feedback flows under `/mock-interviews`
- add PostgreSQL schema and SQL functions for mock interview profiles, requests, sessions, matching, and feedback
- wire the new feature into site routes, templates, DB traits, and the Jobs navigation menu

## Test plan
- [ ] Open `/mock-interviews` and confirm the landing page renders
- [ ] Log in, complete `/mock-interviews/onboarding`, and confirm a profile is saved
- [ ] Visit `/mock-interviews/matches` and verify suggested interviewer cards render
- [ ] Send a request, accept/decline it from `/mock-interviews/requests`, and open the created session page
- [ ] Submit interviewer and interviewee feedback on `/mock-interviews/session/{id}`
- [ ] Run a Rust compile/check pass once the local toolchain and Docker dev image are updated to Rust 1.96+


Made with [Cursor](https://cursor.com)