### PR TITLE
Add accelerator management

### DIFF
--- a/database/migrations/functions/landscape/add_landscape_entry.sql
+++ b/database/migrations/functions/landscape/add_landscape_entry.sql
@@ -2,7 +2,8 @@ create or replace function add_landscape_entry(
     p_actor_user_id uuid,
     p_alliance_id uuid,
     p_input jsonb,
-    p_tags text[]
+    p_tags text[],
+    p_accelerator_tracks text[]
 ) returns uuid language plpgsql as $$
 declare
     v_entry_id uuid;
@@ -45,6 +46,29 @@ begin
         coalesce(p_tags, '{}'::text[])
     )
     returning landscape_entry_id into v_entry_id;
+
+    if trim(p_input->>'kind') = 'accelerator' then
+        insert into landscape_accelerator_profile (
+            landscape_entry_id,
+            application_url,
+            curriculum_url,
+            cohort_status,
+            starts_on,
+            ends_on,
+            tracks,
+            weekly_agenda
+        )
+        values (
+            v_entry_id,
+            nullif(trim(p_input->>'accelerator_application_url'), ''),
+            nullif(trim(p_input->>'accelerator_curriculum_url'), ''),
+            nullif(trim(p_input->>'accelerator_cohort_status'), ''),
+            nullif(trim(p_input->>'accelerator_starts_on'), '')::date,
+            nullif(trim(p_input->>'accelerator_ends_on'), '')::date,
+            coalesce(p_accelerator_tracks, '{}'::text[]),
+            nullif(trim(p_input->>'accelerator_weekly_agenda'), '')::jsonb
+        );
+    end if;
 
     perform insert_audit_log(
         'landscape_entry_added',

--- a/database/migrations/functions/landscape/landscape_entry_json.sql
+++ b/database/migrations/functions/landscape/landscape_entry_json.sql
@@ -16,6 +16,23 @@ returns jsonb language sql stable as $$
         'tags', p_entry.tags,
         'published', p_entry.published,
         'created_at', extract(epoch from p_entry.created_at)::bigint,
-        'updated_at', extract(epoch from p_entry.updated_at)::bigint
+        'updated_at', extract(epoch from p_entry.updated_at)::bigint,
+        'accelerator', (
+            select case
+                when lap.landscape_entry_id is null then null
+                else jsonb_build_object(
+                    'application_url', lap.application_url,
+                    'curriculum_url', lap.curriculum_url,
+                    'cohort_status', lap.cohort_status,
+                    'starts_on', lap.starts_on,
+                    'ends_on', lap.ends_on,
+                    'tracks', lap.tracks,
+                    'weekly_agenda', lap.weekly_agenda,
+                    'updated_at', extract(epoch from lap.updated_at)::bigint
+                )
+            end
+            from landscape_accelerator_profile lap
+            where lap.landscape_entry_id = p_entry.landscape_entry_id
+        )
     );
 $$;

--- a/database/migrations/functions/landscape/list_alliance_landscape_entries.sql
+++ b/database/migrations/functions/landscape/list_alliance_landscape_entries.sql
@@ -12,6 +12,7 @@ begin
     with matches as (
         select le.*
         from landscape_entry le
+        left join landscape_accelerator_profile lap on lap.landscape_entry_id = le.landscape_entry_id
         where le.alliance_id = p_alliance_id
         and (
             v_query is null
@@ -19,10 +20,19 @@ begin
             or le.summary ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             or le.description ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             or le.category ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.application_url ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.curriculum_url ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.cohort_status ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.weekly_agenda::text ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             or exists (
                 select 1
                 from unnest(le.tags) tag
                 where tag ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+            or exists (
+                select 1
+                from unnest(lap.tracks) track
+                where track ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             )
         )
     ),

--- a/database/migrations/functions/landscape/search_landscape_entries.sql
+++ b/database/migrations/functions/landscape/search_landscape_entries.sql
@@ -14,6 +14,7 @@ begin
         select le.*
         from landscape_entry le
         join alliance a on a.alliance_id = le.alliance_id
+        left join landscape_accelerator_profile lap on lap.landscape_entry_id = le.landscape_entry_id
         where le.published = true
         and (v_alliance is null or a.name = v_alliance)
         and (v_kind is null or le.kind = v_kind)
@@ -27,10 +28,19 @@ begin
             or le.summary ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             or le.description ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             or le.category ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.application_url ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.curriculum_url ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.cohort_status ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.weekly_agenda::text ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             or exists (
                 select 1
                 from unnest(le.tags) tag
                 where tag ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+            or exists (
+                select 1
+                from unnest(lap.tracks) track
+                where track ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
             )
         )
     ),

--- a/database/migrations/functions/landscape/update_landscape_entry.sql
+++ b/database/migrations/functions/landscape/update_landscape_entry.sql
@@ -3,7 +3,8 @@ create or replace function update_landscape_entry(
     p_alliance_id uuid,
     p_entry_id uuid,
     p_input jsonb,
-    p_tags text[]
+    p_tags text[],
+    p_accelerator_tracks text[]
 ) returns void language plpgsql as $$
 begin
     update landscape_entry
@@ -22,6 +23,43 @@ begin
 
     if not found then
         raise exception 'landscape entry not found';
+    end if;
+
+    if trim(p_input->>'kind') = 'accelerator' then
+        insert into landscape_accelerator_profile (
+            landscape_entry_id,
+            application_url,
+            curriculum_url,
+            cohort_status,
+            starts_on,
+            ends_on,
+            tracks,
+            weekly_agenda,
+            updated_at
+        )
+        values (
+            p_entry_id,
+            nullif(trim(p_input->>'accelerator_application_url'), ''),
+            nullif(trim(p_input->>'accelerator_curriculum_url'), ''),
+            nullif(trim(p_input->>'accelerator_cohort_status'), ''),
+            nullif(trim(p_input->>'accelerator_starts_on'), '')::date,
+            nullif(trim(p_input->>'accelerator_ends_on'), '')::date,
+            coalesce(p_accelerator_tracks, '{}'::text[]),
+            nullif(trim(p_input->>'accelerator_weekly_agenda'), '')::jsonb,
+            current_timestamp
+        )
+        on conflict (landscape_entry_id) do update
+        set application_url = excluded.application_url,
+            curriculum_url = excluded.curriculum_url,
+            cohort_status = excluded.cohort_status,
+            starts_on = excluded.starts_on,
+            ends_on = excluded.ends_on,
+            tracks = excluded.tracks,
+            weekly_agenda = excluded.weekly_agenda,
+            updated_at = current_timestamp;
+    else
+        delete from landscape_accelerator_profile
+        where landscape_entry_id = p_entry_id;
     end if;
 
     perform insert_audit_log(

--- a/database/migrations/schema/0038_landscape_accelerators.sql
+++ b/database/migrations/schema/0038_landscape_accelerators.sql
@@ -1,0 +1,19 @@
+alter table landscape_entry
+drop constraint if exists landscape_entry_kind_check;
+
+alter table landscape_entry
+add constraint landscape_entry_kind_check
+check (kind in ('startup', 'github_project', 'partner_community', 'podcast_lead', 'investor', 'accelerator'));
+
+create table landscape_accelerator_profile (
+    landscape_entry_id uuid primary key references landscape_entry (landscape_entry_id) on delete cascade,
+    application_url text,
+    curriculum_url text,
+    cohort_status text check (cohort_status in ('planned', 'open', 'running', 'completed')),
+    starts_on date,
+    ends_on date,
+    tracks text[] default '{}'::text[] not null,
+    weekly_agenda jsonb,
+    updated_at timestamp with time zone default current_timestamp not null,
+    check (starts_on is null or ends_on is null or starts_on <= ends_on)
+);

--- a/database/migrations/schema/0039_group_accelerators.sql
+++ b/database/migrations/schema/0039_group_accelerators.sql
@@ -1,0 +1,136 @@
+create table group_accelerator_program (
+    group_accelerator_program_id uuid primary key default gen_random_uuid(),
+    group_id uuid not null references "group" (group_id) on delete cascade,
+    created_by uuid not null references "user" (user_id),
+    name text not null,
+    summary text not null,
+    description text,
+    application_url text,
+    curriculum_url text,
+    active boolean default true not null,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_accelerator_program_name_check check (btrim(name) <> ''),
+    constraint group_accelerator_program_summary_check check (btrim(summary) <> ''),
+    constraint group_accelerator_program_description_check check (description is null or btrim(description) <> ''),
+    constraint group_accelerator_program_application_url_check check (application_url is null or btrim(application_url) <> ''),
+    constraint group_accelerator_program_curriculum_url_check check (curriculum_url is null or btrim(curriculum_url) <> '')
+);
+
+create index group_accelerator_program_group_id_idx
+on group_accelerator_program (group_id, active desc, created_at desc);
+
+create table group_accelerator_cohort (
+    group_accelerator_cohort_id uuid primary key default gen_random_uuid(),
+    group_accelerator_program_id uuid not null references group_accelerator_program (group_accelerator_program_id) on delete cascade,
+    created_by uuid not null references "user" (user_id),
+    name text not null,
+    status text default 'planned' not null check (status in ('planned', 'open', 'running', 'completed', 'archived')),
+    starts_on date,
+    ends_on date,
+    application_deadline date,
+    capacity integer,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_accelerator_cohort_name_check check (btrim(name) <> ''),
+    constraint group_accelerator_cohort_capacity_check check (capacity is null or capacity > 0),
+    constraint group_accelerator_cohort_dates_check check (starts_on is null or ends_on is null or starts_on <= ends_on)
+);
+
+create index group_accelerator_cohort_program_id_idx
+on group_accelerator_cohort (group_accelerator_program_id, status, starts_on desc nulls last);
+
+create table group_accelerator_application (
+    group_accelerator_application_id uuid primary key default gen_random_uuid(),
+    group_accelerator_cohort_id uuid not null references group_accelerator_cohort (group_accelerator_cohort_id) on delete cascade,
+    user_id uuid references "user" (user_id) on delete set null,
+    applicant_name text not null,
+    applicant_email text not null,
+    project_name text not null,
+    project_url text,
+    pitch text not null,
+    goals text,
+    status text default 'submitted' not null check (status in ('submitted', 'reviewing', 'accepted', 'rejected', 'waitlisted')),
+    reviewer_notes text,
+    reviewed_by uuid references "user" (user_id) on delete set null,
+    reviewed_at timestamptz,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_accelerator_application_applicant_name_check check (btrim(applicant_name) <> ''),
+    constraint group_accelerator_application_applicant_email_check check (btrim(applicant_email) <> ''),
+    constraint group_accelerator_application_project_name_check check (btrim(project_name) <> ''),
+    constraint group_accelerator_application_project_url_check check (project_url is null or btrim(project_url) <> ''),
+    constraint group_accelerator_application_pitch_check check (btrim(pitch) <> ''),
+    constraint group_accelerator_application_goals_check check (goals is null or btrim(goals) <> '')
+);
+
+create index group_accelerator_application_cohort_id_idx
+on group_accelerator_application (group_accelerator_cohort_id, status, created_at desc);
+
+create table group_accelerator_member (
+    group_accelerator_member_id uuid primary key default gen_random_uuid(),
+    group_accelerator_cohort_id uuid not null references group_accelerator_cohort (group_accelerator_cohort_id) on delete cascade,
+    group_accelerator_application_id uuid references group_accelerator_application (group_accelerator_application_id) on delete set null,
+    user_id uuid references "user" (user_id) on delete set null,
+    display_name text not null,
+    project_name text not null,
+    project_url text,
+    status text default 'active' not null check (status in ('active', 'graduated', 'dropped')),
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_accelerator_member_display_name_check check (btrim(display_name) <> ''),
+    constraint group_accelerator_member_project_name_check check (btrim(project_name) <> ''),
+    constraint group_accelerator_member_project_url_check check (project_url is null or btrim(project_url) <> ''),
+    unique (group_accelerator_cohort_id, group_accelerator_application_id)
+);
+
+create index group_accelerator_member_cohort_id_idx
+on group_accelerator_member (group_accelerator_cohort_id, status, created_at desc);
+
+create table group_accelerator_week (
+    group_accelerator_week_id uuid primary key default gen_random_uuid(),
+    group_accelerator_cohort_id uuid not null references group_accelerator_cohort (group_accelerator_cohort_id) on delete cascade,
+    created_by uuid not null references "user" (user_id),
+    week_number integer not null,
+    title text not null,
+    goals text,
+    resources_url text,
+    deliverable text,
+    starts_on date,
+    due_on date,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_accelerator_week_number_check check (week_number > 0),
+    constraint group_accelerator_week_title_check check (btrim(title) <> ''),
+    constraint group_accelerator_week_goals_check check (goals is null or btrim(goals) <> ''),
+    constraint group_accelerator_week_resources_url_check check (resources_url is null or btrim(resources_url) <> ''),
+    constraint group_accelerator_week_deliverable_check check (deliverable is null or btrim(deliverable) <> ''),
+    constraint group_accelerator_week_dates_check check (starts_on is null or due_on is null or starts_on <= due_on),
+    unique (group_accelerator_cohort_id, week_number)
+);
+
+create index group_accelerator_week_cohort_id_idx
+on group_accelerator_week (group_accelerator_cohort_id, week_number);
+
+create table group_accelerator_weekly_update (
+    group_accelerator_weekly_update_id uuid primary key default gen_random_uuid(),
+    group_accelerator_member_id uuid not null references group_accelerator_member (group_accelerator_member_id) on delete cascade,
+    group_accelerator_week_id uuid not null references group_accelerator_week (group_accelerator_week_id) on delete cascade,
+    user_id uuid references "user" (user_id) on delete set null,
+    shipped text not null,
+    metrics text,
+    blockers text,
+    asks text,
+    links text,
+    status text default 'submitted' not null check (status in ('submitted', 'reviewed')),
+    reviewer_notes text,
+    reviewed_by uuid references "user" (user_id) on delete set null,
+    reviewed_at timestamptz,
+    created_at timestamptz default current_timestamp not null,
+    updated_at timestamptz,
+    constraint group_accelerator_weekly_update_shipped_check check (btrim(shipped) <> ''),
+    unique (group_accelerator_member_id, group_accelerator_week_id)
+);
+
+create index group_accelerator_weekly_update_week_id_idx
+on group_accelerator_weekly_update (group_accelerator_week_id, status, created_at desc);

--- a/ocg-server/Dockerfile.dev
+++ b/ocg-server/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM rust:1.95.0-bookworm
+FROM rust:1.96.0-bookworm
 
 ARG TARGETARCH
 

--- a/ocg-server/src/db.rs
+++ b/ocg-server/src/db.rs
@@ -9,11 +9,14 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use tokio_postgres::types::{FromSql, Json, ToSql};
 
 use crate::db::{
-    activity_tracker::DBActivityTracker, alliance::DBAlliance, auth::DBAuth, common::DBCommon,
-    dashboard::DBDashboard, event::DBEvent, group::DBGroup, images::DBImages, jobs::DBJobs,
-    landscape::DBLandscape, meetings::DBMeetings, notifications::DBNotifications,
-    payments::DBPayments, site::DBSite,
+    accelerator::DBAccelerator, activity_tracker::DBActivityTracker, alliance::DBAlliance,
+    auth::DBAuth, common::DBCommon, dashboard::DBDashboard, event::DBEvent, group::DBGroup,
+    images::DBImages, jobs::DBJobs, landscape::DBLandscape, meetings::DBMeetings,
+    notifications::DBNotifications, payments::DBPayments, site::DBSite,
 };
+
+/// Module containing database functionality for accelerator management.
+pub(crate) mod accelerator;
 
 /// Module containing authentication database operations.
 pub(crate) mod auth;
@@ -71,6 +74,7 @@ pub(crate) mod site;
 /// Database operations supported by root and transaction-scoped handles.
 pub(crate) trait DBOperations:
     DBAuth
+    + DBAccelerator
     + DBActivityTracker
     + DBCommon
     + DBAlliance
@@ -91,6 +95,7 @@ pub(crate) trait DBOperations:
 
 impl<T> DBOperations for T where
     T: DBAuth
+        + DBAccelerator
         + DBActivityTracker
         + DBCommon
         + DBAlliance

--- a/ocg-server/src/db/accelerator.rs
+++ b/ocg-server/src/db/accelerator.rs
@@ -1,0 +1,524 @@
+//! Database operations for accelerator management.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::PgExecutor,
+    templates::dashboard::group::accelerator::{
+        AcceleratorApplicationInput, AcceleratorApplicationReviewInput, AcceleratorCohortInput,
+        AcceleratorDashboard, AcceleratorProgramInput, AcceleratorWeekInput,
+        AcceleratorWeeklyUpdateInput, AcceleratorWeeklyUpdateReviewInput,
+    },
+};
+
+/// Database operations for group accelerator programs.
+#[async_trait]
+pub(crate) trait DBAccelerator {
+    /// Lists the full accelerator dashboard payload for one group.
+    async fn get_group_accelerator_dashboard(&self, group_id: Uuid) -> Result<AcceleratorDashboard>;
+
+    /// Adds an accelerator program.
+    async fn add_group_accelerator_program(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &AcceleratorProgramInput,
+    ) -> Result<Uuid>;
+
+    /// Adds a cohort.
+    async fn add_group_accelerator_cohort(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &AcceleratorCohortInput,
+    ) -> Result<Uuid>;
+
+    /// Adds a curriculum week.
+    async fn add_group_accelerator_week(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &AcceleratorWeekInput,
+    ) -> Result<Uuid>;
+
+    /// Submits an application for a cohort.
+    async fn submit_group_accelerator_application(
+        &self,
+        user_id: Uuid,
+        group_id: Uuid,
+        cohort_id: Uuid,
+        input: &AcceleratorApplicationInput,
+    ) -> Result<Uuid>;
+
+    /// Reviews an application.
+    async fn review_group_accelerator_application(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        application_id: Uuid,
+        input: &AcceleratorApplicationReviewInput,
+    ) -> Result<()>;
+
+    /// Accepts an application and creates a cohort member.
+    async fn accept_group_accelerator_application(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        application_id: Uuid,
+    ) -> Result<Uuid>;
+
+    /// Submits or replaces a member weekly update.
+    async fn submit_group_accelerator_weekly_update(
+        &self,
+        user_id: Uuid,
+        group_id: Uuid,
+        week_id: Uuid,
+        input: &AcceleratorWeeklyUpdateInput,
+    ) -> Result<Uuid>;
+
+    /// Reviews a weekly update.
+    async fn review_group_accelerator_weekly_update(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        weekly_update_id: Uuid,
+        input: &AcceleratorWeeklyUpdateReviewInput,
+    ) -> Result<()>;
+}
+
+#[async_trait]
+impl<T> DBAccelerator for T
+where
+    T: PgExecutor + Send + Sync,
+{
+    #[instrument(skip(self), err)]
+    async fn get_group_accelerator_dashboard(&self, group_id: Uuid) -> Result<AcceleratorDashboard> {
+        self.fetch_json_one(
+            r#"
+            with programs as (
+                select gap.*
+                from group_accelerator_program gap
+                where gap.group_id = $1::uuid
+            ),
+            cohorts as (
+                select gac.*
+                from group_accelerator_cohort gac
+                join programs gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+            ),
+            applications as (
+                select gaa.*
+                from group_accelerator_application gaa
+                join cohorts gac on gac.group_accelerator_cohort_id = gaa.group_accelerator_cohort_id
+            ),
+            members as (
+                select gam.*
+                from group_accelerator_member gam
+                join cohorts gac on gac.group_accelerator_cohort_id = gam.group_accelerator_cohort_id
+            ),
+            weeks as (
+                select gaw.*
+                from group_accelerator_week gaw
+                join cohorts gac on gac.group_accelerator_cohort_id = gaw.group_accelerator_cohort_id
+            ),
+            weekly_updates as (
+                select gawu.*
+                from group_accelerator_weekly_update gawu
+                join members gam on gam.group_accelerator_member_id = gawu.group_accelerator_member_id
+                join cohorts gac on gac.group_accelerator_cohort_id = gam.group_accelerator_cohort_id
+            )
+            select jsonb_build_object(
+                'programs', coalesce((select jsonb_agg(jsonb_build_object(
+                    'group_accelerator_program_id', group_accelerator_program_id,
+                    'group_id', group_id,
+                    'name', name,
+                    'summary', summary,
+                    'description', description,
+                    'application_url', application_url,
+                    'curriculum_url', curriculum_url,
+                    'active', active,
+                    'created_at', extract(epoch from created_at)::bigint,
+                    'updated_at', extract(epoch from updated_at)::bigint
+                ) order by created_at desc) from programs), '[]'::jsonb),
+                'cohorts', coalesce((select jsonb_agg(jsonb_build_object(
+                    'group_accelerator_cohort_id', group_accelerator_cohort_id,
+                    'group_accelerator_program_id', group_accelerator_program_id,
+                    'name', name,
+                    'status', status,
+                    'starts_on', starts_on,
+                    'ends_on', ends_on,
+                    'application_deadline', application_deadline,
+                    'capacity', capacity,
+                    'created_at', extract(epoch from created_at)::bigint
+                ) order by starts_on desc nulls last, created_at desc) from cohorts), '[]'::jsonb),
+                'applications', coalesce((select jsonb_agg(jsonb_build_object(
+                    'group_accelerator_application_id', group_accelerator_application_id,
+                    'group_accelerator_cohort_id', group_accelerator_cohort_id,
+                    'user_id', user_id,
+                    'applicant_name', applicant_name,
+                    'applicant_email', applicant_email,
+                    'project_name', project_name,
+                    'project_url', project_url,
+                    'pitch', pitch,
+                    'goals', goals,
+                    'status', status,
+                    'reviewer_notes', reviewer_notes,
+                    'created_at', extract(epoch from created_at)::bigint
+                ) order by created_at desc) from applications), '[]'::jsonb),
+                'members', coalesce((select jsonb_agg(jsonb_build_object(
+                    'group_accelerator_member_id', group_accelerator_member_id,
+                    'group_accelerator_cohort_id', group_accelerator_cohort_id,
+                    'user_id', user_id,
+                    'display_name', display_name,
+                    'project_name', project_name,
+                    'project_url', project_url,
+                    'status', status,
+                    'created_at', extract(epoch from created_at)::bigint
+                ) order by created_at desc) from members), '[]'::jsonb),
+                'weeks', coalesce((select jsonb_agg(jsonb_build_object(
+                    'group_accelerator_week_id', group_accelerator_week_id,
+                    'group_accelerator_cohort_id', group_accelerator_cohort_id,
+                    'week_number', week_number,
+                    'title', title,
+                    'goals', goals,
+                    'resources_url', resources_url,
+                    'deliverable', deliverable,
+                    'starts_on', starts_on,
+                    'due_on', due_on,
+                    'created_at', extract(epoch from created_at)::bigint
+                ) order by week_number) from weeks), '[]'::jsonb),
+                'weekly_updates', coalesce((select jsonb_agg(jsonb_build_object(
+                    'group_accelerator_weekly_update_id', group_accelerator_weekly_update_id,
+                    'group_accelerator_member_id', group_accelerator_member_id,
+                    'group_accelerator_week_id', group_accelerator_week_id,
+                    'user_id', user_id,
+                    'shipped', shipped,
+                    'metrics', metrics,
+                    'blockers', blockers,
+                    'asks', asks,
+                    'links', links,
+                    'status', status,
+                    'reviewer_notes', reviewer_notes,
+                    'created_at', extract(epoch from created_at)::bigint
+                ) order by created_at desc) from weekly_updates), '[]'::jsonb)
+            )
+            "#,
+            &[&group_id],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_group_accelerator_program(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &AcceleratorProgramInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            r#"
+            insert into group_accelerator_program (
+                group_id, created_by, name, summary, description, application_url, curriculum_url, active
+            )
+            values ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8)
+            returning group_accelerator_program_id
+            "#,
+            &[
+                &group_id,
+                &actor_user_id,
+                &input.name,
+                &input.summary,
+                &input.description,
+                &input.application_url,
+                &input.curriculum_url,
+                &input.active,
+            ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_group_accelerator_cohort(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &AcceleratorCohortInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            r#"
+            insert into group_accelerator_cohort (
+                group_accelerator_program_id, created_by, name, status, starts_on, ends_on, application_deadline, capacity
+            )
+            select gap.group_accelerator_program_id, $2::uuid, $3, $4, $5::date, $6::date, $7::date, $8
+            from group_accelerator_program gap
+            where gap.group_id = $1::uuid
+            and gap.group_accelerator_program_id = $9::uuid
+            returning group_accelerator_cohort_id
+            "#,
+            &[
+                &group_id,
+                &actor_user_id,
+                &input.name,
+                &input.status,
+                &input.starts_on,
+                &input.ends_on,
+                &input.application_deadline,
+                &input.capacity,
+                &input.group_accelerator_program_id,
+            ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn add_group_accelerator_week(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        input: &AcceleratorWeekInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            r#"
+            insert into group_accelerator_week (
+                group_accelerator_cohort_id, created_by, week_number, title, goals, resources_url, deliverable, starts_on, due_on
+            )
+            select gac.group_accelerator_cohort_id, $2::uuid, $3, $4, $5, $6, $7, $8::date, $9::date
+            from group_accelerator_cohort gac
+            join group_accelerator_program gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+            where gap.group_id = $1::uuid
+            and gac.group_accelerator_cohort_id = $10::uuid
+            on conflict (group_accelerator_cohort_id, week_number) do update
+            set title = excluded.title,
+                goals = excluded.goals,
+                resources_url = excluded.resources_url,
+                deliverable = excluded.deliverable,
+                starts_on = excluded.starts_on,
+                due_on = excluded.due_on,
+                updated_at = current_timestamp
+            returning group_accelerator_week_id
+            "#,
+            &[
+                &group_id,
+                &actor_user_id,
+                &input.week_number,
+                &input.title,
+                &input.goals,
+                &input.resources_url,
+                &input.deliverable,
+                &input.starts_on,
+                &input.due_on,
+                &input.group_accelerator_cohort_id,
+            ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn submit_group_accelerator_application(
+        &self,
+        user_id: Uuid,
+        group_id: Uuid,
+        cohort_id: Uuid,
+        input: &AcceleratorApplicationInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            r#"
+            insert into group_accelerator_application (
+                group_accelerator_cohort_id, user_id, applicant_name, applicant_email, project_name, project_url, pitch, goals
+            )
+            select gac.group_accelerator_cohort_id, $2::uuid, $3, $4, $5, $6, $7, $8
+            from group_accelerator_cohort gac
+            join group_accelerator_program gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+            where gap.group_id = $1::uuid
+            and gac.group_accelerator_cohort_id = $9::uuid
+            returning group_accelerator_application_id
+            "#,
+            &[
+                &group_id,
+                &user_id,
+                &input.applicant_name,
+                &input.applicant_email,
+                &input.project_name,
+                &input.project_url,
+                &input.pitch,
+                &input.goals,
+                &cohort_id,
+            ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn review_group_accelerator_application(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        application_id: Uuid,
+        input: &AcceleratorApplicationReviewInput,
+    ) -> Result<()> {
+        self.execute(
+            r#"
+            update group_accelerator_application gaa
+            set status = $3,
+                reviewer_notes = $4,
+                reviewed_by = $5::uuid,
+                reviewed_at = current_timestamp,
+                updated_at = current_timestamp
+            from group_accelerator_cohort gac
+            join group_accelerator_program gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+            where gaa.group_accelerator_cohort_id = gac.group_accelerator_cohort_id
+            and gap.group_id = $1::uuid
+            and gaa.group_accelerator_application_id = $2::uuid
+            "#,
+            &[
+                &group_id,
+                &application_id,
+                &input.status,
+                &input.reviewer_notes,
+                &actor_user_id,
+            ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self), err)]
+    async fn accept_group_accelerator_application(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        application_id: Uuid,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            r#"
+            with accepted as (
+                update group_accelerator_application gaa
+                set status = 'accepted',
+                    reviewed_by = $2::uuid,
+                    reviewed_at = current_timestamp,
+                    updated_at = current_timestamp
+                from group_accelerator_cohort gac
+                join group_accelerator_program gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+                where gaa.group_accelerator_cohort_id = gac.group_accelerator_cohort_id
+                and gap.group_id = $1::uuid
+                and gaa.group_accelerator_application_id = $3::uuid
+                returning gaa.*
+            )
+            insert into group_accelerator_member (
+                group_accelerator_cohort_id,
+                group_accelerator_application_id,
+                user_id,
+                display_name,
+                project_name,
+                project_url
+            )
+            select
+                group_accelerator_cohort_id,
+                group_accelerator_application_id,
+                user_id,
+                applicant_name,
+                project_name,
+                project_url
+            from accepted
+            on conflict (group_accelerator_cohort_id, group_accelerator_application_id) do update
+            set status = 'active',
+                updated_at = current_timestamp
+            returning group_accelerator_member_id
+            "#,
+            &[&group_id, &actor_user_id, &application_id],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn submit_group_accelerator_weekly_update(
+        &self,
+        user_id: Uuid,
+        group_id: Uuid,
+        week_id: Uuid,
+        input: &AcceleratorWeeklyUpdateInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            r#"
+            insert into group_accelerator_weekly_update (
+                group_accelerator_member_id,
+                group_accelerator_week_id,
+                user_id,
+                shipped,
+                metrics,
+                blockers,
+                asks,
+                links
+            )
+            select gam.group_accelerator_member_id, gaw.group_accelerator_week_id, $2::uuid, $3, $4, $5, $6, $7
+            from group_accelerator_member gam
+            join group_accelerator_cohort gac on gac.group_accelerator_cohort_id = gam.group_accelerator_cohort_id
+            join group_accelerator_program gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+            join group_accelerator_week gaw on gaw.group_accelerator_cohort_id = gac.group_accelerator_cohort_id
+            where gap.group_id = $1::uuid
+            and gaw.group_accelerator_week_id = $8::uuid
+            and gam.group_accelerator_member_id = $9::uuid
+            and (gam.user_id is null or gam.user_id = $2::uuid)
+            on conflict (group_accelerator_member_id, group_accelerator_week_id) do update
+            set shipped = excluded.shipped,
+                metrics = excluded.metrics,
+                blockers = excluded.blockers,
+                asks = excluded.asks,
+                links = excluded.links,
+                status = 'submitted',
+                reviewer_notes = null,
+                reviewed_by = null,
+                reviewed_at = null,
+                updated_at = current_timestamp
+            returning group_accelerator_weekly_update_id
+            "#,
+            &[
+                &group_id,
+                &user_id,
+                &input.shipped,
+                &input.metrics,
+                &input.blockers,
+                &input.asks,
+                &input.links,
+                &week_id,
+                &input.group_accelerator_member_id,
+            ],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, input), err)]
+    async fn review_group_accelerator_weekly_update(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        weekly_update_id: Uuid,
+        input: &AcceleratorWeeklyUpdateReviewInput,
+    ) -> Result<()> {
+        self.execute(
+            r#"
+            update group_accelerator_weekly_update gawu
+            set status = $3,
+                reviewer_notes = $4,
+                reviewed_by = $5::uuid,
+                reviewed_at = current_timestamp,
+                updated_at = current_timestamp
+            from group_accelerator_member gam
+            join group_accelerator_cohort gac on gac.group_accelerator_cohort_id = gam.group_accelerator_cohort_id
+            join group_accelerator_program gap on gap.group_accelerator_program_id = gac.group_accelerator_program_id
+            where gawu.group_accelerator_member_id = gam.group_accelerator_member_id
+            and gap.group_id = $1::uuid
+            and gawu.group_accelerator_weekly_update_id = $2::uuid
+            "#,
+            &[
+                &group_id,
+                &weekly_update_id,
+                &input.status,
+                &input.reviewer_notes,
+                &actor_user_id,
+            ],
+        )
+        .await
+    }
+}

--- a/ocg-server/src/db/landscape.rs
+++ b/ocg-server/src/db/landscape.rs
@@ -10,7 +10,7 @@ use crate::{
     db::PgExecutor,
     types::landscape::{
         DashboardLandscapeFilters, LandscapeEntryInput, LandscapeFilters, LandscapeOutput,
-        parse_tags,
+        parse_accelerator_tracks, parse_tags,
     },
 };
 
@@ -18,8 +18,10 @@ use crate::{
 #[async_trait]
 pub(crate) trait DBLandscape {
     /// Search published landscape entries.
-    async fn search_landscape_entries(&self, filters: &LandscapeFilters)
-    -> Result<LandscapeOutput>;
+    async fn search_landscape_entries(
+        &self,
+        filters: &LandscapeFilters,
+    ) -> Result<LandscapeOutput>;
 
     /// List entries for one alliance dashboard.
     async fn list_alliance_landscape_entries(
@@ -101,9 +103,16 @@ where
         input: &LandscapeEntryInput,
     ) -> Result<Uuid> {
         let tags = parse_tags(input.tags.as_deref());
+        let accelerator_tracks = parse_accelerator_tracks(input.accelerator_tracks.as_deref());
         self.fetch_scalar_one(
-            "select add_landscape_entry($1::uuid, $2::uuid, $3::jsonb, $4::text[])",
-            &[&actor_user_id, &alliance_id, &Json(input), &tags],
+            "select add_landscape_entry($1::uuid, $2::uuid, $3::jsonb, $4::text[], $5::text[])",
+            &[
+                &actor_user_id,
+                &alliance_id,
+                &Json(input),
+                &tags,
+                &accelerator_tracks,
+            ],
         )
         .await
     }
@@ -117,9 +126,17 @@ where
         input: &LandscapeEntryInput,
     ) -> Result<()> {
         let tags = parse_tags(input.tags.as_deref());
+        let accelerator_tracks = parse_accelerator_tracks(input.accelerator_tracks.as_deref());
         self.execute(
-            "select update_landscape_entry($1::uuid, $2::uuid, $3::uuid, $4::jsonb, $5::text[])",
-            &[&actor_user_id, &alliance_id, &entry_id, &Json(input), &tags],
+            "select update_landscape_entry($1::uuid, $2::uuid, $3::uuid, $4::jsonb, $5::text[], $6::text[])",
+            &[
+                &actor_user_id,
+                &alliance_id,
+                &entry_id,
+                &Json(input),
+                &tags,
+                &accelerator_tracks,
+            ],
         )
         .await?;
         Ok(())

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -23,6 +23,66 @@ mock! {
     }
 
     #[async_trait]
+    impl crate::db::accelerator::DBAccelerator for DB {
+        async fn get_group_accelerator_dashboard(
+            &self,
+            group_id: Uuid,
+        ) -> Result<crate::templates::dashboard::group::accelerator::AcceleratorDashboard>;
+        async fn add_group_accelerator_program(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorProgramInput,
+        ) -> Result<Uuid>;
+        async fn add_group_accelerator_cohort(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorCohortInput,
+        ) -> Result<Uuid>;
+        async fn add_group_accelerator_week(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorWeekInput,
+        ) -> Result<Uuid>;
+        async fn submit_group_accelerator_application(
+            &self,
+            user_id: Uuid,
+            group_id: Uuid,
+            cohort_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorApplicationInput,
+        ) -> Result<Uuid>;
+        async fn review_group_accelerator_application(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            application_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorApplicationReviewInput,
+        ) -> Result<()>;
+        async fn accept_group_accelerator_application(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            application_id: Uuid,
+        ) -> Result<Uuid>;
+        async fn submit_group_accelerator_weekly_update(
+            &self,
+            user_id: Uuid,
+            group_id: Uuid,
+            week_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorWeeklyUpdateInput,
+        ) -> Result<Uuid>;
+        async fn review_group_accelerator_weekly_update(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            weekly_update_id: Uuid,
+            input: &crate::templates::dashboard::group::accelerator::AcceleratorWeeklyUpdateReviewInput,
+        ) -> Result<()>;
+    }
+
+    #[async_trait]
     impl crate::db::auth::DBAuth for DB {
         async fn activate_pre_registered_user_email_password(
             &self,

--- a/ocg-server/src/handlers/dashboard/group.rs
+++ b/ocg-server/src/handlers/dashboard/group.rs
@@ -22,6 +22,7 @@ use crate::{
 mod tests;
 
 pub(crate) mod analytics;
+pub(crate) mod accelerator;
 pub(crate) mod attendees;
 pub(crate) mod coffee_meet;
 pub(crate) mod events;

--- a/ocg-server/src/handlers/dashboard/group/accelerator.rs
+++ b/ocg-server/src/handlers/dashboard/group/accelerator.rs
@@ -1,0 +1,170 @@
+//! HTTP handlers for group accelerator management.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::{HeaderName, StatusCode},
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId, ValidatedForm},
+    },
+    templates::dashboard::group::accelerator::{
+        self, AcceleratorApplicationReviewInput, AcceleratorCohortInput, AcceleratorProgramInput,
+        AcceleratorWeekInput, AcceleratorWeeklyUpdateReviewInput,
+    },
+    types::permissions::GroupPermission,
+};
+
+const DASHBOARD_URL: &str = "/dashboard/group?tab=accelerator";
+
+/// Displays the accelerator dashboard.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let template = prepare_page(&db, alliance_id, group_id, user.user_id).await?;
+    let headers = [(
+        HeaderName::from_static("hx-push-url"),
+        DASHBOARD_URL.to_string(),
+    )];
+
+    Ok((headers, Html(template.render()?)))
+}
+
+/// Adds an accelerator program.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_program(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<AcceleratorProgramInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_group_accelerator_program(user.user_id, group_id, &input)
+        .await?;
+
+    Ok(refresh_created())
+}
+
+/// Adds a cohort.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_cohort(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<AcceleratorCohortInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_group_accelerator_cohort(user.user_id, group_id, &input)
+        .await?;
+
+    Ok(refresh_created())
+}
+
+/// Adds or updates a curriculum week.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_week(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<AcceleratorWeekInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_group_accelerator_week(user.user_id, group_id, &input)
+        .await?;
+
+    Ok(refresh_created())
+}
+
+/// Reviews an application.
+#[instrument(skip_all, err)]
+pub(crate) async fn review_application(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(application_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<AcceleratorApplicationReviewInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.review_group_accelerator_application(user.user_id, group_id, application_id, &input)
+        .await?;
+
+    Ok(refresh_no_content())
+}
+
+/// Accepts an application and creates a cohort member.
+#[instrument(skip_all, err)]
+pub(crate) async fn accept_application(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(application_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.accept_group_accelerator_application(user.user_id, group_id, application_id)
+        .await?;
+
+    Ok(refresh_no_content())
+}
+
+/// Reviews a weekly update.
+#[instrument(skip_all, err)]
+pub(crate) async fn review_weekly_update(
+    CurrentUser(user): CurrentUser,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(weekly_update_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<AcceleratorWeeklyUpdateReviewInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.review_group_accelerator_weekly_update(user.user_id, group_id, weekly_update_id, &input)
+        .await?;
+
+    Ok(refresh_no_content())
+}
+
+/// Prepares the accelerator dashboard template.
+pub(crate) async fn prepare_page(
+    db: &DynDB,
+    alliance_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<accelerator::Page, HandlerError> {
+    let (can_manage_accelerator, dashboard) = tokio::try_join!(
+        db.user_has_group_permission(
+            &alliance_id,
+            &group_id,
+            &user_id,
+            GroupPermission::EventsWrite,
+        ),
+        db.get_group_accelerator_dashboard(group_id),
+    )?;
+
+    Ok(accelerator::Page {
+        can_manage_accelerator,
+        programs: dashboard.programs,
+        cohorts: dashboard.cohorts,
+        applications: dashboard.applications,
+        members: dashboard.members,
+        weeks: dashboard.weeks,
+        weekly_updates: dashboard.weekly_updates,
+    })
+}
+
+fn refresh_created() -> impl IntoResponse {
+    (
+        StatusCode::CREATED,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    )
+}
+
+fn refresh_no_content() -> impl IntoResponse {
+    (
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-group-dashboard-table")],
+    )
+}

--- a/ocg-server/src/handlers/dashboard/group/home.rs
+++ b/ocg-server/src/handlers/dashboard/group/home.rs
@@ -11,7 +11,7 @@ use axum::{
 use axum_messages::Messages;
 use tracing::instrument;
 
-use super::{coffee_meet, events, logs, members, sponsors, spotlights, store, team};
+use super::{accelerator, coffee_meet, events, logs, members, sponsors, spotlights, store, team};
 
 use crate::{
     auth::AuthSession,
@@ -67,6 +67,11 @@ pub(crate) async fn page(
 
     // Prepare content for the selected tab
     let content = match tab {
+        Tab::Accelerator => {
+            let template =
+                accelerator::prepare_page(&db, alliance_id, group_id, user.user_id).await?;
+            Content::Accelerator(template)
+        }
         Tab::Analytics => {
             let (group, stats) = tokio::try_join!(
                 db.get_group_full(alliance_id, group_id),

--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -17,7 +17,8 @@ use crate::{
     config::HttpServerConfig,
     db::DynDB,
     handlers::{
-        extractors::CurrentUser, request_matches_site, site::not_found, trim_public_gallery_images,
+        extractors::{CurrentUser, ValidatedForm},
+        request_matches_site, site::not_found, trim_public_gallery_images,
     },
     router::PUBLIC_SHARED_CACHE_HEADERS,
     router::serde_qs_config,
@@ -25,6 +26,9 @@ use crate::{
     templates::{
         PageId,
         auth::User,
+        dashboard::group::accelerator::{
+            AcceleratorApplicationInput, AcceleratorWeeklyUpdateInput,
+        },
         dashboard::group::members::GroupMembersFilters,
         group::{self, MembersPage, Page, ReportPage, SpotlightsPage, StorePage},
         notifications::GroupWelcome,
@@ -109,6 +113,43 @@ pub(crate) async fn page(
     };
 
     Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
+}
+
+/// Submits an application to an accelerator cohort.
+#[instrument(skip_all, err)]
+pub(crate) async fn apply_to_accelerator_cohort(
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path((_alliance_name, group_id, cohort_id)): Path<(String, Uuid, Uuid)>,
+    ValidatedForm(input): ValidatedForm<AcceleratorApplicationInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.submit_group_accelerator_application(user.user_id, group_id, cohort_id, &input)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        [(
+            "HX-Trigger",
+            "accelerator-application-submitted, refresh-body",
+        )],
+    ))
+}
+
+/// Submits a weekly update for an accepted accelerator member.
+#[instrument(skip_all, err)]
+pub(crate) async fn submit_accelerator_weekly_update(
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path((_alliance_name, group_id, week_id)): Path<(String, Uuid, Uuid)>,
+    ValidatedForm(input): ValidatedForm<AcceleratorWeeklyUpdateInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.submit_group_accelerator_weekly_update(user.user_id, group_id, week_id, &input)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        [("HX-Trigger", "accelerator-weekly-update-submitted")],
+    ))
 }
 
 /// Handler that renders logged-in group member spotlights.

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -208,6 +208,14 @@ pub(crate) async fn setup(
         )
         .route("/{alliance}/group/{group_id}/join", post(group::join_group))
         .route(
+            "/{alliance}/group/{group_id}/accelerator/cohorts/{cohort_id}/apply",
+            post(group::apply_to_accelerator_cohort),
+        )
+        .route(
+            "/{alliance}/group/{group_id}/accelerator/weeks/{week_id}/updates",
+            post(group::submit_accelerator_weekly_update),
+        )
+        .route(
             "/{alliance}/group/{group_id}/leave",
             delete(group::leave_group),
         )

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -258,6 +258,7 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
     // Read-only group dashboard endpoints
     let dashboard_read = Router::new()
         .route("/", get(dashboard::group::home::page))
+        .route("/accelerator", get(dashboard::group::accelerator::page))
         .route("/analytics", get(dashboard::group::analytics::page))
         .route(
             "/coffee-meet",
@@ -320,6 +321,30 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
 
     // Group events management endpoints
     let events_management = Router::new()
+        .route(
+            "/accelerator/applications/{application_id}",
+            put(dashboard::group::accelerator::review_application),
+        )
+        .route(
+            "/accelerator/applications/{application_id}/accept",
+            post(dashboard::group::accelerator::accept_application),
+        )
+        .route(
+            "/accelerator/cohorts",
+            post(dashboard::group::accelerator::add_cohort),
+        )
+        .route(
+            "/accelerator/programs",
+            post(dashboard::group::accelerator::add_program),
+        )
+        .route(
+            "/accelerator/weekly-updates/{weekly_update_id}",
+            put(dashboard::group::accelerator::review_weekly_update),
+        )
+        .route(
+            "/accelerator/weeks",
+            post(dashboard::group::accelerator::add_week),
+        )
         .route("/events/add", post(dashboard::group::events::add))
         .route("/events/preview", post(dashboard::group::events::preview))
         .route(

--- a/ocg-server/src/templates/dashboard/group.rs
+++ b/ocg-server/src/templates/dashboard/group.rs
@@ -1,5 +1,6 @@
 //! Templates for the group dashboard.
 
+pub(crate) mod accelerator;
 pub(crate) mod analytics;
 pub(crate) mod attendees;
 pub(crate) mod coffee_meet;

--- a/ocg-server/src/templates/dashboard/group/accelerator.rs
+++ b/ocg-server/src/templates/dashboard/group/accelerator.rs
@@ -1,0 +1,461 @@
+//! Templates and types for group accelerator management.
+
+use chrono::{DateTime, Utc};
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use uuid::Uuid;
+
+use crate::validation::{
+    MAX_LEN_DATE, MAX_LEN_DESCRIPTION, MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_ENTITY_NAME, MAX_LEN_L,
+    MAX_LEN_M, optional_trimmed_string, trimmed_non_empty, trimmed_non_empty_opt,
+};
+
+/// Group dashboard accelerator management page.
+#[derive(Debug, Clone, askama::Template, Serialize, Deserialize)]
+#[template(path = "dashboard/group/accelerator.html")]
+pub(crate) struct Page {
+    /// Whether the current user can manage accelerator operations.
+    pub can_manage_accelerator: bool,
+    /// Accelerator programs owned by the selected group.
+    pub programs: Vec<AcceleratorProgram>,
+    /// Cohorts for all listed programs.
+    pub cohorts: Vec<AcceleratorCohort>,
+    /// Applications for all listed cohorts.
+    pub applications: Vec<AcceleratorApplication>,
+    /// Cohort members for all listed cohorts.
+    pub members: Vec<AcceleratorMember>,
+    /// Weekly curriculum entries for all listed cohorts.
+    pub weeks: Vec<AcceleratorWeek>,
+    /// Submitted weekly updates for all listed weeks.
+    pub weekly_updates: Vec<AcceleratorWeeklyUpdate>,
+}
+
+/// Full accelerator dashboard payload.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct AcceleratorDashboard {
+    /// Accelerator programs.
+    #[serde(default)]
+    pub programs: Vec<AcceleratorProgram>,
+    /// Cohorts.
+    #[serde(default)]
+    pub cohorts: Vec<AcceleratorCohort>,
+    /// Applications.
+    #[serde(default)]
+    pub applications: Vec<AcceleratorApplication>,
+    /// Members.
+    #[serde(default)]
+    pub members: Vec<AcceleratorMember>,
+    /// Weeks.
+    #[serde(default)]
+    pub weeks: Vec<AcceleratorWeek>,
+    /// Weekly updates.
+    #[serde(default)]
+    pub weekly_updates: Vec<AcceleratorWeeklyUpdate>,
+}
+
+/// Accelerator program form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorProgramInput {
+    /// Program name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub name: String,
+    /// Short program summary.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub summary: String,
+    /// Full program description.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub description: Option<String>,
+    /// External or public application URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
+    pub application_url: Option<String>,
+    /// Curriculum URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
+    pub curriculum_url: Option<String>,
+    /// Whether the program is active.
+    #[serde(default = "default_true")]
+    #[garde(skip)]
+    pub active: bool,
+}
+
+/// Cohort form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorCohortInput {
+    /// Parent program ID.
+    #[garde(skip)]
+    pub group_accelerator_program_id: Uuid,
+    /// Cohort name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub name: String,
+    /// Cohort status.
+    #[garde(custom(valid_cohort_status), length(max = MAX_LEN_M))]
+    pub status: String,
+    /// Start date.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub starts_on: Option<String>,
+    /// End date.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub ends_on: Option<String>,
+    /// Application deadline.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub application_deadline: Option<String>,
+    /// Capacity.
+    #[garde(range(min = 1))]
+    pub capacity: Option<i32>,
+}
+
+/// Public application form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorApplicationInput {
+    /// Applicant name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub applicant_name: String,
+    /// Applicant email.
+    #[garde(email, length(max = MAX_LEN_M))]
+    pub applicant_email: String,
+    /// Project name.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub project_name: String,
+    /// Project URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
+    pub project_url: Option<String>,
+    /// Application pitch.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION))]
+    pub pitch: String,
+    /// Applicant goals.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub goals: Option<String>,
+}
+
+/// Application review form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorApplicationReviewInput {
+    /// Review status.
+    #[garde(custom(valid_application_status), length(max = MAX_LEN_M))]
+    pub status: String,
+    /// Reviewer notes.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub reviewer_notes: Option<String>,
+}
+
+/// Cohort week form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorWeekInput {
+    /// Parent cohort ID.
+    #[garde(skip)]
+    pub group_accelerator_cohort_id: Uuid,
+    /// Week number.
+    #[garde(range(min = 1))]
+    pub week_number: i32,
+    /// Week title.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub title: String,
+    /// Week goals.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub goals: Option<String>,
+    /// Resources URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
+    pub resources_url: Option<String>,
+    /// Suggested deliverable.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub deliverable: Option<String>,
+    /// Start date.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub starts_on: Option<String>,
+    /// Due date.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub due_on: Option<String>,
+}
+
+/// Member weekly update form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorWeeklyUpdateInput {
+    /// Cohort member ID.
+    #[garde(skip)]
+    pub group_accelerator_member_id: Uuid,
+    /// Shipped work.
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_DESCRIPTION))]
+    pub shipped: String,
+    /// Metrics.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub metrics: Option<String>,
+    /// Blockers.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub blockers: Option<String>,
+    /// Asks.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub asks: Option<String>,
+    /// Links.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub links: Option<String>,
+}
+
+/// Weekly update review form.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct AcceleratorWeeklyUpdateReviewInput {
+    /// Review status.
+    #[garde(custom(valid_weekly_update_status), length(max = MAX_LEN_M))]
+    pub status: String,
+    /// Reviewer notes.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub reviewer_notes: Option<String>,
+}
+
+/// Accelerator program.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcceleratorProgram {
+    /// Program ID.
+    pub group_accelerator_program_id: Uuid,
+    /// Group ID.
+    pub group_id: Uuid,
+    /// Program name.
+    pub name: String,
+    /// Summary.
+    pub summary: String,
+    /// Description.
+    pub description: Option<String>,
+    /// Application URL.
+    pub application_url: Option<String>,
+    /// Curriculum URL.
+    pub curriculum_url: Option<String>,
+    /// Active flag.
+    pub active: bool,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+    /// Last update time.
+    #[serde(default, with = "chrono::serde::ts_seconds_option")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Accelerator cohort.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcceleratorCohort {
+    /// Cohort ID.
+    pub group_accelerator_cohort_id: Uuid,
+    /// Program ID.
+    pub group_accelerator_program_id: Uuid,
+    /// Cohort name.
+    pub name: String,
+    /// Status.
+    pub status: String,
+    /// Start date.
+    pub starts_on: Option<String>,
+    /// End date.
+    pub ends_on: Option<String>,
+    /// Application deadline.
+    pub application_deadline: Option<String>,
+    /// Capacity.
+    pub capacity: Option<i32>,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
+/// Accelerator application.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcceleratorApplication {
+    /// Application ID.
+    pub group_accelerator_application_id: Uuid,
+    /// Cohort ID.
+    pub group_accelerator_cohort_id: Uuid,
+    /// Applicant user ID.
+    pub user_id: Option<Uuid>,
+    /// Applicant name.
+    pub applicant_name: String,
+    /// Applicant email.
+    pub applicant_email: String,
+    /// Project name.
+    pub project_name: String,
+    /// Project URL.
+    pub project_url: Option<String>,
+    /// Pitch.
+    pub pitch: String,
+    /// Goals.
+    pub goals: Option<String>,
+    /// Status.
+    pub status: String,
+    /// Reviewer notes.
+    pub reviewer_notes: Option<String>,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
+/// Accepted accelerator member.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcceleratorMember {
+    /// Member ID.
+    pub group_accelerator_member_id: Uuid,
+    /// Cohort ID.
+    pub group_accelerator_cohort_id: Uuid,
+    /// User ID.
+    pub user_id: Option<Uuid>,
+    /// Display name.
+    pub display_name: String,
+    /// Project name.
+    pub project_name: String,
+    /// Project URL.
+    pub project_url: Option<String>,
+    /// Status.
+    pub status: String,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
+/// Accelerator week.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcceleratorWeek {
+    /// Week ID.
+    pub group_accelerator_week_id: Uuid,
+    /// Cohort ID.
+    pub group_accelerator_cohort_id: Uuid,
+    /// Week number.
+    pub week_number: i32,
+    /// Title.
+    pub title: String,
+    /// Goals.
+    pub goals: Option<String>,
+    /// Resources URL.
+    pub resources_url: Option<String>,
+    /// Deliverable.
+    pub deliverable: Option<String>,
+    /// Start date.
+    pub starts_on: Option<String>,
+    /// Due date.
+    pub due_on: Option<String>,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
+/// Weekly update.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AcceleratorWeeklyUpdate {
+    /// Update ID.
+    pub group_accelerator_weekly_update_id: Uuid,
+    /// Member ID.
+    pub group_accelerator_member_id: Uuid,
+    /// Week ID.
+    pub group_accelerator_week_id: Uuid,
+    /// User ID.
+    pub user_id: Option<Uuid>,
+    /// Shipped work.
+    pub shipped: String,
+    /// Metrics.
+    pub metrics: Option<String>,
+    /// Blockers.
+    pub blockers: Option<String>,
+    /// Asks.
+    pub asks: Option<String>,
+    /// Links.
+    pub links: Option<String>,
+    /// Status.
+    pub status: String,
+    /// Reviewer notes.
+    pub reviewer_notes: Option<String>,
+    /// Creation time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub created_at: DateTime<Utc>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn valid_cohort_status(value: &impl AsRef<str>, _ctx: &()) -> garde::Result {
+    match value.as_ref() {
+        "planned" | "open" | "running" | "completed" | "archived" => Ok(()),
+        _ => Err(garde::Error::new("invalid cohort status")),
+    }
+}
+
+fn valid_application_status(value: &impl AsRef<str>, _ctx: &()) -> garde::Result {
+    match value.as_ref() {
+        "submitted" | "reviewing" | "accepted" | "rejected" | "waitlisted" => Ok(()),
+        _ => Err(garde::Error::new("invalid application status")),
+    }
+}
+
+fn valid_weekly_update_status(value: &impl AsRef<str>, _ctx: &()) -> garde::Result {
+    match value.as_ref() {
+        "submitted" | "reviewed" => Ok(()),
+        _ => Err(garde::Error::new("invalid weekly update status")),
+    }
+}
+
+fn valid_date_opt(value: &Option<String>, _ctx: &()) -> garde::Result {
+    let Some(value) = value.as_deref() else {
+        return Ok(());
+    };
+    chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map(|_| ())
+        .map_err(|_| garde::Error::new("invalid date"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_cohort_statuses() {
+        assert!(valid_cohort_status(&"planned", &()).is_ok());
+        assert!(valid_cohort_status(&"open", &()).is_ok());
+        assert!(valid_cohort_status(&"running", &()).is_ok());
+        assert!(valid_cohort_status(&"completed", &()).is_ok());
+        assert!(valid_cohort_status(&"archived", &()).is_ok());
+        assert!(valid_cohort_status(&"paused", &()).is_err());
+    }
+
+    #[test]
+    fn validates_application_statuses() {
+        assert!(valid_application_status(&"submitted", &()).is_ok());
+        assert!(valid_application_status(&"reviewing", &()).is_ok());
+        assert!(valid_application_status(&"accepted", &()).is_ok());
+        assert!(valid_application_status(&"rejected", &()).is_ok());
+        assert!(valid_application_status(&"waitlisted", &()).is_ok());
+        assert!(valid_application_status(&"unknown", &()).is_err());
+    }
+
+    #[test]
+    fn validates_weekly_update_statuses_and_dates() {
+        assert!(valid_weekly_update_status(&"submitted", &()).is_ok());
+        assert!(valid_weekly_update_status(&"reviewed", &()).is_ok());
+        assert!(valid_weekly_update_status(&"done", &()).is_err());
+        assert!(valid_date_opt(&Some("2027-03-01".to_string()), &()).is_ok());
+        assert!(valid_date_opt(&Some("03/01/2027".to_string()), &()).is_err());
+    }
+}

--- a/ocg-server/src/templates/dashboard/group/home.rs
+++ b/ocg-server/src/templates/dashboard/group/home.rs
@@ -12,8 +12,8 @@ use crate::{
         dashboard::{
             audit,
             group::{
-                analytics, coffee_meet, events, members, settings, sponsors, spotlights, store,
-                team,
+                accelerator, analytics, coffee_meet, events, members, settings, sponsors,
+                spotlights, store, team,
             },
         },
         filters,
@@ -80,6 +80,8 @@ impl Page {
 /// Content section for the group dashboard home page.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum Content {
+    /// Accelerator operations page.
+    Accelerator(accelerator::Page),
     /// Analytics page.
     Analytics(Box<analytics::Page>),
     /// Events management page.
@@ -103,6 +105,11 @@ pub(crate) enum Content {
 }
 
 impl Content {
+    /// Check if the content is the analytics page.
+    fn is_accelerator(&self) -> bool {
+        matches!(self, Content::Accelerator(_))
+    }
+
     /// Check if the content is the analytics page.
     fn is_analytics(&self) -> bool {
         matches!(self, Content::Analytics(_))
@@ -157,6 +164,7 @@ impl Content {
 impl std::fmt::Display for Content {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Content::Accelerator(template) => write!(f, "{}", template.render()?),
             Content::Analytics(template) => write!(f, "{}", template.render()?),
             Content::CoffeeMeet(template) => write!(f, "{}", template.render()?),
             Content::Events(template) => write!(f, "{}", template.render()?),
@@ -178,6 +186,8 @@ impl std::fmt::Display for Content {
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub(crate) enum Tab {
+    /// Accelerator tab.
+    Accelerator,
     /// Analytics tab (default).
     #[default]
     Analytics,

--- a/ocg-server/src/templates/filters.rs
+++ b/ocg-server/src/templates/filters.rs
@@ -110,6 +110,7 @@ pub(crate) fn landscape_kind_label<S: AsRef<str>>(
     _: &dyn askama::Values,
 ) -> askama::Result<String> {
     let label = match kind.as_ref() {
+        "accelerator" => "Accelerator",
         "github_project" => "GitHub project",
         "investor" => "Investor",
         "partner_community" => "Partner community",
@@ -260,6 +261,12 @@ mod tests {
     fn test_landscape_kind_label() {
         let values = askama::NO_VALUES;
 
+        assert_eq!(
+            landscape_kind_label::default()
+                .execute("accelerator", values)
+                .unwrap(),
+            "Accelerator"
+        );
         assert_eq!(
             landscape_kind_label::default()
                 .execute("partner_community", values)

--- a/ocg-server/src/types/landscape.rs
+++ b/ocg-server/src/types/landscape.rs
@@ -1,6 +1,6 @@
 //! Landscape domain types.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use garde::Validate;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
@@ -10,19 +10,21 @@ use crate::{
     templates::dashboard,
     types::pagination::{Pagination, ToRawQuery},
     validation::{
-        MAX_LEN_DESCRIPTION, MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_ENTITY_NAME, MAX_LEN_M,
-        MAX_LEN_TAG, MAX_PAGINATION_LIMIT, image_url_opt, optional_trimmed_string,
+        MAX_LEN_DATE, MAX_LEN_DESCRIPTION, MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_ENTITY_NAME,
+        MAX_LEN_M, MAX_LEN_TAG, MAX_PAGINATION_LIMIT, image_url_opt, optional_trimmed_string,
         trimmed_non_empty, trimmed_non_empty_opt,
     },
 };
 
-const LANDSCAPE_KINDS: [&str; 5] = [
+const LANDSCAPE_KINDS: [&str; 6] = [
+    "accelerator",
     "startup",
     "github_project",
     "partner_community",
     "podcast_lead",
     "investor",
 ];
+const ACCELERATOR_COHORT_STATUSES: [&str; 4] = ["planned", "open", "running", "completed"];
 
 /// Public landscape search filters.
 #[skip_serializing_none]
@@ -135,6 +137,34 @@ pub(crate) struct LandscapeEntryInput {
     #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(length(max = MAX_LEN_M))]
     pub tags: Option<String>,
+    /// Accelerator application URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_M), custom(trimmed_non_empty_opt))]
+    pub accelerator_application_url: Option<String>,
+    /// Accelerator curriculum URL.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(url, length(max = MAX_LEN_M), custom(trimmed_non_empty_opt))]
+    pub accelerator_curriculum_url: Option<String>,
+    /// Accelerator cohort status.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_accelerator_cohort_status_opt), length(max = MAX_LEN_M))]
+    pub accelerator_cohort_status: Option<String>,
+    /// Accelerator start date in YYYY-MM-DD format.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub accelerator_starts_on: Option<String>,
+    /// Accelerator end date in YYYY-MM-DD format.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_date_opt), length(max = MAX_LEN_DATE))]
+    pub accelerator_ends_on: Option<String>,
+    /// Accelerator tracks, comma-separated.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(length(max = MAX_LEN_M))]
+    pub accelerator_tracks: Option<String>,
+    /// Accelerator weekly agenda as JSON.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(valid_json_opt), length(max = MAX_LEN_DESCRIPTION))]
+    pub accelerator_weekly_agenda: Option<String>,
 }
 
 /// Landscape search output.
@@ -179,12 +209,38 @@ pub(crate) struct LandscapeEntry {
     pub tags: Vec<String>,
     /// Whether the entry is public.
     pub published: bool,
+    /// Accelerator-specific profile.
+    pub accelerator: Option<LandscapeAcceleratorProfile>,
     /// Creation time.
     #[serde(with = "chrono::serde::ts_seconds")]
     pub created_at: DateTime<Utc>,
     /// Last update time.
     #[serde(default, with = "chrono::serde::ts_seconds_option")]
     pub updated_at: Option<DateTime<Utc>>,
+}
+
+/// Accelerator-specific metadata for a landscape entry.
+#[skip_serializing_none]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct LandscapeAcceleratorProfile {
+    /// Application URL.
+    pub application_url: Option<String>,
+    /// Curriculum URL.
+    pub curriculum_url: Option<String>,
+    /// Cohort lifecycle status.
+    pub cohort_status: Option<String>,
+    /// Cohort start date in YYYY-MM-DD format.
+    pub starts_on: Option<String>,
+    /// Cohort end date in YYYY-MM-DD format.
+    pub ends_on: Option<String>,
+    /// Accelerator tracks.
+    #[serde(default)]
+    pub tracks: Vec<String>,
+    /// Structured weekly agenda.
+    pub weekly_agenda: Option<serde_json::Value>,
+    /// Last accelerator metadata update time.
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Tags parsed from comma-separated form input.
@@ -199,6 +255,11 @@ pub(crate) fn parse_tags(input: Option<&str>) -> Vec<String> {
         .collect()
 }
 
+/// Accelerator tracks parsed from comma-separated form input.
+pub(crate) fn parse_accelerator_tracks(input: Option<&str>) -> Vec<String> {
+    parse_tags(input)
+}
+
 #[allow(clippy::trivially_copy_pass_by_ref)]
 fn valid_landscape_kind(value: &impl AsRef<str>, _ctx: &()) -> garde::Result {
     let value = value.as_ref().trim();
@@ -209,17 +270,82 @@ fn valid_landscape_kind(value: &impl AsRef<str>, _ctx: &()) -> garde::Result {
     }
 }
 
+fn valid_accelerator_cohort_status_opt(
+    value: &Option<String>,
+    _ctx: &(),
+) -> garde::Result {
+    let Some(value) = value.as_deref().map(str::trim) else {
+        return Ok(());
+    };
+    if ACCELERATOR_COHORT_STATUSES.contains(&value) {
+        Ok(())
+    } else {
+        Err(garde::Error::new("invalid accelerator cohort status"))
+    }
+}
+
+fn valid_date_opt(value: &Option<String>, _ctx: &()) -> garde::Result {
+    let Some(value) = value.as_deref().map(str::trim) else {
+        return Ok(());
+    };
+    NaiveDate::parse_from_str(value, "%Y-%m-%d")
+        .map(|_| ())
+        .map_err(|_| garde::Error::new("invalid date"))
+}
+
+fn valid_json_opt(value: &Option<String>, _ctx: &()) -> garde::Result {
+    let Some(value) = value.as_deref().map(str::trim) else {
+        return Ok(());
+    };
+    serde_json::from_str::<serde_json::Value>(value)
+        .map(|_| ())
+        .map_err(|_| garde::Error::new("invalid JSON"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn validates_landscape_kinds() {
+        assert!(valid_landscape_kind(&"accelerator", &()).is_ok());
         assert!(valid_landscape_kind(&"startup", &()).is_ok());
         assert!(valid_landscape_kind(&"github_project", &()).is_ok());
         assert!(valid_landscape_kind(&"partner_community", &()).is_ok());
         assert!(valid_landscape_kind(&"podcast_lead", &()).is_ok());
         assert!(valid_landscape_kind(&"investor", &()).is_ok());
         assert!(valid_landscape_kind(&"unknown", &()).is_err());
+    }
+
+    #[test]
+    fn parses_accelerator_tracks() {
+        assert_eq!(
+            parse_accelerator_tracks(Some("AI, Open Source, Revenue")),
+            vec!["AI", "Open Source", "Revenue"]
+        );
+        assert!(parse_accelerator_tracks(None).is_empty());
+    }
+
+    #[test]
+    fn validates_accelerator_cohort_statuses() {
+        assert!(valid_accelerator_cohort_status_opt(&None, &()).is_ok());
+        assert!(valid_accelerator_cohort_status_opt(&Some("planned".to_string()), &()).is_ok());
+        assert!(valid_accelerator_cohort_status_opt(&Some("open".to_string()), &()).is_ok());
+        assert!(valid_accelerator_cohort_status_opt(&Some("running".to_string()), &()).is_ok());
+        assert!(valid_accelerator_cohort_status_opt(&Some("completed".to_string()), &()).is_ok());
+        assert!(valid_accelerator_cohort_status_opt(&Some("paused".to_string()), &()).is_err());
+    }
+
+    #[test]
+    fn validates_accelerator_dates_and_agenda_json() {
+        assert!(valid_date_opt(&Some("2026-07-08".to_string()), &()).is_ok());
+        assert!(valid_date_opt(&Some("07/08/2026".to_string()), &()).is_err());
+        assert!(
+            valid_json_opt(&Some(
+                r#"[{"week":1,"focus":"AI Distribution"}]"#.to_string()
+            ), &())
+            .is_ok()
+        );
+        assert!(valid_json_opt(&Some("not-json".to_string()), &()).is_err());
     }
 }

--- a/ocg-server/templates/dashboard/alliance/analytics.html
+++ b/ocg-server/templates/dashboard/alliance/analytics.html
@@ -32,8 +32,7 @@ description = "Alliance statistics and growth trends. Analytics are cached for a
           <button type="submit" class="btn-secondary">Unpublish</button>
         </form>
       {% else -%}
-        <form hx-put="/dashboard/alliance/analytics/report/public"
-              hx-swap="none">
+        <form hx-put="/dashboard/alliance/analytics/report/public" hx-swap="none">
           <button type="submit" class="btn-primary">Publish to public page</button>
         </form>
       {% endif -%}

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -306,7 +306,9 @@
                      value="{{ entry.github_url.as_deref().unwrap_or("") }}" />
             </div>
             {% let logo_value -%}
-            {% if let Some(logo_url) = &entry.logo_url %}value="{{ logo_url }}"{% endif %}
+            {% if let Some(logo_url) = &entry.logo_url %}
+              value="{{ logo_url }}"
+            {% endif %}
           {%- endlet %}
           {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", value_attr = logo_value, field_class = "lg:col-span-2") -}}
           <div class="space-y-2">
@@ -334,7 +336,7 @@
                      class="input-primary"
                      type="url"
                      {% if let Some(accelerator) = &entry.accelerator -%}
-                       value="{{ accelerator.application_url.as_deref().unwrap_or("") }}"
+                     value="{{ accelerator.application_url.as_deref().unwrap_or("") }}"
                      {%- endif %} />
             </div>
             <div class="space-y-2 lg:col-span-6">
@@ -345,7 +347,7 @@
                      class="input-primary"
                      type="url"
                      {% if let Some(accelerator) = &entry.accelerator -%}
-                       value="{{ accelerator.curriculum_url.as_deref().unwrap_or("") }}"
+                     value="{{ accelerator.curriculum_url.as_deref().unwrap_or("") }}"
                      {%- endif %} />
             </div>
             <div class="space-y-2 lg:col-span-4">
@@ -356,13 +358,21 @@
                       class="select-primary">
                 <option value="">Not set</option>
                 <option value="planned"
-                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("planned") %}selected{% endif %}{% endif %}>Planned</option>
+                        {% if let Some(accelerator) = &entry.accelerator %}
+                          {% if accelerator.cohort_status.as_deref() == Some("planned") %}selected{% endif %}
+                        {% endif %}>Planned</option>
                 <option value="open"
-                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("open") %}selected{% endif %}{% endif %}>Open</option>
+                        {% if let Some(accelerator) = &entry.accelerator %}
+                          {% if accelerator.cohort_status.as_deref() == Some("open") %}selected{% endif %}
+                        {% endif %}>Open</option>
                 <option value="running"
-                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("running") %}selected{% endif %}{% endif %}>Running</option>
+                        {% if let Some(accelerator) = &entry.accelerator %}
+                          {% if accelerator.cohort_status.as_deref() == Some("running") %}selected{% endif %}
+                        {% endif %}>Running</option>
                 <option value="completed"
-                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("completed") %}selected{% endif %}{% endif %}>Completed</option>
+                        {% if let Some(accelerator) = &entry.accelerator %}
+                          {% if accelerator.cohort_status.as_deref() == Some("completed") %}selected{% endif %}
+                        {% endif %}>Completed</option>
               </select>
             </div>
             <div class="space-y-2 lg:col-span-4">
@@ -373,7 +383,7 @@
                      class="input-primary"
                      type="date"
                      {% if let Some(accelerator) = &entry.accelerator -%}
-                       value="{{ accelerator.starts_on.as_deref().unwrap_or("") }}"
+                     value="{{ accelerator.starts_on.as_deref().unwrap_or("") }}"
                      {%- endif %} />
             </div>
             <div class="space-y-2 lg:col-span-4">
@@ -384,7 +394,7 @@
                      class="input-primary"
                      type="date"
                      {% if let Some(accelerator) = &entry.accelerator -%}
-                       value="{{ accelerator.ends_on.as_deref().unwrap_or("") }}"
+                     value="{{ accelerator.ends_on.as_deref().unwrap_or("") }}"
                      {%- endif %} />
             </div>
             <div class="space-y-2 lg:col-span-12">
@@ -394,13 +404,13 @@
                      name="accelerator_tracks"
                      class="input-primary"
                      placeholder="AI, Open Source, Startup, Revenue"
-                     {% if let Some(accelerator) = &entry.accelerator -%}
-                       value="{{ accelerator.tracks.join(", ") }}"
-                     {%- endif %} />
+                     {% if let Some(accelerator) = &entry.accelerator -%}value="{{ accelerator.tracks.join(", ") }}"{%- endif %} />
             </div>
             <div class="space-y-2 lg:col-span-12">
               <label class="form-label"
-                     for="accelerator-weekly-agenda-{{ entry.landscape_entry_id }}">Weekly agenda JSON</label>
+                     for="accelerator-weekly-agenda-{{ entry.landscape_entry_id }}">
+                Weekly agenda JSON
+              </label>
               <textarea id="accelerator-weekly-agenda-{{ entry.landscape_entry_id }}"
                         name="accelerator_weekly_agenda"
                         rows="6"

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -2,7 +2,7 @@
 {% import "macros/form_fields.html" as form_fields -%}
 {% import "macros/pagination.html" as pagination -%}
 
-{{ dashboard::page_title(title = "Landscape", description = "Manage startups, GitHub projects, partner communities, investors, and podcast leads shown on the public landscape.") -}}
+{{ dashboard::page_title(title = "Landscape", description = "Manage startups, accelerators, GitHub projects, partner communities, investors, and podcast leads shown on the public landscape.") -}}
 
 {% if can_manage_landscape -%}
   <section class="mt-8 overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
@@ -14,7 +14,7 @@
           </div>
           <h2 class="mt-3 text-xl font-black tracking-tight text-stone-950">Add landscape entry</h2>
           <p class="mt-2 max-w-2xl text-sm/6 text-stone-600">
-            Add startups, open-source projects, partner communities, investors, podcast leads, and tools that should appear in the public GOUP
+            Add startups, accelerators, open-source projects, partner communities, investors, podcast leads, and tools that should appear in the public GOUP
             ecosystem map. Keep the summary clear so visitors understand what it does quickly.
           </p>
         </div>
@@ -33,12 +33,13 @@
           <input id="new-landscape-name"
                  name="name"
                  class="input-primary"
-                 placeholder="Project, startup, community, investor, or podcast name"
+                 placeholder="Project, startup, accelerator, community, investor, or podcast name"
                  required />
         </div>
         <div class="space-y-2 lg:col-span-3">
           <label class="form-label" for="new-landscape-kind">Kind</label>
           <select id="new-landscape-kind" name="kind" class="select-primary" required>
+            <option value="accelerator">Accelerator</option>
             <option value="startup">Startup</option>
             <option value="github_project">GitHub project</option>
             <option value="partner_community">Partner community</option>
@@ -96,6 +97,74 @@
         </div>
         {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", legend = "Optional logo shown on public landscape cards.", field_class = "lg:col-span-12") -}}
       </div>
+      <div class="rounded-3xl border border-primary-100 bg-primary-50/40 p-5">
+        <div class="mb-4">
+          <h3 class="text-base font-black tracking-tight text-stone-950">Accelerator details</h3>
+          <p class="mt-1 text-sm/6 text-stone-600">
+            Used when the kind is Accelerator. These fields power application, curriculum, cohort, and track details on the public landscape.
+          </p>
+        </div>
+        <div class="grid gap-5 lg:grid-cols-12">
+          <div class="space-y-2 lg:col-span-6">
+            <label class="form-label" for="new-accelerator-application-url">Application URL</label>
+            <input id="new-accelerator-application-url"
+                   name="accelerator_application_url"
+                   class="input-primary"
+                   type="url"
+                   placeholder="https://..." />
+          </div>
+          <div class="space-y-2 lg:col-span-6">
+            <label class="form-label" for="new-accelerator-curriculum-url">Curriculum URL</label>
+            <input id="new-accelerator-curriculum-url"
+                   name="accelerator_curriculum_url"
+                   class="input-primary"
+                   type="url"
+                   placeholder="https://..." />
+          </div>
+          <div class="space-y-2 lg:col-span-4">
+            <label class="form-label" for="new-accelerator-cohort-status">Cohort status</label>
+            <select id="new-accelerator-cohort-status"
+                    name="accelerator_cohort_status"
+                    class="select-primary">
+              <option value="">Not set</option>
+              <option value="planned">Planned</option>
+              <option value="open">Open</option>
+              <option value="running">Running</option>
+              <option value="completed">Completed</option>
+            </select>
+          </div>
+          <div class="space-y-2 lg:col-span-4">
+            <label class="form-label" for="new-accelerator-starts-on">Starts on</label>
+            <input id="new-accelerator-starts-on"
+                   name="accelerator_starts_on"
+                   class="input-primary"
+                   type="date" />
+          </div>
+          <div class="space-y-2 lg:col-span-4">
+            <label class="form-label" for="new-accelerator-ends-on">Ends on</label>
+            <input id="new-accelerator-ends-on"
+                   name="accelerator_ends_on"
+                   class="input-primary"
+                   type="date" />
+          </div>
+          <div class="space-y-2 lg:col-span-12">
+            <label class="form-label" for="new-accelerator-tracks">Tracks</label>
+            <input id="new-accelerator-tracks"
+                   name="accelerator_tracks"
+                   class="input-primary"
+                   placeholder="AI, Open Source, Startup, Revenue" />
+          </div>
+          <div class="space-y-2 lg:col-span-12">
+            <label class="form-label" for="new-accelerator-weekly-agenda">Weekly agenda JSON</label>
+            <textarea id="new-accelerator-weekly-agenda"
+                      name="accelerator_weekly_agenda"
+                      rows="6"
+                      class="input-primary min-h-40 resize-y"
+                      placeholder='[{"week":1,"focus":"AI Distribution","outcome":"Publish AI content"}]'></textarea>
+            <p class="form-legend">Optional structured agenda JSON. Leave blank if the curriculum URL is enough.</p>
+          </div>
+        </div>
+      </div>
       <div class="flex flex-col gap-4 rounded-3xl border border-stone-100 bg-stone-50/80 p-4 sm:flex-row sm:items-center sm:justify-end">
         <button class="btn-primary" type="submit">Add entry</button>
       </div>
@@ -130,7 +199,7 @@
   <div class="rounded-2xl border border-dashed border-stone-300 bg-white px-6 py-16 text-center">
     <h2 class="text-lg font-semibold text-stone-900">No landscape entries yet</h2>
     <p class="mt-2 text-sm text-stone-600">
-      Add startups, GitHub projects, partner communities, investors, or podcast leads using the form above.
+      Add startups, accelerators, GitHub projects, partner communities, investors, or podcast leads using the form above.
     </p>
   </div>
 {% else -%}
@@ -179,6 +248,8 @@
                       class="select-primary"
                       required>
                 <option value="startup" {% if entry.kind == "startup" %}selected{% endif %}>Startup</option>
+                <option value="accelerator"
+                        {% if entry.kind == "accelerator" %}selected{% endif %}>Accelerator</option>
                 <option value="github_project"
                         {% if entry.kind == "github_project" %}selected{% endif %}>GitHub project</option>
                 <option value="partner_community"
@@ -245,6 +316,98 @@
                    name="tags"
                    class="input-primary"
                    value="{{ entry.tags.join(", ") }}" />
+          </div>
+        </div>
+        <div class="rounded-3xl border border-primary-100 bg-primary-50/40 p-5">
+          <div class="mb-4">
+            <h3 class="text-base font-black tracking-tight text-stone-950">Accelerator details</h3>
+            <p class="mt-1 text-sm/6 text-stone-600">
+              Used when the kind is Accelerator. Changing the kind away from Accelerator clears these details on save.
+            </p>
+          </div>
+          <div class="grid gap-5 lg:grid-cols-12">
+            <div class="space-y-2 lg:col-span-6">
+              <label class="form-label"
+                     for="accelerator-application-url-{{ entry.landscape_entry_id }}">Application URL</label>
+              <input id="accelerator-application-url-{{ entry.landscape_entry_id }}"
+                     name="accelerator_application_url"
+                     class="input-primary"
+                     type="url"
+                     {% if let Some(accelerator) = &entry.accelerator -%}
+                       value="{{ accelerator.application_url.as_deref().unwrap_or("") }}"
+                     {%- endif %} />
+            </div>
+            <div class="space-y-2 lg:col-span-6">
+              <label class="form-label"
+                     for="accelerator-curriculum-url-{{ entry.landscape_entry_id }}">Curriculum URL</label>
+              <input id="accelerator-curriculum-url-{{ entry.landscape_entry_id }}"
+                     name="accelerator_curriculum_url"
+                     class="input-primary"
+                     type="url"
+                     {% if let Some(accelerator) = &entry.accelerator -%}
+                       value="{{ accelerator.curriculum_url.as_deref().unwrap_or("") }}"
+                     {%- endif %} />
+            </div>
+            <div class="space-y-2 lg:col-span-4">
+              <label class="form-label"
+                     for="accelerator-cohort-status-{{ entry.landscape_entry_id }}">Cohort status</label>
+              <select id="accelerator-cohort-status-{{ entry.landscape_entry_id }}"
+                      name="accelerator_cohort_status"
+                      class="select-primary">
+                <option value="">Not set</option>
+                <option value="planned"
+                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("planned") %}selected{% endif %}{% endif %}>Planned</option>
+                <option value="open"
+                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("open") %}selected{% endif %}{% endif %}>Open</option>
+                <option value="running"
+                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("running") %}selected{% endif %}{% endif %}>Running</option>
+                <option value="completed"
+                        {% if let Some(accelerator) = &entry.accelerator %}{% if accelerator.cohort_status.as_deref() == Some("completed") %}selected{% endif %}{% endif %}>Completed</option>
+              </select>
+            </div>
+            <div class="space-y-2 lg:col-span-4">
+              <label class="form-label"
+                     for="accelerator-starts-on-{{ entry.landscape_entry_id }}">Starts on</label>
+              <input id="accelerator-starts-on-{{ entry.landscape_entry_id }}"
+                     name="accelerator_starts_on"
+                     class="input-primary"
+                     type="date"
+                     {% if let Some(accelerator) = &entry.accelerator -%}
+                       value="{{ accelerator.starts_on.as_deref().unwrap_or("") }}"
+                     {%- endif %} />
+            </div>
+            <div class="space-y-2 lg:col-span-4">
+              <label class="form-label"
+                     for="accelerator-ends-on-{{ entry.landscape_entry_id }}">Ends on</label>
+              <input id="accelerator-ends-on-{{ entry.landscape_entry_id }}"
+                     name="accelerator_ends_on"
+                     class="input-primary"
+                     type="date"
+                     {% if let Some(accelerator) = &entry.accelerator -%}
+                       value="{{ accelerator.ends_on.as_deref().unwrap_or("") }}"
+                     {%- endif %} />
+            </div>
+            <div class="space-y-2 lg:col-span-12">
+              <label class="form-label"
+                     for="accelerator-tracks-{{ entry.landscape_entry_id }}">Tracks</label>
+              <input id="accelerator-tracks-{{ entry.landscape_entry_id }}"
+                     name="accelerator_tracks"
+                     class="input-primary"
+                     placeholder="AI, Open Source, Startup, Revenue"
+                     {% if let Some(accelerator) = &entry.accelerator -%}
+                       value="{{ accelerator.tracks.join(", ") }}"
+                     {%- endif %} />
+            </div>
+            <div class="space-y-2 lg:col-span-12">
+              <label class="form-label"
+                     for="accelerator-weekly-agenda-{{ entry.landscape_entry_id }}">Weekly agenda JSON</label>
+              <textarea id="accelerator-weekly-agenda-{{ entry.landscape_entry_id }}"
+                        name="accelerator_weekly_agenda"
+                        rows="6"
+                        class="input-primary min-h-40 resize-y"
+                        placeholder='[{"week":1,"focus":"AI Distribution","outcome":"Publish AI content"}]'>{% if let Some(accelerator) = &entry.accelerator %}{% if let Some(weekly_agenda) = &accelerator.weekly_agenda %}{{ weekly_agenda }}{% endif %}{% endif %}</textarea>
+              <p class="form-legend">Optional structured agenda JSON. Leave blank if the curriculum URL is enough.</p>
+            </div>
           </div>
         </div>
         {% if can_manage_landscape -%}

--- a/ocg-server/templates/dashboard/group/accelerator.html
+++ b/ocg-server/templates/dashboard/group/accelerator.html
@@ -1,0 +1,356 @@
+{% import "macros/dashboard.html" as dashboard -%}
+
+{{ dashboard::page_title(title = "Accelerator", description = "Run accelerator programs, cohorts, applications, members, curriculum, and weekly updates from the group dashboard.") -}}
+
+<div class="my-5 grid gap-6">
+  <section class="overflow-hidden rounded-[2rem] border border-stone-200 bg-white shadow-sm">
+    <div class="border-b border-stone-100 bg-linear-to-br from-primary-50/80 via-white to-stone-50 px-5 py-5 sm:px-6">
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div class="inline-flex rounded-full border border-primary-200 bg-white/80 px-3 py-1 text-xs font-bold uppercase tracking-[0.18em] text-primary-700">
+            Program
+          </div>
+          <h2 class="mt-3 text-xl font-black tracking-tight text-stone-950">Create accelerator program</h2>
+          <p class="mt-2 max-w-2xl text-sm/6 text-stone-600">
+            Programs are the top-level container for cohorts, applications, weekly curriculum, and updates.
+          </p>
+        </div>
+        {% if !can_manage_accelerator -%}
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">Read only.</div>
+        {% endif -%}
+      </div>
+    </div>
+
+    <form class="inert-form grid gap-5 p-5 sm:p-6"
+          hx-post="/dashboard/group/accelerator/programs"
+          hx-target="#dashboard-content"
+          hx-indicator="#dashboard-spinner"
+          {% if !can_manage_accelerator -%}
+            inert
+          {% endif -%}>
+      <div class="grid gap-4 lg:grid-cols-2">
+        <label class="block">
+          <span class="form-label">Name</span>
+          <input name="name" class="input-primary mt-2" placeholder="Open Source Accelerator" required>
+        </label>
+        <label class="block">
+          <span class="form-label">Summary</span>
+          <input name="summary" class="input-primary mt-2" placeholder="10-week build and distribution program" required>
+        </label>
+      </div>
+      <label class="block">
+        <span class="form-label">Description</span>
+        <textarea name="description" class="input-primary mt-2 min-h-24" placeholder="Who it is for, how it works, and what outcomes you expect."></textarea>
+      </label>
+      <div class="grid gap-4 lg:grid-cols-3">
+        <label class="block">
+          <span class="form-label">Application URL</span>
+          <input name="application_url" class="input-primary mt-2" placeholder="https://...">
+        </label>
+        <label class="block">
+          <span class="form-label">Curriculum URL</span>
+          <input name="curriculum_url" class="input-primary mt-2" placeholder="https://...">
+        </label>
+        <label class="block">
+          <span class="form-label">Active</span>
+          <select name="active" class="select-primary mt-2">
+            <option value="true">Yes</option>
+            <option value="false">No</option>
+          </select>
+        </label>
+      </div>
+      <div class="flex justify-end border-t border-stone-100 pt-5">
+        <button type="submit" class="btn-primary" {% if !can_manage_accelerator %}disabled{% endif %}>Add program</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="grid gap-6 xl:grid-cols-2">
+    <article class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-6">
+      <h2 class="text-xl font-black tracking-tight text-stone-950">Create cohort</h2>
+      <p class="mt-2 text-sm/6 text-stone-600">Open applications, run cohorts, and close them after demo day.</p>
+      <form class="inert-form mt-5 grid gap-4"
+            hx-post="/dashboard/group/accelerator/cohorts"
+            hx-target="#dashboard-content"
+            hx-indicator="#dashboard-spinner"
+            {% if !can_manage_accelerator || programs.is_empty() -%}
+              inert
+            {% endif -%}>
+        <label class="block">
+          <span class="form-label">Program</span>
+          <select name="group_accelerator_program_id" class="select-primary mt-2" required>
+            {% for program in programs -%}
+              <option value="{{ program.group_accelerator_program_id }}">{{ program.name }}</option>
+            {% endfor -%}
+          </select>
+        </label>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <label class="block">
+            <span class="form-label">Name</span>
+            <input name="name" class="input-primary mt-2" placeholder="Spring 2027" required>
+          </label>
+          <label class="block">
+            <span class="form-label">Status</span>
+            <select name="status" class="select-primary mt-2">
+              <option value="planned">Planned</option>
+              <option value="open">Open</option>
+              <option value="running">Running</option>
+              <option value="completed">Completed</option>
+              <option value="archived">Archived</option>
+            </select>
+          </label>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <label class="block">
+            <span class="form-label">Starts on</span>
+            <input name="starts_on" type="date" class="input-primary mt-2">
+          </label>
+          <label class="block">
+            <span class="form-label">Ends on</span>
+            <input name="ends_on" type="date" class="input-primary mt-2">
+          </label>
+          <label class="block">
+            <span class="form-label">Application deadline</span>
+            <input name="application_deadline" type="date" class="input-primary mt-2">
+          </label>
+          <label class="block">
+            <span class="form-label">Capacity</span>
+            <input name="capacity" type="number" min="1" class="input-primary mt-2">
+          </label>
+        </div>
+        <button type="submit" class="btn-primary" {% if !can_manage_accelerator || programs.is_empty() %}disabled{% endif %}>Add cohort</button>
+      </form>
+    </article>
+
+    <article class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-6">
+      <h2 class="text-xl font-black tracking-tight text-stone-950">Add weekly curriculum</h2>
+      <p class="mt-2 text-sm/6 text-stone-600">Create or replace a week by cohort and week number.</p>
+      <form class="inert-form mt-5 grid gap-4"
+            hx-post="/dashboard/group/accelerator/weeks"
+            hx-target="#dashboard-content"
+            hx-indicator="#dashboard-spinner"
+            {% if !can_manage_accelerator || cohorts.is_empty() -%}
+              inert
+            {% endif -%}>
+        <label class="block">
+          <span class="form-label">Cohort</span>
+          <select name="group_accelerator_cohort_id" class="select-primary mt-2" required>
+            {% for cohort in cohorts -%}
+              <option value="{{ cohort.group_accelerator_cohort_id }}">{{ cohort.name }}</option>
+            {% endfor -%}
+          </select>
+        </label>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <label class="block">
+            <span class="form-label">Week number</span>
+            <input name="week_number" type="number" min="1" class="input-primary mt-2" required>
+          </label>
+          <label class="block">
+            <span class="form-label">Title</span>
+            <input name="title" class="input-primary mt-2" placeholder="AI Distribution" required>
+          </label>
+        </div>
+        <label class="block">
+          <span class="form-label">Goals</span>
+          <textarea name="goals" class="input-primary mt-2 min-h-20" placeholder="What participants should accomplish this week."></textarea>
+        </label>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <label class="block">
+            <span class="form-label">Resources URL</span>
+            <input name="resources_url" class="input-primary mt-2" placeholder="https://...">
+          </label>
+          <label class="block">
+            <span class="form-label">Deliverable</span>
+            <input name="deliverable" class="input-primary mt-2" placeholder="Publish 3 posts and share metrics">
+          </label>
+        </div>
+        <div class="grid gap-4 lg:grid-cols-2">
+          <label class="block">
+            <span class="form-label">Starts on</span>
+            <input name="starts_on" type="date" class="input-primary mt-2">
+          </label>
+          <label class="block">
+            <span class="form-label">Due on</span>
+            <input name="due_on" type="date" class="input-primary mt-2">
+          </label>
+        </div>
+        <button type="submit" class="btn-primary" {% if !can_manage_accelerator || cohorts.is_empty() %}disabled{% endif %}>Save week</button>
+      </form>
+    </article>
+  </section>
+
+  <section class="grid gap-5 xl:grid-cols-2">
+    {% for program in programs -%}
+      <article class="rounded-2xl border border-stone-200 bg-white p-5 shadow-sm">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-bold text-stone-950">{{ program.name }}</h2>
+            <p class="mt-1 text-sm/6 text-stone-600">{{ program.summary }}</p>
+          </div>
+          {% if program.active -%}
+            <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-bold text-primary-700">Active</span>
+          {% else -%}
+            <span class="rounded-full bg-stone-100 px-2.5 py-1 text-xs font-bold text-stone-600">Inactive</span>
+          {% endif -%}
+        </div>
+        <div class="mt-4 flex flex-wrap gap-2">
+          {% if let Some(application_url) = &program.application_url -%}
+            <a href="{{ application_url }}" target="_blank" rel="noopener noreferrer" class="btn-secondary-anchor">Application</a>
+          {% endif -%}
+          {% if let Some(curriculum_url) = &program.curriculum_url -%}
+            <a href="{{ curriculum_url }}" target="_blank" rel="noopener noreferrer" class="btn-secondary-anchor">Curriculum</a>
+          {% endif -%}
+        </div>
+      </article>
+    {% endfor -%}
+  </section>
+
+  <section class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-6">
+    <h2 class="text-xl font-black tracking-tight text-stone-950">Cohorts and curriculum</h2>
+    {% if cohorts.is_empty() -%}
+      <p class="mt-3 text-sm text-stone-600">No cohorts yet.</p>
+    {% else -%}
+      <div class="mt-5 grid gap-5">
+        {% for cohort in cohorts -%}
+          <article class="rounded-2xl border border-stone-100 bg-stone-50/60 p-4">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 class="font-bold text-stone-950">{{ cohort.name }}</h3>
+                <p class="mt-1 text-sm text-stone-600">
+                  {{ cohort.status }}
+                  {% if let Some(starts_on) = &cohort.starts_on %} · Starts {{ starts_on }}{% endif %}
+                  {% if let Some(ends_on) = &cohort.ends_on %} · Ends {{ ends_on }}{% endif %}
+                  {% if let Some(capacity) = cohort.capacity %} · {{ capacity }} seats{% endif %}
+                </p>
+              </div>
+            </div>
+            <div class="mt-4 grid gap-3">
+              {% for week in weeks -%}
+                {% if week.group_accelerator_cohort_id == cohort.group_accelerator_cohort_id -%}
+                  <div class="rounded-xl border border-stone-200 bg-white p-3">
+                    <div class="font-semibold text-stone-950">Week {{ week.week_number }}: {{ week.title }}</div>
+                    {% if let Some(goals) = &week.goals -%}
+                      <p class="mt-1 text-sm/6 text-stone-600">{{ goals }}</p>
+                    {% endif -%}
+                    <div class="mt-2 flex flex-wrap gap-2 text-xs text-stone-500">
+                      {% if let Some(due_on) = &week.due_on -%}<span>Due {{ due_on }}</span>{% endif -%}
+                      {% if let Some(deliverable) = &week.deliverable -%}<span>{{ deliverable }}</span>{% endif -%}
+                      {% if let Some(resources_url) = &week.resources_url -%}<a href="{{ resources_url }}" target="_blank" rel="noopener noreferrer" class="text-primary-700 hover:underline">Resources</a>{% endif -%}
+                    </div>
+                  </div>
+                {% endif -%}
+              {% endfor -%}
+            </div>
+          </article>
+        {% endfor -%}
+      </div>
+    {% endif -%}
+  </section>
+
+  <section class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-6">
+    <h2 class="text-xl font-black tracking-tight text-stone-950">Applications</h2>
+    {% if applications.is_empty() -%}
+      <p class="mt-3 text-sm text-stone-600">No applications yet.</p>
+    {% else -%}
+      <div class="mt-5 grid gap-4">
+        {% for application in applications -%}
+          <article class="rounded-2xl border border-stone-200 p-4">
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <h3 class="font-bold text-stone-950">{{ application.project_name }}</h3>
+                <p class="mt-1 text-sm text-stone-600">{{ application.applicant_name }} · {{ application.applicant_email }} · {{ application.status }}</p>
+              </div>
+              {% if let Some(project_url) = &application.project_url -%}
+                <a href="{{ project_url }}" target="_blank" rel="noopener noreferrer" class="btn-secondary-anchor">Project</a>
+              {% endif -%}
+            </div>
+            <p class="mt-3 text-sm/6 text-stone-700">{{ application.pitch }}</p>
+            {% if let Some(goals) = &application.goals -%}
+              <p class="mt-2 text-sm/6 text-stone-500">{{ goals }}</p>
+            {% endif -%}
+            <form class="inert-form mt-4 grid gap-3 lg:grid-cols-[180px_1fr_auto_auto]"
+                  hx-put="/dashboard/group/accelerator/applications/{{ application.group_accelerator_application_id }}"
+                  hx-target="#dashboard-content"
+                  hx-indicator="#dashboard-spinner"
+                  {% if !can_manage_accelerator -%}
+                    inert
+                  {% endif -%}>
+              <select name="status" class="select-primary">
+                <option value="submitted" {% if application.status == "submitted" %}selected{% endif %}>Submitted</option>
+                <option value="reviewing" {% if application.status == "reviewing" %}selected{% endif %}>Reviewing</option>
+                <option value="accepted" {% if application.status == "accepted" %}selected{% endif %}>Accepted</option>
+                <option value="rejected" {% if application.status == "rejected" %}selected{% endif %}>Rejected</option>
+                <option value="waitlisted" {% if application.status == "waitlisted" %}selected{% endif %}>Waitlisted</option>
+              </select>
+              <input name="reviewer_notes" class="input-primary" value="{{ application.reviewer_notes.as_deref().unwrap_or("") }}" placeholder="Reviewer notes">
+              <button type="submit" class="btn-secondary" {% if !can_manage_accelerator %}disabled{% endif %}>Save review</button>
+              <button type="button"
+                      class="btn-primary"
+                      hx-post="/dashboard/group/accelerator/applications/{{ application.group_accelerator_application_id }}/accept"
+                      hx-target="#dashboard-content"
+                      hx-indicator="#dashboard-spinner"
+                      {% if !can_manage_accelerator -%}
+                        disabled
+                      {% endif -%}>Accept</button>
+            </form>
+          </article>
+        {% endfor -%}
+      </div>
+    {% endif -%}
+  </section>
+
+  <section class="grid gap-6 xl:grid-cols-2">
+    <article class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-6">
+      <h2 class="text-xl font-black tracking-tight text-stone-950">Cohort members</h2>
+      {% if members.is_empty() -%}
+        <p class="mt-3 text-sm text-stone-600">No accepted members yet.</p>
+      {% else -%}
+        <div class="mt-5 grid gap-3">
+          {% for member in members -%}
+            <div class="rounded-xl border border-stone-200 p-3">
+              <div class="font-semibold text-stone-950">{{ member.display_name }}</div>
+              <div class="text-sm text-stone-600">{{ member.project_name }} · {{ member.status }}</div>
+              {% if let Some(project_url) = &member.project_url -%}
+                <a href="{{ project_url }}" target="_blank" rel="noopener noreferrer" class="mt-2 inline-flex text-sm font-semibold text-primary-700 hover:underline">Project</a>
+              {% endif -%}
+            </div>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    </article>
+
+    <article class="rounded-[2rem] border border-stone-200 bg-white p-5 shadow-sm sm:p-6">
+      <h2 class="text-xl font-black tracking-tight text-stone-950">Weekly updates</h2>
+      {% if weekly_updates.is_empty() -%}
+        <p class="mt-3 text-sm text-stone-600">No weekly updates yet.</p>
+      {% else -%}
+        <div class="mt-5 grid gap-4">
+          {% for update in weekly_updates -%}
+            <form class="inert-form rounded-2xl border border-stone-200 p-4"
+                  hx-put="/dashboard/group/accelerator/weekly-updates/{{ update.group_accelerator_weekly_update_id }}"
+                  hx-target="#dashboard-content"
+                  hx-indicator="#dashboard-spinner"
+                  {% if !can_manage_accelerator -%}
+                    inert
+                  {% endif -%}>
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div class="font-semibold text-stone-950">{{ update.status }}</div>
+                <select name="status" class="select-primary max-w-40">
+                  <option value="submitted" {% if update.status == "submitted" %}selected{% endif %}>Submitted</option>
+                  <option value="reviewed" {% if update.status == "reviewed" %}selected{% endif %}>Reviewed</option>
+                </select>
+              </div>
+              <p class="mt-3 text-sm/6 text-stone-700">{{ update.shipped }}</p>
+              {% if let Some(metrics) = &update.metrics -%}<p class="mt-2 text-sm/6 text-stone-500">Metrics: {{ metrics }}</p>{% endif -%}
+              {% if let Some(blockers) = &update.blockers -%}<p class="mt-2 text-sm/6 text-stone-500">Blockers: {{ blockers }}</p>{% endif -%}
+              {% if let Some(asks) = &update.asks -%}<p class="mt-2 text-sm/6 text-stone-500">Asks: {{ asks }}</p>{% endif -%}
+              {% if let Some(links) = &update.links -%}<p class="mt-2 text-sm/6 text-stone-500">Links: {{ links }}</p>{% endif -%}
+              <textarea name="reviewer_notes" class="input-primary mt-3 min-h-20" placeholder="Feedback for the member">{{ update.reviewer_notes.as_deref().unwrap_or("") }}</textarea>
+              <button type="submit" class="btn-primary mt-3" {% if !can_manage_accelerator %}disabled{% endif %}>Save feedback</button>
+            </form>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    </article>
+  </section>
+</div>

--- a/ocg-server/templates/dashboard/group/accelerator.html
+++ b/ocg-server/templates/dashboard/group/accelerator.html
@@ -16,7 +16,9 @@
           </p>
         </div>
         {% if !can_manage_accelerator -%}
-          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">Read only.</div>
+          <div class="rounded-2xl border border-white/70 bg-white/80 px-4 py-3 text-xs/5 font-medium text-stone-500 shadow-sm">
+            Read only.
+          </div>
         {% endif -%}
       </div>
     </div>
@@ -31,25 +33,37 @@
       <div class="grid gap-4 lg:grid-cols-2">
         <label class="block">
           <span class="form-label">Name</span>
-          <input name="name" class="input-primary mt-2" placeholder="Open Source Accelerator" required>
+          <input name="name"
+                 class="input-primary mt-2"
+                 placeholder="Open Source Accelerator"
+                 required>
         </label>
         <label class="block">
           <span class="form-label">Summary</span>
-          <input name="summary" class="input-primary mt-2" placeholder="10-week build and distribution program" required>
+          <input name="summary"
+                 class="input-primary mt-2"
+                 placeholder="10-week build and distribution program"
+                 required>
         </label>
       </div>
       <label class="block">
         <span class="form-label">Description</span>
-        <textarea name="description" class="input-primary mt-2 min-h-24" placeholder="Who it is for, how it works, and what outcomes you expect."></textarea>
+        <textarea name="description"
+                  class="input-primary mt-2 min-h-24"
+                  placeholder="Who it is for, how it works, and what outcomes you expect."></textarea>
       </label>
       <div class="grid gap-4 lg:grid-cols-3">
         <label class="block">
           <span class="form-label">Application URL</span>
-          <input name="application_url" class="input-primary mt-2" placeholder="https://...">
+          <input name="application_url"
+                 class="input-primary mt-2"
+                 placeholder="https://...">
         </label>
         <label class="block">
           <span class="form-label">Curriculum URL</span>
-          <input name="curriculum_url" class="input-primary mt-2" placeholder="https://...">
+          <input name="curriculum_url"
+                 class="input-primary mt-2"
+                 placeholder="https://...">
         </label>
         <label class="block">
           <span class="form-label">Active</span>
@@ -60,7 +74,9 @@
         </label>
       </div>
       <div class="flex justify-end border-t border-stone-100 pt-5">
-        <button type="submit" class="btn-primary" {% if !can_manage_accelerator %}disabled{% endif %}>Add program</button>
+        <button type="submit"
+                class="btn-primary"
+                {% if !can_manage_accelerator %}disabled{% endif %}>Add program</button>
       </div>
     </form>
   </section>
@@ -78,7 +94,9 @@
             {% endif -%}>
         <label class="block">
           <span class="form-label">Program</span>
-          <select name="group_accelerator_program_id" class="select-primary mt-2" required>
+          <select name="group_accelerator_program_id"
+                  class="select-primary mt-2"
+                  required>
             {% for program in programs -%}
               <option value="{{ program.group_accelerator_program_id }}">{{ program.name }}</option>
             {% endfor -%}
@@ -87,7 +105,10 @@
         <div class="grid gap-4 lg:grid-cols-2">
           <label class="block">
             <span class="form-label">Name</span>
-            <input name="name" class="input-primary mt-2" placeholder="Spring 2027" required>
+            <input name="name"
+                   class="input-primary mt-2"
+                   placeholder="Spring 2027"
+                   required>
           </label>
           <label class="block">
             <span class="form-label">Status</span>
@@ -118,7 +139,9 @@
             <input name="capacity" type="number" min="1" class="input-primary mt-2">
           </label>
         </div>
-        <button type="submit" class="btn-primary" {% if !can_manage_accelerator || programs.is_empty() %}disabled{% endif %}>Add cohort</button>
+        <button type="submit"
+                class="btn-primary"
+                {% if !can_manage_accelerator || programs.is_empty() %}disabled{% endif %}>Add cohort</button>
       </form>
     </article>
 
@@ -134,7 +157,9 @@
             {% endif -%}>
         <label class="block">
           <span class="form-label">Cohort</span>
-          <select name="group_accelerator_cohort_id" class="select-primary mt-2" required>
+          <select name="group_accelerator_cohort_id"
+                  class="select-primary mt-2"
+                  required>
             {% for cohort in cohorts -%}
               <option value="{{ cohort.group_accelerator_cohort_id }}">{{ cohort.name }}</option>
             {% endfor -%}
@@ -143,25 +168,38 @@
         <div class="grid gap-4 lg:grid-cols-2">
           <label class="block">
             <span class="form-label">Week number</span>
-            <input name="week_number" type="number" min="1" class="input-primary mt-2" required>
+            <input name="week_number"
+                   type="number"
+                   min="1"
+                   class="input-primary mt-2"
+                   required>
           </label>
           <label class="block">
             <span class="form-label">Title</span>
-            <input name="title" class="input-primary mt-2" placeholder="AI Distribution" required>
+            <input name="title"
+                   class="input-primary mt-2"
+                   placeholder="AI Distribution"
+                   required>
           </label>
         </div>
         <label class="block">
           <span class="form-label">Goals</span>
-          <textarea name="goals" class="input-primary mt-2 min-h-20" placeholder="What participants should accomplish this week."></textarea>
+          <textarea name="goals"
+                    class="input-primary mt-2 min-h-20"
+                    placeholder="What participants should accomplish this week."></textarea>
         </label>
         <div class="grid gap-4 lg:grid-cols-2">
           <label class="block">
             <span class="form-label">Resources URL</span>
-            <input name="resources_url" class="input-primary mt-2" placeholder="https://...">
+            <input name="resources_url"
+                   class="input-primary mt-2"
+                   placeholder="https://...">
           </label>
           <label class="block">
             <span class="form-label">Deliverable</span>
-            <input name="deliverable" class="input-primary mt-2" placeholder="Publish 3 posts and share metrics">
+            <input name="deliverable"
+                   class="input-primary mt-2"
+                   placeholder="Publish 3 posts and share metrics">
           </label>
         </div>
         <div class="grid gap-4 lg:grid-cols-2">
@@ -174,7 +212,9 @@
             <input name="due_on" type="date" class="input-primary mt-2">
           </label>
         </div>
-        <button type="submit" class="btn-primary" {% if !can_manage_accelerator || cohorts.is_empty() %}disabled{% endif %}>Save week</button>
+        <button type="submit"
+                class="btn-primary"
+                {% if !can_manage_accelerator || cohorts.is_empty() %}disabled{% endif %}>Save week</button>
       </form>
     </article>
   </section>
@@ -195,10 +235,16 @@
         </div>
         <div class="mt-4 flex flex-wrap gap-2">
           {% if let Some(application_url) = &program.application_url -%}
-            <a href="{{ application_url }}" target="_blank" rel="noopener noreferrer" class="btn-secondary-anchor">Application</a>
+            <a href="{{ application_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="btn-secondary-anchor">Application</a>
           {% endif -%}
           {% if let Some(curriculum_url) = &program.curriculum_url -%}
-            <a href="{{ curriculum_url }}" target="_blank" rel="noopener noreferrer" class="btn-secondary-anchor">Curriculum</a>
+            <a href="{{ curriculum_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="btn-secondary-anchor">Curriculum</a>
           {% endif -%}
         </div>
       </article>
@@ -218,9 +264,9 @@
                 <h3 class="font-bold text-stone-950">{{ cohort.name }}</h3>
                 <p class="mt-1 text-sm text-stone-600">
                   {{ cohort.status }}
-                  {% if let Some(starts_on) = &cohort.starts_on %} · Starts {{ starts_on }}{% endif %}
-                  {% if let Some(ends_on) = &cohort.ends_on %} · Ends {{ ends_on }}{% endif %}
-                  {% if let Some(capacity) = cohort.capacity %} · {{ capacity }} seats{% endif %}
+                  {% if let Some(starts_on) = &cohort.starts_on %}· Starts {{ starts_on }}{% endif %}
+                  {% if let Some(ends_on) = &cohort.ends_on %}· Ends {{ ends_on }}{% endif %}
+                  {% if let Some(capacity) = cohort.capacity %}· {{ capacity }} seats{% endif %}
                 </p>
               </div>
             </div>
@@ -233,9 +279,18 @@
                       <p class="mt-1 text-sm/6 text-stone-600">{{ goals }}</p>
                     {% endif -%}
                     <div class="mt-2 flex flex-wrap gap-2 text-xs text-stone-500">
-                      {% if let Some(due_on) = &week.due_on -%}<span>Due {{ due_on }}</span>{% endif -%}
-                      {% if let Some(deliverable) = &week.deliverable -%}<span>{{ deliverable }}</span>{% endif -%}
-                      {% if let Some(resources_url) = &week.resources_url -%}<a href="{{ resources_url }}" target="_blank" rel="noopener noreferrer" class="text-primary-700 hover:underline">Resources</a>{% endif -%}
+                      {% if let Some(due_on) = &week.due_on -%}
+                        <span>Due {{ due_on }}</span>
+                      {% endif -%}
+                      {% if let Some(deliverable) = &week.deliverable -%}
+                        <span>{{ deliverable }}</span>
+                      {% endif -%}
+                      {% if let Some(resources_url) = &week.resources_url -%}
+                        <a href="{{ resources_url }}"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="text-primary-700 hover:underline">Resources</a>
+                      {% endif -%}
                     </div>
                   </div>
                 {% endif -%}
@@ -258,10 +313,15 @@
             <div class="flex flex-wrap items-start justify-between gap-3">
               <div>
                 <h3 class="font-bold text-stone-950">{{ application.project_name }}</h3>
-                <p class="mt-1 text-sm text-stone-600">{{ application.applicant_name }} · {{ application.applicant_email }} · {{ application.status }}</p>
+                <p class="mt-1 text-sm text-stone-600">
+                  {{ application.applicant_name }} · {{ application.applicant_email }} · {{ application.status }}
+                </p>
               </div>
               {% if let Some(project_url) = &application.project_url -%}
-                <a href="{{ project_url }}" target="_blank" rel="noopener noreferrer" class="btn-secondary-anchor">Project</a>
+                <a href="{{ project_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="btn-secondary-anchor">Project</a>
               {% endif -%}
             </div>
             <p class="mt-3 text-sm/6 text-stone-700">{{ application.pitch }}</p>
@@ -276,14 +336,24 @@
                     inert
                   {% endif -%}>
               <select name="status" class="select-primary">
-                <option value="submitted" {% if application.status == "submitted" %}selected{% endif %}>Submitted</option>
-                <option value="reviewing" {% if application.status == "reviewing" %}selected{% endif %}>Reviewing</option>
-                <option value="accepted" {% if application.status == "accepted" %}selected{% endif %}>Accepted</option>
-                <option value="rejected" {% if application.status == "rejected" %}selected{% endif %}>Rejected</option>
-                <option value="waitlisted" {% if application.status == "waitlisted" %}selected{% endif %}>Waitlisted</option>
+                <option value="submitted"
+                        {% if application.status == "submitted" %}selected{% endif %}>Submitted</option>
+                <option value="reviewing"
+                        {% if application.status == "reviewing" %}selected{% endif %}>Reviewing</option>
+                <option value="accepted"
+                        {% if application.status == "accepted" %}selected{% endif %}>Accepted</option>
+                <option value="rejected"
+                        {% if application.status == "rejected" %}selected{% endif %}>Rejected</option>
+                <option value="waitlisted"
+                        {% if application.status == "waitlisted" %}selected{% endif %}>Waitlisted</option>
               </select>
-              <input name="reviewer_notes" class="input-primary" value="{{ application.reviewer_notes.as_deref().unwrap_or("") }}" placeholder="Reviewer notes">
-              <button type="submit" class="btn-secondary" {% if !can_manage_accelerator %}disabled{% endif %}>Save review</button>
+              <input name="reviewer_notes"
+                     class="input-primary"
+                     value="{{ application.reviewer_notes.as_deref().unwrap_or("") }}"
+                     placeholder="Reviewer notes">
+              <button type="submit"
+                      class="btn-secondary"
+                      {% if !can_manage_accelerator %}disabled{% endif %}>Save review</button>
               <button type="button"
                       class="btn-primary"
                       hx-post="/dashboard/group/accelerator/applications/{{ application.group_accelerator_application_id }}/accept"
@@ -311,7 +381,10 @@
               <div class="font-semibold text-stone-950">{{ member.display_name }}</div>
               <div class="text-sm text-stone-600">{{ member.project_name }} · {{ member.status }}</div>
               {% if let Some(project_url) = &member.project_url -%}
-                <a href="{{ project_url }}" target="_blank" rel="noopener noreferrer" class="mt-2 inline-flex text-sm font-semibold text-primary-700 hover:underline">Project</a>
+                <a href="{{ project_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="mt-2 inline-flex text-sm font-semibold text-primary-700 hover:underline">Project</a>
               {% endif -%}
             </div>
           {% endfor -%}
@@ -336,17 +409,31 @@
               <div class="flex flex-wrap items-start justify-between gap-3">
                 <div class="font-semibold text-stone-950">{{ update.status }}</div>
                 <select name="status" class="select-primary max-w-40">
-                  <option value="submitted" {% if update.status == "submitted" %}selected{% endif %}>Submitted</option>
-                  <option value="reviewed" {% if update.status == "reviewed" %}selected{% endif %}>Reviewed</option>
+                  <option value="submitted"
+                          {% if update.status == "submitted" %}selected{% endif %}>Submitted</option>
+                  <option value="reviewed"
+                          {% if update.status == "reviewed" %}selected{% endif %}>Reviewed</option>
                 </select>
               </div>
               <p class="mt-3 text-sm/6 text-stone-700">{{ update.shipped }}</p>
-              {% if let Some(metrics) = &update.metrics -%}<p class="mt-2 text-sm/6 text-stone-500">Metrics: {{ metrics }}</p>{% endif -%}
-              {% if let Some(blockers) = &update.blockers -%}<p class="mt-2 text-sm/6 text-stone-500">Blockers: {{ blockers }}</p>{% endif -%}
-              {% if let Some(asks) = &update.asks -%}<p class="mt-2 text-sm/6 text-stone-500">Asks: {{ asks }}</p>{% endif -%}
-              {% if let Some(links) = &update.links -%}<p class="mt-2 text-sm/6 text-stone-500">Links: {{ links }}</p>{% endif -%}
-              <textarea name="reviewer_notes" class="input-primary mt-3 min-h-20" placeholder="Feedback for the member">{{ update.reviewer_notes.as_deref().unwrap_or("") }}</textarea>
-              <button type="submit" class="btn-primary mt-3" {% if !can_manage_accelerator %}disabled{% endif %}>Save feedback</button>
+              {% if let Some(metrics) = &update.metrics -%}
+                <p class="mt-2 text-sm/6 text-stone-500">Metrics: {{ metrics }}</p>
+              {% endif -%}
+              {% if let Some(blockers) = &update.blockers -%}
+                <p class="mt-2 text-sm/6 text-stone-500">Blockers: {{ blockers }}</p>
+              {% endif -%}
+              {% if let Some(asks) = &update.asks -%}
+                <p class="mt-2 text-sm/6 text-stone-500">Asks: {{ asks }}</p>
+              {% endif -%}
+              {% if let Some(links) = &update.links -%}
+                <p class="mt-2 text-sm/6 text-stone-500">Links: {{ links }}</p>
+              {% endif -%}
+              <textarea name="reviewer_notes"
+                        class="input-primary mt-3 min-h-20"
+                        placeholder="Feedback for the member">{{ update.reviewer_notes.as_deref().unwrap_or("") }}</textarea>
+              <button type="submit"
+                      class="btn-primary mt-3"
+                      {% if !can_manage_accelerator %}disabled{% endif %}>Save feedback</button>
             </form>
           {% endfor -%}
         </div>

--- a/ocg-server/templates/dashboard/group/analytics.html
+++ b/ocg-server/templates/dashboard/group/analytics.html
@@ -27,13 +27,11 @@ description = "Group statistics and growth trends. Analytics are cached for a fe
          rel="noopener noreferrer"
          class="btn-secondary-anchor">Generate PDF</a>
       {% if group.report_public_enabled -%}
-        <form hx-delete="/dashboard/group/analytics/report/public"
-              hx-swap="none">
+        <form hx-delete="/dashboard/group/analytics/report/public" hx-swap="none">
           <button type="submit" class="btn-secondary">Unpublish</button>
         </form>
       {% else -%}
-        <form hx-put="/dashboard/group/analytics/report/public"
-              hx-swap="none">
+        <form hx-put="/dashboard/group/analytics/report/public" hx-swap="none">
           <button type="submit" class="btn-primary">Publish to public page</button>
         </form>
       {% endif -%}

--- a/ocg-server/templates/dashboard/group/home.html
+++ b/ocg-server/templates/dashboard/group/home.html
@@ -90,6 +90,7 @@
     <div class="leading-10 pt-6 border-t border-stone-200 grid gap-y-0.5">
       {{ dashboard::menu_title(text = "Events", extra_styles = "py-1.5") -}}
       {{ dashboard::menu_item(name = "Events", icon = "calendar", is_active = content.is_events() , href = "/dashboard/group?tab=events") -}}
+      {{ dashboard::menu_item(name = "Accelerator", icon = "rocket", is_active = content.is_accelerator() , href = "/dashboard/group?tab=accelerator") -}}
     </div>
     {# End events -#}
 
@@ -124,7 +125,7 @@
        data-alliance-banner-mobile-url="{{ current_selection.0.banner_mobile_url }}"
        data-group-name="{{ current_selection.1.name }}"
        data-group-slug="{{ current_selection.1.public_slug() }}"
-       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_coffee_meet() -%}coffee-meet{%- else if content.is_spotlights() -%}spotlights{%- else if content.is_store() -%}store{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else -%}events{%- endif -%}"
+       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_coffee_meet() -%}coffee-meet{%- else if content.is_spotlights() -%}spotlights{%- else if content.is_store() -%}store{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else if content.is_accelerator() -%}accelerator{%- else -%}events{%- endif -%}"
        hx-trigger="refresh-group-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/group/report.html
+++ b/ocg-server/templates/group/report.html
@@ -38,7 +38,8 @@
 {% block content -%}
   <div class="container mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8 print:px-0">
     <div class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between print:hidden">
-      <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}" class="btn-secondary-anchor">Back to group</a>
+      <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}"
+         class="btn-secondary-anchor">Back to group</a>
       <button type="button" class="btn-primary" onclick="window.print()">Download PDF</button>
     </div>
 

--- a/ocg-server/templates/site/landscape/page.html
+++ b/ocg-server/templates/site/landscape/page.html
@@ -14,7 +14,7 @@
           Ecosystem landscape
         </h1>
         <p class="max-w-2xl text-base/7 font-medium text-stone-600">
-          Browse alliance startups, GitHub projects, partner communities, investors, podcast leads, tools, and community-built products.
+          Browse alliance startups, accelerators, GitHub projects, partner communities, investors, podcast leads, tools, and community-built products.
         </p>
       </div>
     </div>
@@ -109,7 +109,7 @@
              type="search"
              value="{{ filters.query.as_deref().unwrap_or("") }}"
              class="input h-11 border-stone-200 bg-stone-50/70 px-4 focus:bg-white"
-             placeholder="Search startups, GitHub projects, communities, investors, podcasts, categories, or tags" />
+             placeholder="Search startups, accelerators, GitHub projects, communities, investors, podcasts, categories, or tags" />
 
       <label class="sr-only" for="landscape-kind">Kind</label>
       <select id="landscape-kind"
@@ -118,6 +118,8 @@
         <option value="">All kinds</option>
         <option value="startup"
                 {% if filters.kind.as_deref() == Some("startup") %}selected{% endif %}>Startups</option>
+        <option value="accelerator"
+                {% if filters.kind.as_deref() == Some("accelerator") %}selected{% endif %}>Accelerators</option>
         <option value="github_project"
                 {% if filters.kind.as_deref() == Some("github_project") %}selected{% endif %}>GitHub projects</option>
         <option value="partner_community"
@@ -295,7 +297,46 @@
               </div>
             {% endif -%}
 
+            {% if let Some(accelerator) = &entry.accelerator -%}
+              <div class="mt-5 rounded-2xl border border-primary-100 bg-primary-50/50 p-4">
+                <div class="flex flex-wrap gap-2">
+                  {% if let Some(cohort_status) = &accelerator.cohort_status -%}
+                    <span class="rounded-full bg-primary-600 px-2.5 py-1 text-xs font-bold capitalize text-white">{{ cohort_status }}</span>
+                  {% endif -%}
+                  {% if let Some(starts_on) = &accelerator.starts_on -%}
+                    <span class="rounded-full bg-white px-2.5 py-1 text-xs font-bold text-stone-700 ring-1 ring-inset ring-primary-100">Starts {{ starts_on }}</span>
+                  {% endif -%}
+                  {% if let Some(ends_on) = &accelerator.ends_on -%}
+                    <span class="rounded-full bg-white px-2.5 py-1 text-xs font-bold text-stone-700 ring-1 ring-inset ring-primary-100">Ends {{ ends_on }}</span>
+                  {% endif -%}
+                </div>
+                {% if !accelerator.tracks.is_empty() -%}
+                  <div class="mt-3 flex flex-wrap gap-2">
+                    {% for track in accelerator.tracks -%}
+                      <span class="rounded-full bg-white px-2.5 py-1 text-xs font-medium text-primary-900 ring-1 ring-inset ring-primary-100">{{ track }}</span>
+                    {% endfor -%}
+                  </div>
+                {% endif -%}
+              </div>
+            {% endif -%}
+
             <div class="mt-auto flex flex-wrap gap-2 pt-5">
+              {% if let Some(accelerator) = &entry.accelerator -%}
+                {% if let Some(application_url) = &accelerator.application_url -%}
+                  <a class="inline-flex items-center justify-center rounded-full border border-stone-950 bg-stone-950 px-4 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-stone-800"
+                     href="{{ application_url }}"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     hx-boost="false">Apply</a>
+                {% endif -%}
+                {% if let Some(curriculum_url) = &accelerator.curriculum_url -%}
+                  <a class="inline-flex items-center justify-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-bold text-stone-700 shadow-sm transition hover:border-stone-950 hover:bg-stone-950 hover:text-white"
+                     href="{{ curriculum_url }}"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     hx-boost="false">Curriculum</a>
+                {% endif -%}
+              {% endif -%}
               {% if let Some(website_url) = &entry.website_url -%}
                 <a class="inline-flex items-center justify-center rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-bold text-stone-700 shadow-sm transition hover:border-stone-950 hover:bg-stone-950 hover:text-white"
                    href="{{ website_url }}"


### PR DESCRIPTION
## Summary
- Adds accelerator metadata to Landscape entries for public discovery.
- Adds group-level accelerator operations for programs, cohorts, applications, accepted members, weekly curriculum, and weekly updates.
- Wires dashboard/public routes, validation, DB access, templates, and updates the dev Rust image to the required toolchain.

## Test plan
- `git diff --check`
- `docker compose -f /Users/sako/ydc/github/hackathons/goup.vc-pr/docker-compose.dev.yml build server`
- `docker compose -f /Users/sako/ydc/github/hackathons/goup.vc-pr/docker-compose.dev.yml run --rm --no-deps server cargo check -p ocg-server`
- `docker compose -f /Users/sako/ydc/github/hackathons/goup.vc-pr/docker-compose.dev.yml run --rm --no-deps server cargo test -p ocg-server accelerator`
- `docker compose ... run --rm ... migrate` with port binding reset for the local PR checkout


Made with [Cursor](https://cursor.com)