### PR TITLE
Remove padding from landscape logos

### DIFF
--- a/ocg-server/templates/site/landscape/page.html
+++ b/ocg-server/templates/site/landscape/page.html
@@ -45,7 +45,7 @@
                   {% if let Some(logo_url) = &entry.logo_url -%}
                     <img src="{{ logo_url }}"
                          alt="{{ entry.name }} logo"
-                         class="h-full w-full object-contain p-2"
+                         class="h-full w-full object-contain"
                          loading="lazy" />
                   {% else -%}
                     <div class="svg-icon size-7 icon-buildings bg-stone-700"></div>
@@ -64,7 +64,7 @@
                   {% if let Some(logo_url) = &entry.logo_url -%}
                     <img src="{{ logo_url }}"
                          alt="{{ entry.name }} logo"
-                         class="h-full w-full object-contain p-2"
+                         class="h-full w-full object-contain"
                          loading="lazy" />
                   {% else -%}
                     <div class="svg-icon size-7 icon-buildings bg-stone-700"></div>
@@ -79,7 +79,7 @@
                   {% if let Some(logo_url) = &entry.logo_url -%}
                     <img src="{{ logo_url }}"
                          alt="{{ entry.name }} logo"
-                         class="h-full w-full object-contain p-2"
+                         class="h-full w-full object-contain"
                          loading="lazy" />
                   {% else -%}
                     <div class="svg-icon size-7 icon-buildings bg-stone-700"></div>


### PR DESCRIPTION
## Problem

On `/landscape`, each ecosystem logo image carries `p-2` inside an already small `size-14` (56px) framed container. The padding shrinks the logo and leaves an uneven gap around it, so logos look small and inconsistent.

```html
<img src="..." alt="Rastock AI logo" class="h-full w-full object-contain p-2" loading="lazy">
```

## Fix

Drop `p-2` so the logo fills the framed container as `object-contain` already intends. The container keeps its own `overflow-hidden rounded-2xl bg-white ring-1` frame, so nothing bleeds out.

Removed in all three entry branches (website link, github link, and the no link fallback) so every card renders the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)