### PR TITLE
Notify intentional dating introductions

### DIFF
--- a/database/migrations/schema/0044_intentional_dating_notification.sql
+++ b/database/migrations/schema/0044_intentional_dating_notification.sql
@@ -1,0 +1,3 @@
+insert into notification_kind (name, optional_notification)
+values ('intentional-dating-introduction', true)
+on conflict (name) do update set optional_notification = excluded.optional_notification;

--- a/database/tests/schema/06_constraints_and_reference_data.sql
+++ b/database/tests/schema/06_constraints_and_reference_data.sql
@@ -337,6 +337,7 @@ select results_eq(
         ('group-custom', true),
         ('group-team-invitation', false),
         ('group-welcome', false),
+        ('intentional-dating-introduction', true),
         ('session-proposal-co-speaker-invitation', false),
         ('site-onboarding', false),
         ('speaker-series-welcome', false),

--- a/ocg-server/src/handlers/dashboard/alliance/intentional_dating.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/intentional_dating.rs
@@ -9,11 +9,14 @@ use axum::{
 use tracing::instrument;
 
 use crate::{
+    config::HttpServerConfig,
     db::DynDB,
     handlers::{
+        dashboard::common::enqueue_intentional_dating_intro_notifications,
         error::HandlerError,
         extractors::{CurrentUser, SelectedAllianceId, ValidatedForm},
     },
+    services::notifications::DynNotificationsManager,
     templates::dashboard::alliance::intentional_dating::{self, IntroForm},
 };
 
@@ -38,6 +41,8 @@ pub(crate) async fn add_intro(
     CurrentUser(user): CurrentUser,
     SelectedAllianceId(alliance_id): SelectedAllianceId,
     State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
+    State(server_cfg): State<HttpServerConfig>,
     ValidatedForm(input): ValidatedForm<IntroForm>,
 ) -> Result<impl IntoResponse, HandlerError> {
     db.add_intentional_dating_intro(
@@ -46,9 +51,20 @@ pub(crate) async fn add_intro(
         input.group_id,
         input.first_user_id,
         input.second_user_id,
-        input.admin_notes,
+        input.admin_notes.clone(),
     )
     .await?;
+    enqueue_intentional_dating_intro_notifications(
+        &db,
+        &notifications_manager,
+        &server_cfg,
+        alliance_id,
+        input.group_id,
+        input.first_user_id,
+        input.second_user_id,
+        input.notification_message.as_deref(),
+    )
+    .await;
 
     Ok((
         StatusCode::NO_CONTENT,

--- a/ocg-server/src/handlers/dashboard/common.rs
+++ b/ocg-server/src/handlers/dashboard/common.rs
@@ -2,16 +2,23 @@
 
 use std::collections::HashMap;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use axum::{
     Json,
     extract::{Query, State},
     response::IntoResponse,
 };
 use reqwest::StatusCode;
-use tracing::instrument;
+use tracing::{instrument, warn};
+use uuid::Uuid;
 
-use crate::{db::DynDB, handlers::error::HandlerError};
+use crate::{
+    config::HttpServerConfig,
+    db::{DynDB, dashboard::common::IntentionalDatingOptIn},
+    handlers::error::HandlerError,
+    services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
+    templates::notifications::IntentionalDatingIntroduction,
+};
 
 #[cfg(test)]
 mod tests;
@@ -31,4 +38,78 @@ pub(crate) async fn search_user(
     let users = db.search_user(q).await?;
 
     Ok(Json(users).into_response())
+}
+
+/// Enqueues optional notifications for an admin-curated intentional dating introduction.
+pub(crate) async fn enqueue_intentional_dating_intro_notifications(
+    db: &DynDB,
+    notifications_manager: &DynNotificationsManager,
+    server_cfg: &HttpServerConfig,
+    alliance_id: Uuid,
+    group_id: Uuid,
+    first_user_id: Uuid,
+    second_user_id: Uuid,
+    notification_message: Option<&str>,
+) {
+    let Some(message) = notification_message else {
+        return;
+    };
+
+    if let Err(err) = async {
+        let (opt_ins, site_settings) = tokio::try_join!(
+            db.list_intentional_dating_opt_ins(alliance_id, Some(group_id)),
+            db.get_site_settings(),
+        )?;
+        let first = find_intro_opt_in(&opt_ins, first_user_id)?;
+        let second = find_intro_opt_in(&opt_ins, second_user_id)?;
+        let base_url = server_cfg.base_url.strip_suffix('/').unwrap_or(&server_cfg.base_url);
+        let dashboard_link = format!("{base_url}/dashboard/user");
+
+        for (recipient, partner) in [(first, second), (second, first)] {
+            let template_data = IntentionalDatingIntroduction {
+                alliance_display_name: recipient.alliance_display_name.clone(),
+                dashboard_link: dashboard_link.clone(),
+                group_name: recipient.group_name.clone(),
+                message: message.to_string(),
+                partner_name: opt_in_display_name(partner),
+                partner_profile_url: format!("{base_url}/profiles/{}", partner.username),
+                partner_username: partner.username.clone(),
+                theme: site_settings.theme.clone(),
+            };
+            let notification = NewNotification {
+                attachments: vec![],
+                kind: NotificationKind::IntentionalDatingIntroduction,
+                recipients: vec![recipient.user_id],
+                template_data: Some(serde_json::to_value(&template_data)?),
+            };
+            notifications_manager.enqueue(&notification).await?;
+        }
+
+        Result::<()>::Ok(())
+    }
+    .await
+    {
+        warn!(
+            error = %err,
+            %alliance_id,
+            %group_id,
+            %first_user_id,
+            %second_user_id,
+            "failed to enqueue intentional dating introduction notifications"
+        );
+    }
+}
+
+fn find_intro_opt_in(
+    opt_ins: &[IntentionalDatingOptIn],
+    user_id: Uuid,
+) -> Result<&IntentionalDatingOptIn> {
+    opt_ins
+        .iter()
+        .find(|opt_in| opt_in.user_id == user_id)
+        .ok_or_else(|| anyhow!("intentional dating opt-in not found for notification context"))
+}
+
+fn opt_in_display_name(opt_in: &IntentionalDatingOptIn) -> String {
+    opt_in.name.clone().unwrap_or_else(|| opt_in.username.clone())
 }

--- a/ocg-server/src/handlers/dashboard/group/intentional_dating.rs
+++ b/ocg-server/src/handlers/dashboard/group/intentional_dating.rs
@@ -9,11 +9,14 @@ use axum::{
 use tracing::instrument;
 
 use crate::{
+    config::HttpServerConfig,
     db::DynDB,
     handlers::{
+        dashboard::common::enqueue_intentional_dating_intro_notifications,
         error::HandlerError,
         extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId, ValidatedForm},
     },
+    services::notifications::DynNotificationsManager,
     templates::dashboard::group::intentional_dating::{self, IntroForm},
 };
 
@@ -42,6 +45,8 @@ pub(crate) async fn add_intro(
     SelectedAllianceId(alliance_id): SelectedAllianceId,
     SelectedGroupId(group_id): SelectedGroupId,
     State(db): State<DynDB>,
+    State(notifications_manager): State<DynNotificationsManager>,
+    State(server_cfg): State<HttpServerConfig>,
     ValidatedForm(input): ValidatedForm<IntroForm>,
 ) -> Result<impl IntoResponse, HandlerError> {
     db.add_intentional_dating_intro(
@@ -50,9 +55,20 @@ pub(crate) async fn add_intro(
         group_id,
         input.first_user_id,
         input.second_user_id,
-        input.admin_notes,
+        input.admin_notes.clone(),
     )
     .await?;
+    enqueue_intentional_dating_intro_notifications(
+        &db,
+        &notifications_manager,
+        &server_cfg,
+        alliance_id,
+        group_id,
+        input.first_user_id,
+        input.second_user_id,
+        input.notification_message.as_deref(),
+    )
+    .await;
 
     Ok((
         StatusCode::NO_CONTENT,

--- a/ocg-server/src/services/notifications.rs
+++ b/ocg-server/src/services/notifications.rs
@@ -33,8 +33,8 @@ use crate::{
         EventRefundApproved, EventRefundRejected, EventRefundRequested, EventReminder,
         EventRescheduled, EventSeriesCanceled, EventSeriesPublished, EventWaitlistJoined,
         EventWaitlistLeft, EventWaitlistPromoted, EventWelcome, GroupCustom, GroupTeamInvitation,
-        GroupWelcome, MockInterviewMatched, SessionProposalCoSpeakerInvitation, SiteOnboarding,
-        SpeakerSeriesWelcome, SpeakerWelcome,
+        GroupWelcome, IntentionalDatingIntroduction, MockInterviewMatched,
+        SessionProposalCoSpeakerInvitation, SiteOnboarding, SpeakerSeriesWelcome, SpeakerWelcome,
     },
 };
 
@@ -488,6 +488,13 @@ impl DeliveryWorker {
                 let body = template.render()?;
                 (subject, body)
             }
+            NotificationKind::IntentionalDatingIntroduction => {
+                let subject = "You have an intentional dating introduction".to_string();
+                let template: IntentionalDatingIntroduction =
+                    serde_json::from_value(template_data)?;
+                let body = template.render()?;
+                (subject, body)
+            }
             NotificationKind::MockInterviewMatched => {
                 let subject = "You have a mock interview match".to_string();
                 let template: MockInterviewMatched = serde_json::from_value(template_data)?;
@@ -769,6 +776,8 @@ pub(crate) enum NotificationKind {
     GroupTeamInvitation,
     /// Notification welcoming a new group member.
     GroupWelcome,
+    /// Notification for an admin-curated intentional dating introduction.
+    IntentionalDatingIntroduction,
     /// Notification for a mock interview match.
     MockInterviewMatched,
     /// Notification with first steps for a newly created account.

--- a/ocg-server/src/services/notifications/tests.rs
+++ b/ocg-server/src/services/notifications/tests.rs
@@ -909,6 +909,28 @@ fn test_delivery_worker_prepare_content_group_custom_legacy_template_data() {
 }
 
 #[test]
+fn test_delivery_worker_prepare_content_intentional_dating_introduction() {
+    // Setup notification
+    let notification = Notification {
+        attachments: vec![],
+        email: "user@example.test".to_string(),
+        kind: NotificationKind::IntentionalDatingIntroduction,
+        notification_id: Uuid::new_v4(),
+        template_data: Some(sample_intentional_dating_introduction_template_data()),
+    };
+
+    // Prepare content
+    let (subject, body) = DeliveryWorker::prepare_content(&notification).unwrap();
+
+    // Check content matches expectations
+    assert_eq!(subject, "You have an intentional dating introduction");
+    assert!(body.contains("Test Alliance"));
+    assert!(body.contains("Pat Partner"));
+    assert!(body.contains("You both mentioned founder life and long-term relationship goals."));
+    assert!(body.contains("https://example.test/profiles/pat"));
+}
+
+#[test]
 fn test_delivery_worker_prepare_content_missing_data() {
     // Setup notification
     let notification = Notification {
@@ -1444,4 +1466,20 @@ fn sample_group_custom_legacy_template_data() -> serde_json::Value {
     object.remove("subject");
     object.insert("title".to_string(), json!("Custom group title"));
     payload
+}
+
+/// Sample template payload for intentional dating introduction notifications.
+fn sample_intentional_dating_introduction_template_data() -> serde_json::Value {
+    json!({
+        "alliance_display_name": "Test Alliance",
+        "dashboard_link": "https://example.test/dashboard/user",
+        "group_name": "Founders Circle",
+        "message": "You both mentioned founder life and long-term relationship goals.",
+        "partner_name": "Pat Partner",
+        "partner_profile_url": "https://example.test/profiles/pat",
+        "partner_username": "pat",
+        "theme": {
+            "primary_color": "#000000"
+        }
+    })
 }

--- a/ocg-server/src/templates/dashboard/alliance/intentional_dating.rs
+++ b/ocg-server/src/templates/dashboard/alliance/intentional_dating.rs
@@ -38,4 +38,8 @@ pub(crate) struct IntroForm {
     #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
     pub admin_notes: Option<String>,
+    /// Optional message sent to both introduced members.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub notification_message: Option<String>,
 }

--- a/ocg-server/src/templates/dashboard/group/intentional_dating.rs
+++ b/ocg-server/src/templates/dashboard/group/intentional_dating.rs
@@ -35,4 +35,8 @@ pub(crate) struct IntroForm {
     #[serde(default, deserialize_with = "optional_trimmed_string")]
     #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
     pub admin_notes: Option<String>,
+    /// Optional message sent to both introduced members.
+    #[serde(default, deserialize_with = "optional_trimmed_string")]
+    #[garde(custom(trimmed_non_empty_opt), length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub notification_message: Option<String>,
 }

--- a/ocg-server/src/templates/notifications.rs
+++ b/ocg-server/src/templates/notifications.rs
@@ -349,6 +349,28 @@ pub(crate) struct GroupWelcome {
     pub theme: Theme,
 }
 
+/// Template for intentional dating introduction notifications.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "notifications/intentional_dating_introduction.html")]
+pub(crate) struct IntentionalDatingIntroduction {
+    /// Alliance display name for the introduction.
+    pub alliance_display_name: String,
+    /// Admin-written message shown to both matched members.
+    pub message: String,
+    /// Matched partner display name.
+    pub partner_name: String,
+    /// Matched partner public profile link.
+    pub partner_profile_url: String,
+    /// Matched partner username.
+    pub partner_username: String,
+    /// Group name where the introduction was curated.
+    pub group_name: String,
+    /// Link to the user's dashboard.
+    pub dashboard_link: String,
+    /// Theme configuration for the site.
+    pub theme: Theme,
+}
+
 /// Template for mock interview match notifications.
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "notifications/mock_interview_matched.html")]

--- a/ocg-server/templates/dashboard/alliance/intentional_dating.html
+++ b/ocg-server/templates/dashboard/alliance/intentional_dating.html
@@ -28,6 +28,9 @@
           hx-post="/dashboard/alliance/intentional-dating/introductions"
           hx-swap="none"
           hx-indicator="#dashboard-spinner"
+          data-htmx-response
+          data-success-message="Introduction recorded."
+          data-error-message="Something went wrong recording the introduction. Please try again later."
           {% if !can_manage_introductions -%}
             inert
           {% endif -%}>
@@ -60,6 +63,13 @@
         <input name="admin_notes"
                class="input-primary mt-2"
                placeholder="Why this introduction makes sense">
+      </label>
+      <label class="block lg:col-span-2">
+        <span class="form-label">Optional message to both members</span>
+        <textarea name="notification_message"
+                  class="input-primary mt-2 min-h-28"
+                  placeholder="Write the message both introduced members should receive. Leave blank to record only."></textarea>
+        <span class="form-legend">Private admin notes are not sent. This message is emailed to both selected members.</span>
       </label>
       <div class="flex items-end">
         <button type="submit"

--- a/ocg-server/templates/dashboard/group/intentional_dating.html
+++ b/ocg-server/templates/dashboard/group/intentional_dating.html
@@ -28,6 +28,9 @@
           hx-post="/dashboard/group/intentional-dating/introductions"
           hx-swap="none"
           hx-indicator="#dashboard-spinner"
+          data-htmx-response
+          data-success-message="Introduction recorded."
+          data-error-message="Something went wrong recording the introduction. Please try again later."
           {% if !can_manage_introductions -%}
             inert
           {% endif -%}>
@@ -52,6 +55,13 @@
         <input name="admin_notes"
                class="input-primary mt-2"
                placeholder="Why this introduction makes sense">
+      </label>
+      <label class="block lg:col-span-2">
+        <span class="form-label">Optional message to both members</span>
+        <textarea name="notification_message"
+                  class="input-primary mt-2 min-h-28"
+                  placeholder="Write the message both introduced members should receive. Leave blank to record only."></textarea>
+        <span class="form-legend">Private admin notes are not sent. This message is emailed to both selected members.</span>
       </label>
       <div class="flex items-end lg:col-start-3">
         <button type="submit"

--- a/ocg-server/templates/notifications/intentional_dating_introduction.html
+++ b/ocg-server/templates/notifications/intentional_dating_introduction.html
@@ -1,0 +1,41 @@
+{% extends "notifications/base.html" -%}
+{% import "macros/email.html" as email -%}
+
+{% block subject -%}
+  You have an intentional dating introduction
+{% endblock subject -%}
+
+{% block preheader -%}
+  An organizer from {{ alliance_display_name }} introduced you to {{ partner_name }}.
+{% endblock preheader -%}
+
+{% block content -%}
+  <p class="group mb-15" style="margin-bottom: 15px">Intentional Dating</p>
+  <p class="default big mb-15" style="margin-bottom: 15px">
+    An organizer from <strong>{{ alliance_display_name }}</strong> introduced you to
+    <strong>{{ partner_name }}</strong> from <strong>{{ group_name }}</strong>.
+  </p>
+
+  <div class="default mb-30"
+       style="margin-bottom: 30px;
+              padding: 16px;
+              border: 1px solid #e7e5e4;
+              border-radius: 16px;
+              background: #fafaf9">
+    <p class="default" style="margin-bottom: 8px">
+      <strong>{{ partner_name }}</strong>
+      <span style="color: #78716c">@{{ partner_username }}</span>
+    </p>
+    <p class="default preline" style="color: #57534e">{{ message }}</p>
+  </div>
+
+  {{ email::button(link = partner_profile_url, text = "View profile", color = theme.primary_color) }}
+  <p class="default mt-30" style="margin-top: 30px">
+    You can update your intentional dating opt-in from your dashboard profile settings.
+  </p>
+  {{ email::button(link = dashboard_link, text = "Open dashboard", color = theme.primary_color) }}
+{% endblock content -%}
+
+{% block footer -%}
+  You received this email because you opted in to private intentional dating introductions.
+{% endblock footer -%}


### PR DESCRIPTION
## Summary
- Adds an optional admin-written message to intentional dating introduction forms.
- Enqueues personalized introduction notifications to both matched members when that message is provided.
- Registers the new notification kind and adds email rendering coverage.

## Test plan
- cargo check -p ocg-server
- cargo test -p ocg-server services::notifications::tests::test_delivery_worker_prepare_content_intentional_dating_introduction
- ReadLints on edited intentional dating notification files


Made with [Cursor](https://cursor.com)