### PR TITLE
Fix site search submit behavior

### DIFF
--- a/ocg-server/src/handlers/site/search.rs
+++ b/ocg-server/src/handlers/site/search.rs
@@ -33,6 +33,9 @@ use crate::{
 
 const SEARCH_LIMIT: usize = 4;
 
+#[cfg(test)]
+mod tests;
+
 /// Handler that renders the public search page.
 #[instrument(skip_all, err)]
 pub(crate) async fn page(

--- a/ocg-server/src/handlers/site/search/tests.rs
+++ b/ocg-server/src/handlers/site/search/tests.rs
@@ -1,0 +1,38 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use tower::ServiceExt;
+
+use crate::{
+    db::mock::MockDB,
+    handlers::tests::{TestRouterBuilder, sample_site_settings},
+    services::notifications::MockNotificationsManager,
+};
+
+#[tokio::test]
+async fn test_page_search_form_uses_htmx_for_submit_and_live_input() {
+    let mut db = MockDB::new();
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(|| Ok(sample_site_settings()));
+
+    let router = TestRouterBuilder::new(db, MockNotificationsManager::new())
+        .build()
+        .await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/search")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let body = String::from_utf8(to_bytes(body, usize::MAX).await.unwrap().to_vec()).unwrap();
+
+    assert_eq!(parts.status, StatusCode::OK);
+    assert!(body.contains("hx-get=\"/search\""));
+    assert!(body.contains("hx-target=\"#site-search-results\""));
+    assert!(body.contains(
+        "hx-trigger=\"submit, input changed delay:300ms from:#site-search-query, search from:#site-search-query\""
+    ));
+}

--- a/ocg-server/templates/site/search/page.html
+++ b/ocg-server/templates/site/search/page.html
@@ -18,7 +18,7 @@
             hx-target="#site-search-results"
             hx-select="#site-search-results"
             hx-push-url="true"
-            hx-trigger="input changed delay:300ms from:#site-search-query"
+            hx-trigger="submit, input changed delay:300ms from:#site-search-query, search from:#site-search-query"
             class="mt-7 flex flex-col gap-3 sm:flex-row">
         <label class="sr-only" for="site-search-query">Search GOUP</label>
         <input id="site-search-query"


### PR DESCRIPTION
## Summary
- Keep the public `/search` form on the HTMX result-update path when users press Enter or click Search.
- Preserve live search updates for typing and the native search-input clear event.
- Add a regression test for the rendered search form triggers.

## Test plan
- Ran `cargo test -p ocg-server handlers::site::search::tests -- --quiet`.
- Ran `cargo check -p ocg-server`.


Made with [Cursor](https://cursor.com)