### PR TITLE
feat: add community event integrations

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -77,6 +77,7 @@
 {{ template "alliance/get_alliance_site_stats.sql" }}
 {{ template "alliance/get_alliance_upcoming_events.sql" }}
 {{ template "alliance/list_alliance_members.sql" }}
+{{ template "alliance/list_public_partner_integrations.sql" }}
 {{ template "alliance/update_alliance_views.sql" }}
 
 {{ template "dashboard-common/search_user.sql" }}
@@ -91,18 +92,21 @@
 {{ template "dashboard-alliance/add_event_category.sql" }}
 {{ template "dashboard-alliance/add_group.sql" }}
 {{ template "dashboard-alliance/add_group_category.sql" }}
+{{ template "dashboard-alliance/add_partner_integration.sql" }}
 {{ template "dashboard-alliance/add_region.sql" }}
 {{ template "dashboard-alliance/deactivate_group.sql" }}
 {{ template "dashboard-alliance/delete_alliance_team_member.sql" }}
 {{ template "dashboard-alliance/delete_event_category.sql" }}
 {{ template "dashboard-alliance/delete_group.sql" }}
 {{ template "dashboard-alliance/delete_group_category.sql" }}
+{{ template "dashboard-alliance/delete_partner_integration.sql" }}
 {{ template "dashboard-alliance/delete_region.sql" }}
 {{ template "dashboard-alliance/get_alliance_stats.sql" }}
 {{ template "dashboard-alliance/list_alliance_audit_logs.sql" }}
 {{ template "dashboard-alliance/list_alliance_roles.sql" }}
 {{ template "dashboard-alliance/list_alliance_team_members.sql" }}
 {{ template "dashboard-alliance/list_group_categories.sql" }}
+{{ template "dashboard-alliance/list_partner_integrations.sql" }}
 {{ template "dashboard-alliance/list_regions.sql" }}
 {{ template "dashboard-alliance/list_user_alliances.sql" }}
 {{ template "dashboard-alliance/update_alliance.sql" }}
@@ -110,6 +114,7 @@
 {{ template "dashboard-alliance/update_alliance_team_member_role.sql" }}
 {{ template "dashboard-alliance/update_event_category.sql" }}
 {{ template "dashboard-alliance/update_group_category.sql" }}
+{{ template "dashboard-alliance/update_partner_integration.sql" }}
 {{ template "dashboard-alliance/update_region.sql" }}
 
 {{ template "dashboard-group/get_event_ticket_capacity.sql" }} -- Dependency for add/update_event

--- a/database/migrations/functions/alliance/list_public_partner_integrations.sql
+++ b/database/migrations/functions/alliance/list_public_partner_integrations.sql
@@ -1,0 +1,17 @@
+-- Lists public partner integrations for an alliance.
+create or replace function list_public_partner_integrations(p_alliance_id uuid)
+returns json as $$
+    select coalesce(json_agg(
+        json_build_object(
+            'attribution_copy', pi.attribution_copy,
+            'logo_url', pi.logo_url,
+            'name', pi.name,
+            'partner_integration_id', pi.partner_integration_id,
+            'public', pi.public,
+            'website_url', pi.website_url
+        ) order by pi.name
+    ), '[]')
+    from partner_integration pi
+    where pi.alliance_id = p_alliance_id
+      and pi.public;
+$$ language sql stable;

--- a/database/migrations/functions/dashboard-alliance/add_partner_integration.sql
+++ b/database/migrations/functions/dashboard-alliance/add_partner_integration.sql
@@ -1,0 +1,31 @@
+-- Adds a partner integration to an alliance.
+create or replace function add_partner_integration(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_partner_integration jsonb
+)
+returns uuid as $$
+declare
+    v_partner_integration_id uuid;
+begin
+    insert into partner_integration (
+        alliance_id, name, logo_url, website_url, attribution_copy, public
+    ) values (
+        p_alliance_id,
+        trim(p_partner_integration->>'name'),
+        nullif(trim(p_partner_integration->>'logo_url'), ''),
+        nullif(trim(p_partner_integration->>'website_url'), ''),
+        trim(coalesce(p_partner_integration->>'attribution_copy', '')),
+        coalesce((p_partner_integration->>'public')::boolean, false)
+    )
+    returning partner_integration_id into v_partner_integration_id;
+
+    perform insert_audit_log(
+        'partner_integration_added', p_actor_user_id, 'partner_integration',
+        v_partner_integration_id, p_alliance_id
+    );
+    return v_partner_integration_id;
+exception
+    when unique_violation then raise exception 'partner integration already exists';
+end;
+$$ language plpgsql;

--- a/database/migrations/functions/dashboard-alliance/delete_partner_integration.sql
+++ b/database/migrations/functions/dashboard-alliance/delete_partner_integration.sql
@@ -1,0 +1,22 @@
+-- Deletes a partner integration owned by an alliance.
+create or replace function delete_partner_integration(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_partner_integration_id uuid
+)
+returns void as $$
+begin
+    delete from partner_integration
+    where alliance_id = p_alliance_id
+      and partner_integration_id = p_partner_integration_id;
+
+    if not found then
+        raise exception 'partner integration not found';
+    end if;
+
+    perform insert_audit_log(
+        'partner_integration_deleted', p_actor_user_id, 'partner_integration',
+        p_partner_integration_id, p_alliance_id
+    );
+end;
+$$ language plpgsql;

--- a/database/migrations/functions/dashboard-alliance/list_partner_integrations.sql
+++ b/database/migrations/functions/dashboard-alliance/list_partner_integrations.sql
@@ -1,0 +1,16 @@
+-- Lists all partner integrations for an alliance dashboard.
+create or replace function list_partner_integrations(p_alliance_id uuid)
+returns json as $$
+    select coalesce(json_agg(
+        json_build_object(
+            'attribution_copy', pi.attribution_copy,
+            'logo_url', pi.logo_url,
+            'name', pi.name,
+            'partner_integration_id', pi.partner_integration_id,
+            'public', pi.public,
+            'website_url', pi.website_url
+        ) order by pi.name
+    ), '[]')
+    from partner_integration pi
+    where pi.alliance_id = p_alliance_id;
+$$ language sql stable;

--- a/database/migrations/functions/dashboard-alliance/update_partner_integration.sql
+++ b/database/migrations/functions/dashboard-alliance/update_partner_integration.sql
@@ -1,0 +1,32 @@
+-- Updates a partner integration owned by an alliance.
+create or replace function update_partner_integration(
+    p_actor_user_id uuid,
+    p_alliance_id uuid,
+    p_partner_integration_id uuid,
+    p_partner_integration jsonb
+)
+returns void as $$
+begin
+    update partner_integration
+    set
+        name = trim(p_partner_integration->>'name'),
+        logo_url = nullif(trim(p_partner_integration->>'logo_url'), ''),
+        website_url = nullif(trim(p_partner_integration->>'website_url'), ''),
+        attribution_copy = trim(coalesce(p_partner_integration->>'attribution_copy', '')),
+        public = coalesce((p_partner_integration->>'public')::boolean, false),
+        updated_at = now()
+    where alliance_id = p_alliance_id
+      and partner_integration_id = p_partner_integration_id;
+
+    if not found then
+        raise exception 'partner integration not found';
+    end if;
+
+    perform insert_audit_log(
+        'partner_integration_updated', p_actor_user_id, 'partner_integration',
+        p_partner_integration_id, p_alliance_id
+    );
+exception
+    when unique_violation then raise exception 'partner integration already exists';
+end;
+$$ language plpgsql;

--- a/database/migrations/schema/0046_event_integrations.sql
+++ b/database/migrations/schema/0046_event_integrations.sql
@@ -1,0 +1,59 @@
+create table group_event_integration (
+    group_id uuid primary key references "group"(group_id) on delete cascade,
+    created_by_user_id uuid not null references "user"(user_id),
+    enabled boolean not null default false,
+    city text not null default 'Baku',
+    timezone text not null default 'Asia/Baku',
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table group_event_integration_source (
+    group_event_integration_source_id uuid primary key default gen_random_uuid(),
+    group_id uuid not null references "group"(group_id) on delete cascade,
+    url text not null,
+    enabled boolean not null default true,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (group_id, url)
+);
+
+create table group_event_integration_run (
+    group_event_integration_run_id uuid primary key default gen_random_uuid(),
+    group_id uuid not null references "group"(group_id) on delete cascade,
+    started_at timestamptz not null default now(),
+    completed_at timestamptz,
+    status text not null check (status in ('running', 'succeeded', 'failed')),
+    discovered_count integer not null default 0 check (discovered_count >= 0),
+    created_count integer not null default 0 check (created_count >= 0),
+    error_message text
+);
+
+create table group_event_integration_item (
+    group_event_integration_item_id uuid primary key default gen_random_uuid(),
+    group_id uuid not null references "group"(group_id) on delete cascade,
+    source_url text not null,
+    fingerprint text not null,
+    event_id uuid references event(event_id) on delete set null,
+    created_at timestamptz not null default now(),
+    unique (group_id, fingerprint)
+);
+
+create index group_event_integration_source_enabled_idx
+    on group_event_integration_source (group_id)
+    where enabled;
+create index group_event_integration_run_group_started_idx
+    on group_event_integration_run (group_id, started_at desc);
+
+create table partner_integration (
+    partner_integration_id uuid primary key default gen_random_uuid(),
+    alliance_id uuid not null references alliance(alliance_id) on delete cascade,
+    name text not null,
+    logo_url text,
+    website_url text,
+    attribution_copy text not null default '',
+    public boolean not null default false,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (alliance_id, name)
+);

--- a/ocg-server/src/config.rs
+++ b/ocg-server/src/config.rs
@@ -43,6 +43,8 @@ pub(crate) struct Config {
     pub payments: Option<PaymentsConfig>,
     /// Recording publishing configuration.
     pub recording_publishing: Option<RecordingPublishingConfig>,
+    /// External partner integrations.
+    pub integrations: Option<IntegrationsConfig>,
 }
 
 impl Config {
@@ -96,8 +98,77 @@ impl Config {
             recording_publishing_cfg.validate()?;
         }
 
+        if let Some(integrations_cfg) = &self.integrations {
+            integrations_cfg.validate()?;
+        }
+
         Ok(())
     }
+}
+
+/// Configuration for external partner integrations.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct IntegrationsConfig {
+    /// You.com event discovery configuration.
+    pub you_com: Option<YouComConfig>,
+}
+
+impl IntegrationsConfig {
+    fn validate(&self) -> Result<()> {
+        if let Some(you_com) = &self.you_com {
+            you_com.validate()?;
+        }
+        Ok(())
+    }
+}
+
+/// Configuration for You.com event discovery.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct YouComConfig {
+    /// Enables the event discovery worker.
+    #[serde(default)]
+    pub enabled: bool,
+    /// Secret API key. Set this through `OCG_INTEGRATIONS__YOU_COM__API_KEY`.
+    pub api_key: String,
+    /// Search endpoint, allowing API-version changes without source changes.
+    #[serde(default = "default_you_com_search_url")]
+    pub search_url: String,
+    /// IANA timezone used to schedule the daily discovery run.
+    #[serde(default = "default_baku_timezone")]
+    pub schedule_timezone: String,
+    /// Hour of the daily discovery run in the configured timezone.
+    #[serde(default = "default_baku_schedule_hour")]
+    pub schedule_hour: u8,
+}
+
+impl YouComConfig {
+    fn validate(&self) -> Result<()> {
+        if self.enabled && self.api_key.trim().is_empty() {
+            bail!("integrations.you_com.api_key is required when You.com is enabled");
+        }
+        if self.schedule_hour > 23 {
+            bail!("integrations.you_com.schedule_hour must be between 0 and 23");
+        }
+        self.search_url
+            .parse::<reqwest::Url>()
+            .map_err(|err| anyhow::anyhow!("invalid integrations.you_com.search_url: {err}"))?;
+        self.schedule_timezone.parse::<chrono_tz::Tz>().map_err(|err| {
+            anyhow::anyhow!("invalid integrations.you_com.schedule_timezone: {err}")
+        })?;
+        Ok(())
+    }
+}
+
+fn default_you_com_search_url() -> String {
+    "https://api.you.com/v1/search".into()
+}
+
+fn default_baku_timezone() -> String {
+    "Asia/Baku".into()
+}
+
+const fn default_baku_schedule_hour() -> u8 {
+    9
 }
 
 /// Email configuration.

--- a/ocg-server/src/db/alliance.rs
+++ b/ocg-server/src/db/alliance.rs
@@ -13,6 +13,7 @@ use crate::{
     types::{
         event::{EventKind, EventSummary},
         group::GroupSummary,
+        partner_integration::PartnerIntegration,
     },
 };
 
@@ -50,6 +51,12 @@ pub(crate) trait DBAlliance {
         alliance_id: Uuid,
         filters: &AllianceMembersFilters,
     ) -> Result<AllianceMembersOutput>;
+
+    /// Lists enabled partner integrations for the public alliance site.
+    async fn list_public_partner_integrations(
+        &self,
+        alliance_id: Uuid,
+    ) -> Result<Vec<PartnerIntegration>>;
 }
 
 #[async_trait]
@@ -169,6 +176,19 @@ where
         self.fetch_json_one(
             "select list_alliance_members($1::uuid, $2::jsonb)",
             &[&alliance_id, &Json(filters)],
+        )
+        .await
+    }
+
+    /// [`DBAlliance::list_public_partner_integrations`]
+    #[instrument(skip(self), err)]
+    async fn list_public_partner_integrations(
+        &self,
+        alliance_id: Uuid,
+    ) -> Result<Vec<PartnerIntegration>> {
+        self.fetch_json_one(
+            "select list_public_partner_integrations($1::uuid)",
+            &[&alliance_id],
         )
         .await
     }

--- a/ocg-server/src/db/dashboard/alliance.rs
+++ b/ocg-server/src/db/dashboard/alliance.rs
@@ -16,6 +16,7 @@ use crate::{
             event_categories::EventCategoryInput,
             group_categories::GroupCategoryInput,
             groups::Group,
+            partner_integrations::PartnerIntegrationInput,
             regions::RegionInput,
             settings::AllianceUpdate,
             team::{AllianceTeamFilters, AllianceTeamOutput},
@@ -25,6 +26,7 @@ use crate::{
     types::{
         alliance::{AllianceRole, AllianceRoleSummary, AllianceSummary},
         group::{GroupCategory, GroupRegion},
+        partner_integration::PartnerIntegration,
     },
 };
 
@@ -83,6 +85,14 @@ pub(crate) trait DBDashboardAlliance {
         region: &RegionInput,
     ) -> Result<Uuid>;
 
+    /// Adds a partner integration to an alliance.
+    async fn add_partner_integration(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        partner_integration: &PartnerIntegrationInput,
+    ) -> Result<Uuid>;
+
     /// Deactivates a group (sets active=false without deleting).
     async fn deactivate_group(
         &self,
@@ -131,6 +141,14 @@ pub(crate) trait DBDashboardAlliance {
         region_id: Uuid,
     ) -> Result<()>;
 
+    /// Deletes a partner integration from an alliance.
+    async fn delete_partner_integration(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        partner_integration_id: Uuid,
+    ) -> Result<()>;
+
     /// Retrieves analytics statistics for a alliance.
     async fn get_alliance_stats(&self, alliance_id: Uuid) -> Result<AllianceDashboardStats>;
 
@@ -156,6 +174,10 @@ pub(crate) trait DBDashboardAlliance {
 
     /// Lists all regions for a alliance.
     async fn list_regions(&self, alliance_id: Uuid) -> Result<Vec<GroupRegion>>;
+
+    /// Lists all partner integrations for an alliance.
+    async fn list_partner_integrations(&self, alliance_id: Uuid)
+    -> Result<Vec<PartnerIntegration>>;
 
     /// Lists all alliances where the user is a team member.
     async fn list_user_alliances(&self, user_id: &Uuid) -> Result<Vec<AllianceSummary>>;
@@ -211,6 +233,15 @@ pub(crate) trait DBDashboardAlliance {
         region_id: Uuid,
         region: &RegionInput,
     ) -> Result<()>;
+
+    /// Updates a partner integration in an alliance.
+    async fn update_partner_integration(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        partner_integration_id: Uuid,
+        partner_integration: &PartnerIntegrationInput,
+    ) -> Result<()>;
 }
 
 #[async_trait]
@@ -229,6 +260,21 @@ where
         self.execute(
             "select activate_group($1::uuid, $2::uuid, $3::uuid)",
             &[&actor_user_id, &alliance_id, &group_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardAlliance::add_partner_integration`]
+    #[instrument(skip(self, partner_integration), err)]
+    async fn add_partner_integration(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        partner_integration: &PartnerIntegrationInput,
+    ) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            "select add_partner_integration($1::uuid, $2::uuid, $3::jsonb)::uuid",
+            &[&actor_user_id, &alliance_id, &Json(partner_integration)],
         )
         .await
     }
@@ -409,6 +455,21 @@ where
         .await
     }
 
+    /// [`DBDashboardAlliance::delete_partner_integration`]
+    #[instrument(skip(self), err)]
+    async fn delete_partner_integration(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        partner_integration_id: Uuid,
+    ) -> Result<()> {
+        self.execute(
+            "select delete_partner_integration($1::uuid, $2::uuid, $3::uuid)",
+            &[&actor_user_id, &alliance_id, &partner_integration_id],
+        )
+        .await
+    }
+
     /// [`DBDashboardAlliance::get_alliance_stats`]
     #[instrument(skip(self), err)]
     async fn get_alliance_stats(&self, alliance_id: Uuid) -> Result<AllianceDashboardStats> {
@@ -491,6 +552,19 @@ where
     async fn list_regions(&self, alliance_id: Uuid) -> Result<Vec<GroupRegion>> {
         self.fetch_json_one("select list_regions($1::uuid)", &[&alliance_id])
             .await
+    }
+
+    /// [`DBDashboardAlliance::list_partner_integrations`]
+    #[instrument(skip(self), err)]
+    async fn list_partner_integrations(
+        &self,
+        alliance_id: Uuid,
+    ) -> Result<Vec<PartnerIntegration>> {
+        self.fetch_json_one(
+            "select list_partner_integrations($1::uuid)",
+            &[&alliance_id],
+        )
+        .await
     }
 
     /// [`DBDashboardAlliance::list_user_alliances`]
@@ -600,6 +674,27 @@ where
         self.execute(
             "select update_region($1::uuid, $2::uuid, $3::uuid, $4::jsonb)",
             &[&actor_user_id, &alliance_id, &region_id, &Json(region)],
+        )
+        .await
+    }
+
+    /// [`DBDashboardAlliance::update_partner_integration`]
+    #[instrument(skip(self, partner_integration), err)]
+    async fn update_partner_integration(
+        &self,
+        actor_user_id: Uuid,
+        alliance_id: Uuid,
+        partner_integration_id: Uuid,
+        partner_integration: &PartnerIntegrationInput,
+    ) -> Result<()> {
+        self.execute(
+            "select update_partner_integration($1::uuid, $2::uuid, $3::uuid, $4::jsonb)",
+            &[
+                &actor_user_id,
+                &alliance_id,
+                &partner_integration_id,
+                &Json(partner_integration),
+            ],
         )
         .await
     }

--- a/ocg-server/src/db/dashboard/common.rs
+++ b/ocg-server/src/db/dashboard/common.rs
@@ -33,7 +33,7 @@ pub(crate) trait DBDashboardCommon {
         group_id: Option<Uuid>,
     ) -> Result<Vec<IntentionalDatingOptIn>>;
 
-    /// Lists private book exchange member lists visible to authorized admins.
+    /// Lists book exchange member lists visible to authorized viewers.
     async fn list_book_exchange_members(
         &self,
         alliance_id: Uuid,
@@ -173,7 +173,7 @@ pub(crate) struct IntentionalDatingOptIn {
     pub title: Option<String>,
 }
 
-/// Private book exchange member list visible only to authorized admins.
+/// Book exchange member list visible to authorized viewers.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub(crate) struct BookExchangeMember {
     pub user_id: Uuid,

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -22,6 +22,7 @@ use crate::{
                 ApprovedSubmissionSummary, CfsSubmissionStatus, EventsListFilters, GroupEvents,
             },
             home::UserGroupsByAlliance,
+            integrations::IntegrationPage,
             invitation_requests::{InvitationRequestsFilters, InvitationRequestsOutput},
             members::{GroupJoinRequest, GroupMembersFilters, GroupMembersOutput},
             sponsors::{GroupSponsorsFilters, GroupSponsorsOutput, Sponsor},
@@ -235,6 +236,29 @@ pub(crate) trait DBDashboardGroup {
         alliance_id: Uuid,
         group_id: Uuid,
     ) -> Result<Option<serde_json::Value>>;
+
+    /// Gets the group event discovery configuration and latest run.
+    async fn get_group_event_integration(&self, group_id: Uuid) -> Result<IntegrationPage>;
+
+    /// Saves group event discovery settings.
+    async fn update_group_event_integration(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        enabled: bool,
+        city: &str,
+        timezone: &str,
+    ) -> Result<()>;
+
+    /// Adds a source URL to group event discovery.
+    async fn add_group_event_integration_source(&self, group_id: Uuid, url: &str) -> Result<Uuid>;
+
+    /// Removes a source URL from group event discovery.
+    async fn delete_group_event_integration_source(
+        &self,
+        group_id: Uuid,
+        source_id: Uuid,
+    ) -> Result<()>;
 
     /// Gets a single sponsor from the database.
     async fn get_group_sponsor(
@@ -1041,6 +1065,86 @@ where
             )
             ",
             &[&alliance_id, &group_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::get_group_event_integration`]
+    #[instrument(skip(self), err)]
+    async fn get_group_event_integration(&self, group_id: Uuid) -> Result<IntegrationPage> {
+        self.fetch_json_one(
+            "select jsonb_build_object(
+                'can_manage_events', false,
+                'enabled', coalesce(i.enabled, false),
+                'city', coalesce(i.city, 'Baku'),
+                'timezone', coalesce(i.timezone, 'Asia/Baku'),
+                'sources', coalesce((
+                    select jsonb_agg(jsonb_build_object(
+                        'group_event_integration_source_id', s.group_event_integration_source_id,
+                        'url', s.url, 'enabled', s.enabled
+                    ) order by s.created_at)
+                    from group_event_integration_source s where s.group_id = $1
+                ), '[]'::jsonb),
+                'latest_run', (
+                    select jsonb_build_object(
+                        'status', r.status, 'discovered_count', r.discovered_count,
+                        'created_count', r.created_count, 'error_message', r.error_message,
+                        'started_at', extract(epoch from r.started_at)::bigint,
+                        'completed_at', extract(epoch from r.completed_at)::bigint
+                    ) from group_event_integration_run r
+                    where r.group_id = $1 order by r.started_at desc limit 1
+                )
+            ) from (select 1) x left join group_event_integration i on i.group_id = $1",
+            &[&group_id],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::update_group_event_integration`]
+    #[instrument(skip(self), err)]
+    async fn update_group_event_integration(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        enabled: bool,
+        city: &str,
+        timezone: &str,
+    ) -> Result<()> {
+        self.execute(
+            "insert into group_event_integration (
+                group_id, created_by_user_id, enabled, city, timezone
+             ) values ($1, $2, $3, $4, $5)
+             on conflict (group_id) do update set
+                enabled = excluded.enabled, city = excluded.city,
+                timezone = excluded.timezone, updated_at = now()",
+            &[&group_id, &actor_user_id, &enabled, &city, &timezone],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::add_group_event_integration_source`]
+    #[instrument(skip(self), err)]
+    async fn add_group_event_integration_source(&self, group_id: Uuid, url: &str) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            "insert into group_event_integration_source (group_id, url)
+             values ($1, $2) on conflict (group_id, url) do update set enabled = true,
+             updated_at = now() returning group_event_integration_source_id",
+            &[&group_id, &url],
+        )
+        .await
+    }
+
+    /// [`DBDashboardGroup::delete_group_event_integration_source`]
+    #[instrument(skip(self), err)]
+    async fn delete_group_event_integration_source(
+        &self,
+        group_id: Uuid,
+        source_id: Uuid,
+    ) -> Result<()> {
+        self.execute(
+            "delete from group_event_integration_source
+             where group_id = $1 and group_event_integration_source_id = $2",
+            &[&group_id, &source_id],
         )
         .await
     }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -280,6 +280,10 @@ mock! {
             alliance_id: Uuid,
             filters: &crate::templates::alliance::AllianceMembersFilters,
         ) -> Result<crate::templates::alliance::AllianceMembersOutput>;
+        async fn list_public_partner_integrations(
+            &self,
+            alliance_id: Uuid,
+        ) -> Result<Vec<crate::types::partner_integration::PartnerIntegration>>;
     }
 
     impl crate::db::dashboard::DBDashboard for DB {}
@@ -357,6 +361,12 @@ mock! {
             alliance_id: Uuid,
             region: &crate::templates::dashboard::alliance::regions::RegionInput,
         ) -> Result<Uuid>;
+        async fn add_partner_integration(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            partner_integration: &crate::templates::dashboard::alliance::partner_integrations::PartnerIntegrationInput,
+        ) -> Result<Uuid>;
         async fn deactivate_group(&self, actor_user_id: Uuid, alliance_id: Uuid, group_id: Uuid)
             -> Result<()>;
         async fn delete_alliance_team_member(
@@ -379,6 +389,12 @@ mock! {
             group_category_id: Uuid,
         ) -> Result<()>;
         async fn delete_region(&self, actor_user_id: Uuid, alliance_id: Uuid, region_id: Uuid) -> Result<()>;
+        async fn delete_partner_integration(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            partner_integration_id: Uuid,
+        ) -> Result<()>;
         async fn get_alliance_stats(
             &self,
             alliance_id: Uuid,
@@ -404,6 +420,10 @@ mock! {
             &self,
             alliance_id: Uuid,
         ) -> Result<Vec<crate::types::group::GroupRegion>>;
+        async fn list_partner_integrations(
+            &self,
+            alliance_id: Uuid,
+        ) -> Result<Vec<crate::types::partner_integration::PartnerIntegration>>;
         async fn list_user_alliances(
             &self,
             user_id: &Uuid,
@@ -433,6 +453,13 @@ mock! {
             alliance_id: Uuid,
             event_category_id: Uuid,
             event_category: &crate::templates::dashboard::alliance::event_categories::EventCategoryInput,
+        ) -> Result<()>;
+        async fn update_partner_integration(
+            &self,
+            actor_user_id: Uuid,
+            alliance_id: Uuid,
+            partner_integration_id: Uuid,
+            partner_integration: &crate::templates::dashboard::alliance::partner_integrations::PartnerIntegrationInput,
         ) -> Result<()>;
         async fn update_group_category(
             &self,
@@ -590,6 +617,28 @@ mock! {
             alliance_id: Uuid,
             group_id: Uuid,
         ) -> Result<Option<serde_json::Value>>;
+        async fn get_group_event_integration(
+            &self,
+            group_id: Uuid,
+        ) -> Result<crate::templates::dashboard::group::integrations::IntegrationPage>;
+        async fn update_group_event_integration(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            enabled: bool,
+            city: &str,
+            timezone: &str,
+        ) -> Result<()>;
+        async fn add_group_event_integration_source(
+            &self,
+            group_id: Uuid,
+            url: &str,
+        ) -> Result<Uuid>;
+        async fn delete_group_event_integration_source(
+            &self,
+            group_id: Uuid,
+            source_id: Uuid,
+        ) -> Result<()>;
         async fn get_group_sponsor(
             &self,
             group_id: Uuid,

--- a/ocg-server/src/handlers/alliance.rs
+++ b/ocg-server/src/handlers/alliance.rs
@@ -119,6 +119,39 @@ pub(crate) async fn brand_page(
     Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
 }
 
+/// Handler that renders the public alliance integrations page.
+#[instrument(skip_all, err)]
+pub(crate) async fn integrations_page(
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path(alliance_name): Path<String>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let (alliance, integrations) = tokio::try_join!(
+        db.get_alliance_full(alliance_id),
+        db.list_public_partner_integrations(alliance_id),
+    )?;
+    let template = alliance::IntegrationsPage {
+        base_url: server_cfg.base_url,
+        alliance,
+        integrations,
+        page_id: PageId::Alliance,
+        path: uri.path().to_string(),
+        site_settings,
+        user: User::default(),
+    };
+
+    Ok((PUBLIC_SHARED_CACHE_HEADERS, Html(template.render()?)).into_response())
+}
+
 /// Handler that renders the public alliance report page.
 #[instrument(skip_all, err)]
 pub(crate) async fn report_page(

--- a/ocg-server/src/handlers/dashboard/alliance.rs
+++ b/ocg-server/src/handlers/dashboard/alliance.rs
@@ -33,6 +33,7 @@ pub(crate) mod intentional_dating;
 pub(crate) mod landscape;
 pub(crate) mod logs;
 pub(crate) mod members;
+pub(crate) mod partner_integrations;
 pub(crate) mod regions;
 pub(crate) mod settings;
 pub(crate) mod team;

--- a/ocg-server/src/handlers/dashboard/alliance/home.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/home.rs
@@ -164,6 +164,9 @@ pub(crate) async fn page(
                 opt_ins,
             })
         }
+        Tab::PartnerIntegrations => Content::PartnerIntegrations(
+            super::partner_integrations::prepare_page(&db, alliance_id, user_id).await?,
+        ),
         Tab::Landscape => {
             let (_, template) = landscape::prepare_list_page(
                 &db,

--- a/ocg-server/src/handlers/dashboard/alliance/partner_integrations.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/partner_integrations.rs
@@ -1,0 +1,95 @@
+//! HTTP handlers for alliance partner integrations.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{Html, IntoResponse},
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, ValidatedForm},
+    },
+    templates::dashboard::alliance::partner_integrations::{Page, PartnerIntegrationInput},
+    types::permissions::AlliancePermission,
+};
+
+/// Displays partner integrations configured for the selected alliance.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    Ok(Html(
+        prepare_page(&db, alliance_id, user.user_id).await?.render()?,
+    ))
+}
+
+/// Creates a partner integration.
+#[instrument(skip_all, err)]
+pub(crate) async fn add(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<PartnerIntegrationInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.add_partner_integration(user.user_id, alliance_id, &input).await?;
+    Ok((
+        StatusCode::CREATED,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Updates a partner integration.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    Path(partner_integration_id): Path<Uuid>,
+    ValidatedForm(input): ValidatedForm<PartnerIntegrationInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_partner_integration(user.user_id, alliance_id, partner_integration_id, &input)
+        .await?;
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+/// Deletes a partner integration.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    Path(partner_integration_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_partner_integration(user.user_id, alliance_id, partner_integration_id)
+        .await?;
+    Ok((
+        StatusCode::NO_CONTENT,
+        [("HX-Trigger", "refresh-alliance-dashboard-table")],
+    ))
+}
+
+pub(crate) async fn prepare_page(
+    db: &DynDB,
+    alliance_id: Uuid,
+    user_id: Uuid,
+) -> Result<Page, HandlerError> {
+    let (can_manage_settings, integrations) = tokio::try_join!(
+        db.user_has_alliance_permission(&alliance_id, &user_id, AlliancePermission::SettingsWrite),
+        db.list_partner_integrations(alliance_id),
+    )?;
+    Ok(Page {
+        can_manage_settings,
+        integrations,
+    })
+}

--- a/ocg-server/src/handlers/dashboard/group.rs
+++ b/ocg-server/src/handlers/dashboard/group.rs
@@ -28,6 +28,7 @@ pub(crate) mod book_exchange;
 pub(crate) mod coffee_meet;
 pub(crate) mod events;
 pub(crate) mod home;
+pub(crate) mod integrations;
 pub(crate) mod intentional_dating;
 pub(crate) mod invitation_requests;
 pub(crate) mod logs;

--- a/ocg-server/src/handlers/dashboard/group/accelerator.rs
+++ b/ocg-server/src/handlers/dashboard/group/accelerator.rs
@@ -83,8 +83,7 @@ pub(crate) async fn add_week(
     ValidatedForm(input): ValidatedForm<AcceleratorWeekInput>,
 ) -> Result<impl IntoResponse, HandlerError> {
     ensure_can_manage_accelerator(&db, alliance_id, group_id, user.user_id).await?;
-    db.add_group_accelerator_week(user.user_id, group_id, &input)
-        .await?;
+    db.add_group_accelerator_week(user.user_id, group_id, &input).await?;
 
     Ok(refresh_created())
 }

--- a/ocg-server/src/handlers/dashboard/group/book_exchange.rs
+++ b/ocg-server/src/handlers/dashboard/group/book_exchange.rs
@@ -8,24 +8,39 @@ use axum::{
 use tracing::instrument;
 
 use crate::{
+    auth::AuthSession,
     db::DynDB,
     handlers::{
         error::HandlerError,
         extractors::{SelectedAllianceId, SelectedGroupId},
     },
     templates::dashboard::group::book_exchange,
+    types::permissions::GroupPermission,
 };
 
-/// Displays private group book exchange member lists.
+#[cfg(test)]
+mod tests;
+
+/// Displays group book exchange member lists for opted-in members.
 #[instrument(skip_all, err)]
 pub(crate) async fn list_page(
+    auth_session: AuthSession,
     SelectedAllianceId(alliance_id): SelectedAllianceId,
     SelectedGroupId(group_id): SelectedGroupId,
     State(db): State<DynDB>,
 ) -> Result<impl IntoResponse, HandlerError> {
+    let user = auth_session.user.as_ref().expect("user to be logged in");
+    let can_manage_book_exchange = db
+        .user_has_group_permission(
+            &alliance_id,
+            &group_id,
+            &user.user_id,
+            GroupPermission::SettingsWrite,
+        )
+        .await?;
     let members = db.list_book_exchange_members(alliance_id, Some(group_id)).await?;
     let template = book_exchange::ListPage {
-        can_manage_book_exchange: true,
+        can_manage_book_exchange,
         members,
     };
 

--- a/ocg-server/src/handlers/dashboard/group/book_exchange/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/book_exchange/tests.rs
@@ -1,0 +1,84 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::COOKIE},
+};
+use axum_login::tower_sessions::session;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::{
+    db::{dashboard::common::BookExchangeMember, mock::MockDB},
+    handlers::tests::*,
+    services::notifications::MockNotificationsManager,
+    types::permissions::GroupPermission,
+};
+
+#[tokio::test]
+async fn test_list_page_allows_read_only_group_member_without_email() {
+    let alliance_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let member = sample_book_exchange_member(alliance_id, group_id);
+
+    let mut db = MockDB::new();
+    expect_authenticated_group_session(&mut db, session_id, user_id, alliance_id, group_id);
+    expect_group_permission(
+        &mut db,
+        alliance_id,
+        group_id,
+        user_id,
+        GroupPermission::Read,
+    );
+    db.expect_user_has_group_permission()
+        .times(1)
+        .withf(move |cid, gid, uid, permission| {
+            *cid == alliance_id
+                && *gid == group_id
+                && *uid == user_id
+                && permission == GroupPermission::SettingsWrite
+        })
+        .returning(|_, _, _, _| Ok(false));
+    db.expect_list_book_exchange_members()
+        .times(1)
+        .withf(move |cid, gid| *cid == alliance_id && *gid == Some(group_id))
+        .returning(move |_, _| Ok(vec![member.clone()]));
+
+    let router = TestRouterBuilder::new(db, MockNotificationsManager::new())
+        .build()
+        .await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/dashboard/group/book-exchange")
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+
+    assert_html_response(&parts, &bytes, StatusCode::OK);
+    assert!(body.contains("The Pragmatic Programmer"));
+    assert!(body.contains("@book-lover"));
+    assert!(!body.contains("book-lover@example.com"));
+}
+
+fn sample_book_exchange_member(alliance_id: Uuid, group_id: Uuid) -> BookExchangeMember {
+    BookExchangeMember {
+        user_id: Uuid::new_v4(),
+        username: "book-lover".to_string(),
+        group_id,
+        group_name: "GOUP Builders".to_string(),
+        alliance_id,
+        alliance_display_name: "GOUP".to_string(),
+        book_exchange_books: Some("The Pragmatic Programmer".to_string()),
+        city: Some("Phoenix".to_string()),
+        company: Some("GOUP".to_string()),
+        country: Some("US".to_string()),
+        email: Some("book-lover@example.com".to_string()),
+        name: Some("Book Lover".to_string()),
+        photo_url: None,
+        title: Some("Builder".to_string()),
+    }
+}

--- a/ocg-server/src/handlers/dashboard/group/home.rs
+++ b/ocg-server/src/handlers/dashboard/group/home.rs
@@ -11,7 +11,10 @@ use axum::{
 use axum_messages::Messages;
 use tracing::instrument;
 
-use super::{accelerator, coffee_meet, events, logs, members, sponsors, spotlights, store, team};
+use super::{
+    accelerator, coffee_meet, events, integrations, logs, members, sponsors, spotlights, store,
+    team,
+};
 
 use crate::{
     auth::AuthSession,
@@ -104,9 +107,6 @@ pub(crate) async fn page(
                     GroupPermission::SettingsWrite,
                 )
                 .await?;
-            if !can_manage_book_exchange {
-                return Err(HandlerError::Forbidden);
-            }
             let members = db.list_book_exchange_members(alliance_id, Some(group_id)).await?;
             Content::BookExchange(book_exchange_template::ListPage {
                 can_manage_book_exchange,
@@ -133,6 +133,9 @@ pub(crate) async fn page(
                 opt_ins,
             })
         }
+        Tab::Integrations => Content::Integrations(
+            integrations::prepare_page(&db, alliance_id, group_id, user.user_id).await?,
+        ),
         Tab::Members => {
             let (_, template) = members::prepare_list_page(
                 &db,

--- a/ocg-server/src/handlers/dashboard/group/home/tests.rs
+++ b/ocg-server/src/handlers/dashboard/group/home/tests.rs
@@ -7,7 +7,7 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use crate::{
-    db::mock::MockDB,
+    db::{dashboard::common::BookExchangeMember, mock::MockDB},
     handlers::tests::*,
     services::notifications::MockNotificationsManager,
     templates::dashboard::{DASHBOARD_PAGINATION_LIMIT, group::coffee_meet::CoffeeMeetSubscriber},
@@ -176,6 +176,65 @@ async fn test_page_coffee_meet_tab_success() {
 }
 
 #[tokio::test]
+async fn test_page_book_exchange_tab_allows_read_only_group_member() {
+    let alliance_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let groups = sample_user_groups_by_alliance(alliance_id, group_id);
+    let member = sample_book_exchange_member(alliance_id, group_id);
+
+    let mut db = MockDB::new();
+    expect_authenticated_group_session(&mut db, session_id, user_id, alliance_id, group_id);
+    expect_group_permission(
+        &mut db,
+        alliance_id,
+        group_id,
+        user_id,
+        GroupPermission::Read,
+    );
+    db.expect_list_user_groups()
+        .times(1)
+        .withf(move |uid| uid == &user_id)
+        .returning(move |_| Ok(groups.clone()));
+    db.expect_user_has_group_permission()
+        .times(1)
+        .withf(move |cid, gid, uid, permission| {
+            *cid == alliance_id
+                && *gid == group_id
+                && *uid == user_id
+                && permission == GroupPermission::SettingsWrite
+        })
+        .returning(|_, _, _, _| Ok(false));
+    db.expect_list_book_exchange_members()
+        .times(1)
+        .withf(move |cid, gid| *cid == alliance_id && *gid == Some(group_id))
+        .returning(move |_, _| Ok(vec![member.clone()]));
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(|| Ok(sample_site_settings()));
+
+    let router = TestRouterBuilder::new(db, MockNotificationsManager::new())
+        .build()
+        .await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/dashboard/group?tab=book-exchange")
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+    let body = std::str::from_utf8(&bytes).unwrap();
+
+    assert_html_response(&parts, &bytes, StatusCode::OK);
+    assert!(body.contains("The Pragmatic Programmer"));
+    assert!(body.contains("Contact details are only visible to group managers."));
+    assert!(!body.contains("book-lover@example.com"));
+}
+
+#[tokio::test]
 async fn test_page_events_tab_success() {
     // Setup identifiers and data structures
     let alliance_id = Uuid::new_v4();
@@ -256,6 +315,25 @@ async fn test_page_events_tab_success() {
 
     // Check response matches expectations
     assert_html_response(&parts, &bytes, StatusCode::OK);
+}
+
+fn sample_book_exchange_member(alliance_id: Uuid, group_id: Uuid) -> BookExchangeMember {
+    BookExchangeMember {
+        user_id: Uuid::new_v4(),
+        username: "book-lover".to_string(),
+        group_id,
+        group_name: "GOUP Builders".to_string(),
+        alliance_id,
+        alliance_display_name: "GOUP".to_string(),
+        book_exchange_books: Some("The Pragmatic Programmer".to_string()),
+        city: Some("Phoenix".to_string()),
+        company: Some("GOUP".to_string()),
+        country: Some("US".to_string()),
+        email: Some("book-lover@example.com".to_string()),
+        name: Some("Book Lover".to_string()),
+        photo_url: None,
+        title: Some("Builder".to_string()),
+    }
 }
 
 #[tokio::test]

--- a/ocg-server/src/handlers/dashboard/group/integrations.rs
+++ b/ocg-server/src/handlers/dashboard/group/integrations.rs
@@ -1,0 +1,167 @@
+//! Group event discovery configuration handlers.
+
+use askama::Template;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{Html, IntoResponse},
+};
+use garde::Validate;
+use serde::Deserialize;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    db::DynDB,
+    handlers::{
+        error::HandlerError,
+        extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId, ValidatedForm},
+    },
+    integrations::you_com::validate_source_url,
+    services::event_discovery::ManualEventDiscovery,
+    templates::dashboard::group::integrations::Page,
+    types::permissions::GroupPermission,
+};
+
+/// Displays source URLs, settings, and the latest ingestion result.
+#[instrument(skip_all, err)]
+pub(crate) async fn page(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+) -> Result<impl IntoResponse, HandlerError> {
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
+/// Starts an authorized discovery run for the selected group.
+#[instrument(skip_all, err)]
+pub(crate) async fn run(
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(manual_event_discovery): State<Option<ManualEventDiscovery>>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let Some(manual_event_discovery) = manual_event_discovery else {
+        return Ok(StatusCode::NOT_FOUND);
+    };
+    if !manual_event_discovery.enabled() {
+        return Ok(StatusCode::NOT_FOUND);
+    }
+
+    manual_event_discovery.spawn_group_run(group_id);
+    Ok(StatusCode::ACCEPTED)
+}
+
+/// Updates enabled state and location settings.
+#[instrument(skip_all, err)]
+pub(crate) async fn update(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<SettingsInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    validate_settings(&input)?;
+    db.update_group_event_integration(
+        user.user_id,
+        group_id,
+        input.enabled,
+        input.city.trim(),
+        input.timezone.trim(),
+    )
+    .await?;
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
+/// Adds a source URL after server-side URL validation.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_source(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<SourceInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    validate_source_url(input.url.trim()).map_err(HandlerError::from)?;
+    db.add_group_event_integration_source(group_id, input.url.trim())
+        .await?;
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
+/// Deletes one source URL from the selected group only.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete_source(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(source_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_group_event_integration_source(group_id, source_id).await?;
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
+pub(crate) async fn prepare_page(
+    db: &DynDB,
+    alliance_id: Uuid,
+    group_id: Uuid,
+    user_id: Uuid,
+) -> Result<Page, HandlerError> {
+    let (can_manage_events, mut integration) = tokio::try_join!(
+        db.user_has_group_permission(
+            &alliance_id,
+            &group_id,
+            &user_id,
+            GroupPermission::EventsWrite
+        ),
+        db.get_group_event_integration(group_id),
+    )?;
+    integration.can_manage_events = can_manage_events;
+    Ok(Page { integration })
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(crate) struct SettingsInput {
+    #[serde(default)]
+    #[garde(skip)]
+    enabled: bool,
+    #[garde(skip)]
+    city: String,
+    #[garde(skip)]
+    timezone: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(crate) struct SourceInput {
+    #[garde(skip)]
+    url: String,
+}
+
+fn validate_settings(input: &SettingsInput) -> Result<(), HandlerError> {
+    if input.city.trim().is_empty() || input.city.len() > 100 {
+        return Err(HandlerError::Database(
+            "city must be between 1 and 100 characters".into(),
+        ));
+    }
+    input
+        .timezone
+        .trim()
+        .parse::<chrono_tz::Tz>()
+        .map_err(|_| HandlerError::Database("timezone must be a valid IANA timezone".into()))?;
+    Ok(())
+}

--- a/ocg-server/src/handlers/dashboard/user/mock_interviews.rs
+++ b/ocg-server/src/handlers/dashboard/user/mock_interviews.rs
@@ -98,8 +98,5 @@ pub(crate) async fn prepare_list_page(
         db.list_user_mock_interview_matches(user_id),
     )?;
 
-    Ok(mock_interviews::ListPage {
-        requests,
-        matches,
-    })
+    Ok(mock_interviews::ListPage { requests, matches })
 }

--- a/ocg-server/src/handlers/group.rs
+++ b/ocg-server/src/handlers/group.rs
@@ -31,7 +31,10 @@ use crate::{
             AcceleratorApplicationInput, AcceleratorWeeklyUpdateInput,
         },
         dashboard::group::members::GroupMembersFilters,
-        group::{self, AcceleratorPage, MembersPage, Page, ReportPage, SpotlightsPage, StorePage},
+        group::{
+            self, AcceleratorPage, BookExchangePage, MembersPage, Page, ReportPage, SpotlightsPage,
+            StorePage,
+        },
         notifications::{GroupWelcome, MockInterviewMatched},
     },
     types::{
@@ -347,6 +350,63 @@ pub(crate) async fn members_page(
         query: filters.query.clone(),
         site_settings,
         total: results.total,
+        user: template_user,
+    };
+
+    Ok(Html(template.render()?).into_response())
+}
+
+/// Handler that renders group member book exchange lists for logged-in members.
+#[instrument(skip_all)]
+pub(crate) async fn book_exchange_page(
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    State(server_cfg): State<HttpServerConfig>,
+    Path((alliance_name, group_slug)): Path<(String, String)>,
+    uri: Uri,
+) -> Result<impl IntoResponse, HandlerError> {
+    let (alliance_id, site_settings) = tokio::try_join!(
+        db.get_alliance_id_by_name(&alliance_name),
+        db.get_site_settings()
+    )?;
+    let Some(alliance_id) = alliance_id else {
+        return not_found::render(site_settings);
+    };
+
+    let Some(mut group) = db.get_group_full_by_slug(alliance_id, &group_slug).await? else {
+        return not_found::render(site_settings);
+    };
+    trim_public_gallery_images(&mut group.photos_urls);
+    group.sponsors.clear();
+
+    if !db.is_group_member(alliance_id, group.group_id, user.user_id).await? {
+        return Ok((
+            StatusCode::FORBIDDEN,
+            "Join this group first to see book exchange lists.",
+        )
+            .into_response());
+    }
+
+    let members = db
+        .list_book_exchange_members(alliance_id, Some(group.group_id))
+        .await?;
+    let template_user = User {
+        logged_in: true,
+        auth_provider: None,
+        belongs_to_any_group_team: user.belongs_to_any_group_team,
+        belongs_to_alliance_team: user.belongs_to_alliance_team,
+        name: Some(user.name),
+        platform_admin: user.platform_admin,
+        username: Some(user.username),
+    };
+
+    let template = BookExchangePage {
+        base_url: server_cfg.base_url,
+        group,
+        members,
+        page_id: PageId::Group,
+        path: uri.path().to_string(),
+        site_settings,
         user: template_user,
     };
 

--- a/ocg-server/src/handlers/group/tests.rs
+++ b/ocg-server/src/handlers/group/tests.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 
 use crate::{
     activity_tracker::{Activity, MockActivityTracker},
-    db::mock::MockDB,
+    db::{dashboard::common::BookExchangeMember, mock::MockDB},
     handlers::tests::*,
     router::CACHE_CONTROL_PUBLIC_SHARED,
     services::notifications::{MockNotificationsManager, NotificationKind},
@@ -351,6 +351,25 @@ fn expect_empty_group_home_previews(db: &mut MockDB, group_id: Uuid) {
         .returning(|_, _| Ok(vec![]));
 }
 
+fn sample_book_exchange_member(alliance_id: Uuid, group_id: Uuid) -> BookExchangeMember {
+    BookExchangeMember {
+        user_id: Uuid::new_v4(),
+        username: "book-lover".to_string(),
+        group_id,
+        group_name: "Test Group".to_string(),
+        alliance_id,
+        alliance_display_name: "Test Alliance".to_string(),
+        book_exchange_books: Some("The Pragmatic Programmer".to_string()),
+        city: Some("Phoenix".to_string()),
+        company: Some("GOUP".to_string()),
+        country: Some("US".to_string()),
+        email: Some("book-lover@example.com".to_string()),
+        name: Some("Book Lover".to_string()),
+        photo_url: None,
+        title: Some("Builder".to_string()),
+    }
+}
+
 #[tokio::test]
 async fn test_members_page_non_member_explains_join_required() {
     // Setup identifiers and data structures
@@ -405,6 +424,65 @@ async fn test_members_page_non_member_explains_join_required() {
     assert_eq!(parts.status, StatusCode::FORBIDDEN);
     let body = String::from_utf8(bytes.to_vec()).unwrap();
     assert!(body.contains("Join this group first to see members."));
+}
+
+#[tokio::test]
+async fn test_book_exchange_page_allows_group_member_without_email() {
+    let alliance_id = Uuid::new_v4();
+    let group_id = Uuid::new_v4();
+    let session_id = session::Id::default();
+    let user_id = Uuid::new_v4();
+    let auth_hash = "hash".to_string();
+    let session_record = sample_session_record(session_id, user_id, &auth_hash, None, None);
+    let member = sample_book_exchange_member(alliance_id, group_id);
+
+    let mut db = MockDB::new();
+    db.expect_get_session()
+        .times(1)
+        .withf(move |id| *id == session_id)
+        .returning(move |_| Ok(Some(session_record.clone())));
+    db.expect_get_user_by_id()
+        .times(1)
+        .withf(move |id| *id == user_id)
+        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
+    db.expect_get_alliance_id_by_name()
+        .times(1)
+        .withf(|name| name == "test-alliance")
+        .returning(move |_| Ok(Some(alliance_id)));
+    db.expect_get_site_settings()
+        .times(1)
+        .returning(|| Ok(sample_site_settings()));
+    db.expect_get_group_full_by_slug()
+        .times(1)
+        .withf(move |id, slug| *id == alliance_id && slug == "test-group")
+        .returning(move |_, _| Ok(Some(sample_group_full(alliance_id, group_id))));
+    db.expect_is_group_member()
+        .times(1)
+        .withf(move |aid, gid, uid| *aid == alliance_id && *gid == group_id && *uid == user_id)
+        .returning(|_, _, _| Ok(true));
+    db.expect_list_book_exchange_members()
+        .times(1)
+        .withf(move |aid, gid| *aid == alliance_id && *gid == Some(group_id))
+        .returning(move |_, _| Ok(vec![member.clone()]));
+
+    let router = TestRouterBuilder::new(db, MockNotificationsManager::new())
+        .build()
+        .await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/test-alliance/group/test-group/book-exchange")
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let bytes = to_bytes(body, usize::MAX).await.unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+
+    assert_eq!(parts.status, StatusCode::OK);
+    assert!(body.contains("The Pragmatic Programmer"));
+    assert!(body.contains("@book-lover"));
+    assert!(!body.contains("book-lover@example.com"));
 }
 
 #[tokio::test]

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -1570,6 +1570,7 @@ pub(crate) fn test_state_with_server_cfg(
         activity_tracker: Arc::new(crate::activity_tracker::MockActivityTracker::new()),
         db,
         image_storage,
+        manual_event_discovery: None,
         meetings_cfg: None,
         notifications_manager,
         payments_cfg: None,
@@ -1620,7 +1621,9 @@ impl TestRouterBuilder {
         router::setup(
             activity_tracker,
             db,
+            None,
             is,
+            None,
             self.meetings_cfg,
             self.payments_cfg,
             payments_manager,

--- a/ocg-server/src/integrations.rs
+++ b/ocg-server/src/integrations.rs
@@ -1,0 +1,5 @@
+//! External partner integrations.
+//!
+//! This module keeps third-party API details outside handlers and domain models.
+
+pub(crate) mod you_com;

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -1,0 +1,167 @@
+//! You.com search integration used to discover Baku community events.
+
+use std::{collections::HashSet, time::Duration};
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::config::YouComConfig;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// A normalized community event ready for persistence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DiscoveredEvent {
+    pub title: String,
+    pub description: Option<String>,
+    pub starts_at: DateTime<Utc>,
+    pub source_url: String,
+}
+
+impl DiscoveredEvent {
+    /// A stable deduplication key scoped to a group.
+    pub(crate) fn fingerprint(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.title.trim().to_lowercase());
+        hasher.update(b"\0");
+        hasher.update(self.starts_at.timestamp().to_le_bytes());
+        hasher.update(b"\0");
+        hasher.update(self.source_url.trim().to_lowercase());
+        hex::encode(hasher.finalize())
+    }
+}
+
+/// Thin, typed client for the You.com search API.
+#[derive(Clone)]
+pub(crate) struct YouComClient {
+    api_key: String,
+    http: Client,
+    search_url: String,
+}
+
+impl YouComClient {
+    pub(crate) fn new(cfg: &YouComConfig) -> Result<Self> {
+        let http = Client::builder().timeout(REQUEST_TIMEOUT).build()?;
+        Ok(Self {
+            api_key: cfg.api_key.clone(),
+            http,
+            search_url: cfg.search_url.clone(),
+        })
+    }
+
+    /// Searches You.com for current Baku community-event pages.
+    pub(crate) async fn search_baku_events(&self) -> Result<Vec<SearchResult>> {
+        self.search("upcoming community events in Baku Azerbaijan").await
+    }
+
+    /// Searches You.com with a caller-provided, source-scoped query.
+    pub(crate) async fn search(&self, query: &str) -> Result<Vec<SearchResult>> {
+        let mut search_url =
+            reqwest::Url::parse(&self.search_url).context("invalid You.com search URL")?;
+        search_url.query_pairs_mut().append_pair("query", query);
+        let response = self
+            .http
+            .get(search_url)
+            .header("X-API-Key", &self.api_key)
+            .send()
+            .await
+            .context("requesting You.com search")?
+            .error_for_status()
+            .context("You.com search returned an error")?;
+        let payload: SearchResponse =
+            response.json().await.context("decoding You.com search response")?;
+        Ok(payload.results)
+    }
+}
+
+/// Search result fields shared by the supported You.com response shapes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchResult {
+    #[serde(alias = "name")]
+    pub title: String,
+    #[serde(alias = "url", alias = "link")]
+    pub url: String,
+    #[serde(default, alias = "snippet", alias = "description")]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SearchResponse {
+    #[serde(default, alias = "hits")]
+    results: Vec<SearchResult>,
+}
+
+/// Rejects pages that do not identify Baku or Azerbaijan.
+pub(crate) fn is_baku_relevant(result: &SearchResult) -> bool {
+    let text = format!(
+        "{} {} {}",
+        result.title,
+        result.description.as_deref().unwrap_or_default(),
+        result.url
+    )
+    .to_lowercase();
+    text.contains("baku") || text.contains("azerbaijan") || text.contains("azərbaycan")
+}
+
+/// Returns unique, relevant results while preserving discovery order.
+pub(crate) fn unique_baku_results(results: Vec<SearchResult>) -> Vec<SearchResult> {
+    let mut urls = HashSet::new();
+    results
+        .into_iter()
+        .filter(is_baku_relevant)
+        .filter(|result| urls.insert(result.url.trim().to_lowercase()))
+        .collect()
+}
+
+/// Validates a source URL entered in a group dashboard.
+pub(crate) fn validate_source_url(url: &str) -> Result<()> {
+    let parsed = reqwest::Url::parse(url).context("source URL must be absolute")?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        bail!("source URL must use HTTP or HTTPS");
+    }
+    if parsed.host_str().is_none() {
+        bail!("source URL must include a host");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeZone;
+
+    use super::*;
+
+    fn result(title: &str, url: &str, description: Option<&str>) -> SearchResult {
+        SearchResult {
+            title: title.into(),
+            url: url.into(),
+            description: description.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn retains_unique_baku_results() {
+        let results = unique_baku_results(vec![
+            result("Baku Rust meetup", "https://example.test/events/1", None),
+            result("Baku Rust meetup", "https://example.test/events/1", None),
+            result("Tbilisi meetup", "https://example.test/events/2", None),
+        ]);
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn fingerprint_changes_when_event_time_changes() {
+        let event = DiscoveredEvent {
+            title: "Baku meetup".into(),
+            description: None,
+            starts_at: Utc.with_ymd_and_hms(2026, 7, 21, 12, 0, 0).unwrap(),
+            source_url: "https://example.test/events/1".into(),
+        };
+        let mut rescheduled = event.clone();
+        rescheduled.starts_at = Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap();
+        assert_ne!(event.fingerprint(), rescheduled.fingerprint());
+    }
+}

--- a/ocg-server/src/main.rs
+++ b/ocg-server/src/main.rs
@@ -326,7 +326,8 @@ async fn run_server(
     // Build the router before binding the TCP listener
     let router = router::setup(
         activity_tracker,
-        db,
+        db.clone(),
+        Some(db),
         image_storage,
         you_com_cfg,
         meetings_cfg,

--- a/ocg-server/src/main.rs
+++ b/ocg-server/src/main.rs
@@ -48,6 +48,8 @@ mod config;
 mod db;
 /// HTTP request handlers.
 mod handlers;
+/// External partner integrations.
+mod integrations;
 /// HTTP router configuration and setup.
 mod router;
 /// Background services and workers.
@@ -108,6 +110,7 @@ async fn main() -> Result<()> {
     // Configure background services that depend on the database
     start_meetings_workers(&cfg, db.clone(), &background_tasks);
     start_recording_publishing_workers(&cfg, &db, &background_tasks);
+    start_event_discovery_worker(&cfg, db.clone(), &background_tasks);
     let activity_tracker = setup_activity_tracker(db.clone(), &background_tasks);
     let notifications_manager = setup_notifications_manager(&cfg, db.clone(), &background_tasks)?;
     let payments_manager = setup_payments_manager(
@@ -122,6 +125,9 @@ async fn main() -> Result<()> {
         activity_tracker,
         db,
         image_storage,
+        cfg.integrations
+            .as_ref()
+            .and_then(|integrations| integrations.you_com.clone()),
         cfg.meetings.clone(),
         cfg.payments.clone(),
         payments_manager,
@@ -180,6 +186,22 @@ fn setup_image_storage(cfg: &Config, db: Arc<PgDB>) -> DynImageStorage {
     match &cfg.images {
         ImageStorageConfig::Db => Arc::new(DbImageStorage::new(db)),
         ImageStorageConfig::S3(s3_cfg) => Arc::new(S3ImageStorage::new(s3_cfg)),
+    }
+}
+
+/// Starts You.com discovery when its integration is configured and enabled.
+fn start_event_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &BackgroundTasks) {
+    if let Some(you_com_cfg) = cfg
+        .integrations
+        .as_ref()
+        .and_then(|integrations| integrations.you_com.clone())
+    {
+        services::event_discovery::start(
+            you_com_cfg,
+            db,
+            &background_tasks.task_tracker,
+            &background_tasks.cancellation_token,
+        );
     }
 }
 
@@ -294,6 +316,7 @@ async fn run_server(
     activity_tracker: Arc<ActivityTrackerDB>,
     db: Arc<PgDB>,
     image_storage: DynImageStorage,
+    you_com_cfg: Option<config::YouComConfig>,
     meetings_cfg: Option<MeetingsConfig>,
     payments_cfg: Option<PaymentsConfig>,
     payments_manager: DynPaymentsManager,
@@ -305,6 +328,7 @@ async fn run_server(
         activity_tracker,
         db,
         image_storage,
+        you_com_cfg,
         meetings_cfg,
         payments_cfg,
         payments_manager,

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -31,16 +31,16 @@ use tracing::instrument;
 use crate::{
     activity_tracker::DynActivityTracker,
     auth::AuthnBackend,
-    config::{HttpServerConfig, MeetingsConfig, PaymentsConfig},
-    db::DynDB,
+    config::{HttpServerConfig, MeetingsConfig, PaymentsConfig, YouComConfig},
+    db::{DynDB, PgDB},
     handlers::{
         alliance,
         auth::{self, LOG_IN_URL},
         event, group, images, meetings, payments, site,
     },
     services::{
-        images::DynImageStorage, notifications::DynNotificationsManager,
-        payments::DynPaymentsManager,
+        event_discovery::ManualEventDiscovery, images::DynImageStorage,
+        notifications::DynNotificationsManager, payments::DynPaymentsManager,
     },
 };
 
@@ -112,6 +112,8 @@ pub(crate) struct State {
     pub db: DynDB,
     /// Image storage provider handle.
     pub image_storage: DynImageStorage,
+    /// Optional You.com discovery runner for authorized dashboard actions.
+    pub manual_event_discovery: Option<ManualEventDiscovery>,
     /// Meetings configuration.
     pub meetings_cfg: Option<MeetingsConfig>,
     /// Notifications manager handle.
@@ -135,8 +137,9 @@ pub(crate) struct State {
 #[instrument(skip_all)]
 pub(crate) async fn setup(
     activity_tracker: DynActivityTracker,
-    db: DynDB,
+    db: std::sync::Arc<PgDB>,
     image_storage: DynImageStorage,
+    you_com_cfg: Option<YouComConfig>,
     meetings_cfg: Option<MeetingsConfig>,
     payments_cfg: Option<PaymentsConfig>,
     payments_manager: DynPaymentsManager,
@@ -157,6 +160,7 @@ pub(crate) async fn setup(
         db: db.clone(),
         activity_tracker,
         image_storage,
+        manual_event_discovery: you_com_cfg.map(|cfg| ManualEventDiscovery::new(cfg, db.clone())),
         meetings_cfg,
         notifications_manager,
         payments_cfg,
@@ -230,6 +234,10 @@ pub(crate) async fn setup(
         .route(
             "/{alliance}/group/{group_slug}/members",
             get(group::members_page),
+        )
+        .route(
+            "/{alliance}/group/{group_slug}/book-exchange",
+            get(group::book_exchange_page),
         )
         .route(
             "/{alliance}/group/{group_slug}/members/{user_id}/phone-requests",
@@ -368,6 +376,7 @@ pub(crate) async fn setup(
         .route("/wiki", get(site::wiki::page))
         // Alliance-prefixed public routes
         .route("/{alliance}/brand", get(alliance::brand_page))
+        .route("/{alliance}/integrations", get(alliance::integrations_page))
         .route("/{alliance}/members", get(alliance::members_page))
         .route("/{alliance}/reports", get(alliance::report_page))
         .route("/{alliance}", get(alliance::page))

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -137,7 +137,8 @@ pub(crate) struct State {
 #[instrument(skip_all)]
 pub(crate) async fn setup(
     activity_tracker: DynActivityTracker,
-    db: std::sync::Arc<PgDB>,
+    db: DynDB,
+    manual_event_discovery_db: Option<std::sync::Arc<PgDB>>,
     image_storage: DynImageStorage,
     you_com_cfg: Option<YouComConfig>,
     meetings_cfg: Option<MeetingsConfig>,
@@ -160,7 +161,9 @@ pub(crate) async fn setup(
         db: db.clone(),
         activity_tracker,
         image_storage,
-        manual_event_discovery: you_com_cfg.map(|cfg| ManualEventDiscovery::new(cfg, db.clone())),
+        manual_event_discovery: you_com_cfg
+            .zip(manual_event_discovery_db)
+            .map(|(cfg, db)| ManualEventDiscovery::new(cfg, db)),
         meetings_cfg,
         notifications_manager,
         payments_cfg,

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -166,6 +166,16 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
             post(dashboard::alliance::intentional_dating::add_intro),
         )
         .route(
+            "/partner-integrations",
+            get(dashboard::alliance::partner_integrations::page)
+                .post(dashboard::alliance::partner_integrations::add),
+        )
+        .route(
+            "/partner-integrations/{partner_integration_id}",
+            put(dashboard::alliance::partner_integrations::update)
+                .delete(dashboard::alliance::partner_integrations::delete),
+        )
+        .route(
             "/settings/update",
             put(dashboard::alliance::settings::update),
         )
@@ -281,6 +291,7 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             get(dashboard::group::attendees::generate_check_in_qr_code),
         )
         .route("/events", get(dashboard::group::events::list_page))
+        .route("/integrations", get(dashboard::group::integrations::page))
         .route("/events/add", get(dashboard::group::events::add_page))
         .route(
             "/events/{event_id}/attendees",
@@ -316,6 +327,10 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
         )
         .route("/logs", get(dashboard::group::logs::list_page))
         .route("/members", get(dashboard::group::members::list_page))
+        .route(
+            "/book-exchange",
+            get(dashboard::group::book_exchange::list_page),
+        )
         .route("/spotlights", get(dashboard::group::spotlights::list_page))
         .route(
             "/settings/update",
@@ -333,6 +348,19 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
 
     // Group events management endpoints
     let events_management = Router::new()
+        .route("/integrations", put(dashboard::group::integrations::update))
+        .route(
+            "/integrations/run",
+            post(dashboard::group::integrations::run),
+        )
+        .route(
+            "/integrations/sources",
+            post(dashboard::group::integrations::add_source),
+        )
+        .route(
+            "/integrations/sources/{source_id}",
+            delete(dashboard::group::integrations::delete_source),
+        )
         .route(
             "/accelerator/applications/{application_id}",
             put(dashboard::group::accelerator::review_application),
@@ -473,10 +501,6 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             "/analytics/report/public",
             put(dashboard::group::analytics::publish_report)
                 .delete(dashboard::group::analytics::unpublish_report),
-        )
-        .route(
-            "/book-exchange",
-            get(dashboard::group::book_exchange::list_page),
         )
         .route(
             "/intentional-dating",

--- a/ocg-server/src/services.rs
+++ b/ocg-server/src/services.rs
@@ -1,5 +1,7 @@
 //! Services modules.
 
+/// Scheduled external event discovery.
+pub(crate) mod event_discovery;
 /// Images service module.
 pub(crate) mod images;
 

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -1,0 +1,376 @@
+//! Scheduled discovery of Baku community-event pages.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
+use serde::Deserialize;
+use serde_json::Value;
+use tokio::time::sleep;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::{
+    config::YouComConfig,
+    db::{PgDB, PgExecutor, dashboard::group::DBDashboardGroup},
+    integrations::you_com::{DiscoveredEvent, SearchResult, YouComClient, unique_baku_results},
+};
+
+/// Executes authorized, on-demand discovery runs from the dashboard.
+#[derive(Clone)]
+pub(crate) struct ManualEventDiscovery {
+    cfg: YouComConfig,
+    db: std::sync::Arc<PgDB>,
+}
+
+impl ManualEventDiscovery {
+    /// Creates a runner when You.com discovery is configured.
+    pub(crate) fn new(cfg: YouComConfig, db: std::sync::Arc<PgDB>) -> Self {
+        Self { cfg, db }
+    }
+
+    /// Starts a group-specific discovery run without blocking the HTTP request.
+    pub(crate) fn spawn_group_run(&self, group_id: Uuid) {
+        let cfg = self.cfg.clone();
+        let db = self.db.clone();
+        tokio::spawn(async move {
+            if let Err(err) = run_group(cfg, db, group_id).await {
+                error!(%err, %group_id, "manual You.com event discovery failed");
+            }
+        });
+    }
+
+    /// Returns whether dashboard-initiated discovery is enabled.
+    pub(crate) fn enabled(&self) -> bool {
+        self.cfg.enabled
+    }
+}
+
+/// Starts the daily discovery worker when the You.com integration is enabled.
+pub(crate) fn start(
+    cfg: YouComConfig,
+    db: std::sync::Arc<PgDB>,
+    task_tracker: &TaskTracker,
+    cancellation_token: &CancellationToken,
+) {
+    if !cfg.enabled {
+        return;
+    }
+
+    task_tracker.spawn({
+        let cancellation_token = cancellation_token.clone();
+        async move {
+            let client = match YouComClient::new(&cfg) {
+                Ok(client) => client,
+                Err(err) => {
+                    error!(%err, "could not start You.com event discovery");
+                    return;
+                }
+            };
+            let timezone = match cfg.schedule_timezone.parse() {
+                Ok(timezone) => timezone,
+                Err(err) => {
+                    error!(%err, "invalid You.com event discovery timezone");
+                    return;
+                }
+            };
+
+            loop {
+                let delay = delay_until_next_run(timezone, cfg.schedule_hour);
+                tokio::select! {
+                    () = sleep(delay) => {},
+                    () = cancellation_token.cancelled() => break,
+                }
+
+                if let Err(err) = ingest_configured_sources(&db, &client).await {
+                    error!(%err, "You.com Baku event discovery failed");
+                }
+            }
+        }
+    });
+}
+
+/// Runs discovery immediately for one enabled group.
+pub(crate) async fn run_group(
+    cfg: YouComConfig,
+    db: std::sync::Arc<PgDB>,
+    group_id: Uuid,
+) -> anyhow::Result<()> {
+    anyhow::ensure!(cfg.enabled, "You.com event discovery is disabled");
+    let integration_enabled: bool = db
+        .fetch_scalar_one(
+            "select exists(
+                select 1 from group_event_integration
+                where group_id = $1 and enabled
+            )",
+            &[&group_id],
+        )
+        .await?;
+    anyhow::ensure!(
+        integration_enabled,
+        "event discovery is not enabled for this group"
+    );
+    let client = YouComClient::new(&cfg)?;
+    ingest_sources(&db, &client, &[group_id]).await
+}
+
+#[derive(Debug, Deserialize)]
+struct Source {
+    created_by_user_id: Uuid,
+    city: String,
+    group_id: Uuid,
+    timezone: String,
+    url: String,
+}
+
+async fn ingest_configured_sources(db: &PgDB, client: &YouComClient) -> anyhow::Result<()> {
+    let run_group_ids: Vec<Uuid> = db
+        .fetch_scalar_one(
+            "select coalesce(array_agg(group_id), '{}'::uuid[])
+             from group_event_integration where enabled",
+            &[],
+        )
+        .await?;
+    ingest_sources(db, client, &run_group_ids).await
+}
+
+/// Ingests sources and records runs for the supplied enabled groups.
+async fn ingest_sources(
+    db: &PgDB,
+    client: &YouComClient,
+    run_group_ids: &[Uuid],
+) -> anyhow::Result<()> {
+    for group_id in run_group_ids {
+        db.execute(
+            "insert into group_event_integration_run (group_id, status) values ($1, 'running')",
+            &[group_id],
+        )
+        .await?;
+    }
+
+    let sources: Vec<Source> = db
+        .fetch_json_one(
+            "select coalesce(jsonb_agg(jsonb_build_object(
+                'created_by_user_id', i.created_by_user_id,
+                'city', i.city,
+                'group_id', s.group_id,
+                'timezone', i.timezone,
+                'url', s.url
+            )), '[]'::jsonb)
+             from group_event_integration_source s
+             join group_event_integration i using (group_id)
+             where s.enabled and i.enabled
+               and s.group_id = any($1::uuid[])",
+            &[&run_group_ids],
+        )
+        .await?;
+
+    let mut counts = std::collections::HashMap::<Uuid, (i32, i32)>::new();
+    let result = async {
+    for source in sources {
+        let results = unique_baku_results(
+            client
+                .search(&format!("Baku Azerbaijan events site:{}", source.url))
+                .await?,
+        );
+        for result in results {
+            let Some(event) = parse_discovered_event(&result, &source.url) else {
+                continue;
+            };
+            let fingerprint = event.fingerprint();
+            let inserted: Option<Uuid> = db
+                .fetch_scalar_opt(
+                    "insert into group_event_integration_item (group_id, source_url, fingerprint)
+                     values ($1, $2, $3) on conflict (group_id, fingerprint) do nothing
+                     returning group_event_integration_item_id",
+                    &[&source.group_id, &source.url, &fingerprint],
+                )
+                .await?;
+            if inserted.is_none() {
+                continue;
+            }
+            let count = counts.entry(source.group_id).or_default();
+            count.0 += 1;
+            if let Some(event_id) = create_and_publish_event(db, &source, &event).await? {
+                db.execute(
+                    "update group_event_integration_item set event_id = $1
+                     where group_id = $2 and fingerprint = $3",
+                    &[&event_id, &source.group_id, &fingerprint],
+                )
+                .await?;
+                count.1 += 1;
+            }
+        }
+        info!(group_id = %source.group_id, source_url = %source.url, "ingested event discovery candidates");
+    }
+    anyhow::Ok(())
+    }.await;
+
+    for group_id in run_group_ids {
+        let (discovered_count, created_count) = counts.get(&group_id).copied().unwrap_or_default();
+        match &result {
+            Ok(()) => {
+                db.execute(
+                    "update group_event_integration_run
+                 set completed_at = now(), status = 'succeeded',
+                     discovered_count = $2, created_count = $3
+                 where group_event_integration_run_id = (
+                     select group_event_integration_run_id from group_event_integration_run
+                     where group_id = $1 and status = 'running'
+                     order by started_at desc limit 1
+                 )",
+                    &[&group_id, &discovered_count, &created_count],
+                )
+                .await?
+            }
+            Err(err) => {
+                db.execute(
+                    "update group_event_integration_run
+                 set completed_at = now(), status = 'failed', error_message = $2
+                 where group_event_integration_run_id = (
+                     select group_event_integration_run_id from group_event_integration_run
+                     where group_id = $1 and status = 'running'
+                     order by started_at desc limit 1
+                 )",
+                    &[&group_id, &err.to_string()],
+                )
+                .await?
+            }
+        };
+    }
+    result?;
+    Ok(())
+}
+
+/// Extract only events with an explicit RFC3339 date from the search response.
+///
+/// We intentionally reject ambiguous natural-language dates: they are locale-dependent and
+/// cannot safely be published without a human review step.
+fn parse_discovered_event(result: &SearchResult, source_url: &str) -> Option<DiscoveredEvent> {
+    let title = result.title.trim();
+    if title.is_empty() || title.len() > 240 {
+        return None;
+    }
+    let description = result
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|text| !text.is_empty());
+    let starts_at = description?
+        .split_whitespace()
+        .map(|word| {
+            word.trim_matches(|c: char| {
+                !c.is_ascii_alphanumeric() && c != ':' && c != '+' && c != '-'
+            })
+        })
+        .find_map(|word| DateTime::parse_from_rfc3339(word).ok())
+        .map(|time| time.with_timezone(&Utc))?;
+    if starts_at <= Utc::now() {
+        return None;
+    }
+    Some(DiscoveredEvent {
+        title: title.to_owned(),
+        description: description.map(str::to_owned),
+        starts_at,
+        source_url: source_url.to_owned(),
+    })
+}
+
+/// Creates from an organizer-configured event-default payload, never guessed fields.
+async fn create_and_publish_event(
+    db: &PgDB,
+    source: &Source,
+    discovered: &DiscoveredEvent,
+) -> anyhow::Result<Option<Uuid>> {
+    let Some(Value::Object(mut payload)) = db
+        .fetch_json_opt(
+            "select event_defaults from \"group\" where group_id = $1",
+            &[&source.group_id],
+        )
+        .await?
+    else {
+        return Ok(None);
+    };
+    let timezone: chrono_tz::Tz = source.timezone.parse()?;
+    let starts_at = discovered.starts_at.with_timezone(&timezone);
+    let ends_at = starts_at + chrono::Duration::hours(2);
+    payload.insert("name".into(), Value::String(discovered.title.clone()));
+    payload.insert(
+        "description".into(),
+        Value::String(format!(
+            "{}\n\nSource: {}",
+            discovered.description.as_deref().unwrap_or_default(),
+            discovered.source_url
+        )),
+    );
+    payload.insert("timezone".into(), Value::String(source.timezone.clone()));
+    payload.insert(
+        "starts_at".into(),
+        Value::String(starts_at.format("%F %T").to_string()),
+    );
+    payload.insert(
+        "ends_at".into(),
+        Value::String(ends_at.format("%F %T").to_string()),
+    );
+    payload.insert("venue_city".into(), Value::String(source.city.clone()));
+    payload.insert("test_event".into(), Value::Bool(false));
+    let event_id = db
+        .add_event(
+            source.created_by_user_id,
+            source.group_id,
+            &Value::Object(payload),
+            &Default::default(),
+        )
+        .await?;
+    db.publish_event(source.created_by_user_id, None, source.group_id, event_id)
+        .await?;
+    Ok(Some(event_id))
+}
+
+fn delay_until_next_run(timezone: chrono_tz::Tz, hour: u8) -> Duration {
+    let now = Utc::now().with_timezone(&timezone);
+    let today = timezone
+        .with_ymd_and_hms(now.year(), now.month(), now.day(), u32::from(hour), 0, 0)
+        .single()
+        .expect("configured timezone must have a valid scheduled hour");
+    let next = if now.hour() < u32::from(hour) {
+        today
+    } else {
+        today + chrono::Duration::days(1)
+    };
+    (next.with_timezone(&Utc) - Utc::now())
+        .to_std()
+        .unwrap_or_else(|_| Duration::from_secs(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_run_delay_is_bounded_by_one_day() {
+        let delay = delay_until_next_run(chrono_tz::Asia::Baku, 9);
+        assert!(delay <= Duration::from_secs(24 * 60 * 60));
+    }
+
+    #[test]
+    fn rejects_ambiguous_event_dates() {
+        let result = SearchResult {
+            title: "Baku Rust meetup".into(),
+            url: "https://example.test/event".into(),
+            description: Some("Join us next Thursday in Baku".into()),
+        };
+        assert!(parse_discovered_event(&result, "https://example.test").is_none());
+    }
+
+    #[test]
+    fn parses_explicit_future_rfc3339_date() {
+        let result = SearchResult {
+            title: "Baku Rust meetup".into(),
+            url: "https://example.test/event".into(),
+            description: Some("Starts 2099-07-21T12:00:00Z in Baku".into()),
+        };
+        let event = parse_discovered_event(&result, "https://example.test").unwrap();
+        assert_eq!(event.title, "Baku Rust meetup");
+    }
+}

--- a/ocg-server/src/templates/alliance.rs
+++ b/ocg-server/src/templates/alliance.rs
@@ -21,6 +21,7 @@ use crate::{
         event::{EventKind, EventSummary},
         group::GroupSummary,
         pagination::{NavigationLinks, Pagination, ToRawQuery},
+        partner_integration::PartnerIntegration,
         site::SiteSettings,
     },
     validation::{MAX_LEN_M, MAX_PAGINATION_LIMIT, trimmed_non_empty_opt},
@@ -90,6 +91,27 @@ pub(crate) struct BrandPage {
     pub base_url: String,
     /// Alliance information.
     pub alliance: AllianceFull,
+    /// Identifier for the current page.
+    #[allow(dead_code)]
+    pub page_id: PageId,
+    /// Current request path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
+    /// Authenticated user information.
+    pub user: User,
+}
+
+/// Template for the public alliance integrations page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "alliance/integrations.html")]
+pub(crate) struct IntegrationsPage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Alliance information.
+    pub alliance: AllianceFull,
+    /// Enabled partner integrations configured by alliance administrators.
+    pub integrations: Vec<PartnerIntegration>,
     /// Identifier for the current page.
     #[allow(dead_code)]
     pub page_id: PageId,
@@ -317,6 +339,30 @@ impl BrandPage {
     /// Returns the preview title for the alliance brand page.
     pub(crate) fn preview_title(&self) -> String {
         format!("{} brand", self.alliance.display_name)
+    }
+}
+
+impl IntegrationsPage {
+    /// Returns the canonical public URL for the integrations page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!("/{}/integrations", self.alliance.name),
+        )
+    }
+
+    /// Returns the Open Graph image URL for the integrations page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.alliance
+            .og_image_url
+            .as_deref()
+            .or(Some(self.alliance.logo_url.as_str()))
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+
+    /// Returns the preview title for the integrations page.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} integrations", self.alliance.display_name)
     }
 }
 

--- a/ocg-server/src/templates/dashboard/alliance.rs
+++ b/ocg-server/src/templates/dashboard/alliance.rs
@@ -11,6 +11,7 @@ pub(crate) mod home;
 pub(crate) mod intentional_dating;
 pub(crate) mod landscape;
 pub(crate) mod members;
+pub(crate) mod partner_integrations;
 pub(crate) mod regions;
 pub(crate) mod settings;
 pub(crate) mod team;

--- a/ocg-server/src/templates/dashboard/alliance/home.rs
+++ b/ocg-server/src/templates/dashboard/alliance/home.rs
@@ -12,8 +12,8 @@ use crate::{
         dashboard::{
             alliance::{
                 analytics, book_exchange, create, email_templates, event_categories,
-                group_categories, groups, intentional_dating, landscape, members, regions,
-                settings, team,
+                group_categories, groups, intentional_dating, landscape, members,
+                partner_integrations, regions, settings, team,
             },
             audit,
         },
@@ -65,6 +65,8 @@ pub(crate) enum Content {
     BookExchange(book_exchange::ListPage),
     /// Private intentional dating curation page.
     IntentionalDating(intentional_dating::ListPage),
+    /// Partner integrations management page.
+    PartnerIntegrations(partner_integrations::Page),
     /// Landscape management page.
     Landscape(landscape::ListPage),
     /// Members page across all alliance groups.
@@ -120,6 +122,11 @@ impl Content {
         matches!(self, Content::IntentionalDating(_))
     }
 
+    /// Check if the content is the partner integrations page.
+    fn is_partner_integrations(&self) -> bool {
+        matches!(self, Content::PartnerIntegrations(_))
+    }
+
     /// Check if the content is the landscape page.
     fn is_landscape(&self) -> bool {
         matches!(self, Content::Landscape(_))
@@ -162,6 +169,7 @@ impl std::fmt::Display for Content {
             Content::Groups(template) => write!(f, "{}", template.render()?),
             Content::BookExchange(template) => write!(f, "{}", template.render()?),
             Content::IntentionalDating(template) => write!(f, "{}", template.render()?),
+            Content::PartnerIntegrations(template) => write!(f, "{}", template.render()?),
             Content::Landscape(template) => write!(f, "{}", template.render()?),
             Content::Members(template) => write!(f, "{}", template.render()?),
             Content::Logs(template) => write!(f, "{}", template.render()?),
@@ -196,6 +204,8 @@ pub(crate) enum Tab {
     BookExchange,
     /// Private intentional dating curation tab.
     IntentionalDating,
+    /// Partner integrations management tab.
+    PartnerIntegrations,
     /// Landscape management tab.
     Landscape,
     /// Members tab across all alliance groups.

--- a/ocg-server/src/templates/dashboard/alliance/partner_integrations.rs
+++ b/ocg-server/src/templates/dashboard/alliance/partner_integrations.rs
@@ -1,0 +1,37 @@
+//! Templates and inputs for alliance partner integrations.
+
+use askama::Template;
+use garde::Validate;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    types::partner_integration::PartnerIntegration,
+    validation::{
+        MAX_LEN_DESCRIPTION_SHORT, MAX_LEN_ENTITY_NAME, MAX_LEN_L, image_url_opt,
+        trimmed_non_empty, trimmed_non_empty_opt,
+    },
+};
+
+/// Partner integrations list page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/alliance/partner_integrations.html")]
+pub(crate) struct Page {
+    pub can_manage_settings: bool,
+    pub integrations: Vec<PartnerIntegration>,
+}
+
+/// Input used to create or update a partner integration.
+#[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+pub(crate) struct PartnerIntegrationInput {
+    #[garde(length(max = MAX_LEN_DESCRIPTION_SHORT))]
+    pub attribution_copy: String,
+    #[garde(custom(image_url_opt))]
+    pub logo_url: Option<String>,
+    #[garde(custom(trimmed_non_empty), length(max = MAX_LEN_ENTITY_NAME))]
+    pub name: String,
+    #[serde(default)]
+    #[garde(skip)]
+    pub public: bool,
+    #[garde(url, length(max = MAX_LEN_L), custom(trimmed_non_empty_opt))]
+    pub website_url: Option<String>,
+}

--- a/ocg-server/src/templates/dashboard/group.rs
+++ b/ocg-server/src/templates/dashboard/group.rs
@@ -7,6 +7,7 @@ pub(crate) mod book_exchange;
 pub(crate) mod coffee_meet;
 pub(crate) mod events;
 pub(crate) mod home;
+pub(crate) mod integrations;
 pub(crate) mod intentional_dating;
 pub(crate) mod invitation_requests;
 pub(crate) mod members;

--- a/ocg-server/src/templates/dashboard/group/accelerator.rs
+++ b/ocg-server/src/templates/dashboard/group/accelerator.rs
@@ -116,10 +116,7 @@ impl Page {
 
     /// Count cohorts by status.
     pub(crate) fn cohort_status_count(&self, status: &str) -> usize {
-        self.cohorts
-            .iter()
-            .filter(|cohort| cohort.status == status)
-            .count()
+        self.cohorts.iter().filter(|cohort| cohort.status == status).count()
     }
 
     /// Count applications that still need organizer attention.
@@ -127,7 +124,10 @@ impl Page {
         self.applications
             .iter()
             .filter(|application| {
-                matches!(application.status.as_str(), "submitted" | "reviewing" | "waitlisted")
+                matches!(
+                    application.status.as_str(),
+                    "submitted" | "reviewing" | "waitlisted"
+                )
             })
             .count()
     }
@@ -142,10 +142,7 @@ impl Page {
 
     /// Count active cohort members.
     pub(crate) fn active_member_count(&self) -> usize {
-        self.members
-            .iter()
-            .filter(|member| member.status == "active")
-            .count()
+        self.members.iter().filter(|member| member.status == "active").count()
     }
 
     /// Count submitted weekly updates waiting for review.

--- a/ocg-server/src/templates/dashboard/group/book_exchange.rs
+++ b/ocg-server/src/templates/dashboard/group/book_exchange.rs
@@ -9,8 +9,8 @@ use crate::db::dashboard::common::BookExchangeMember;
 #[derive(Debug, Clone, Template, Serialize, Deserialize)]
 #[template(path = "dashboard/group/book_exchange.html")]
 pub(crate) struct ListPage {
-    /// Whether the current user can review book exchange members.
+    /// Whether the current user can manage book exchange settings and contact details.
     pub can_manage_book_exchange: bool,
-    /// Private book exchange member lists visible to authorized group admins.
+    /// Book exchange member lists visible to authorized group members.
     pub members: Vec<BookExchangeMember>,
 }

--- a/ocg-server/src/templates/dashboard/group/home.rs
+++ b/ocg-server/src/templates/dashboard/group/home.rs
@@ -12,8 +12,8 @@ use crate::{
         dashboard::{
             audit,
             group::{
-                accelerator, analytics, book_exchange, coffee_meet, events, intentional_dating,
-                members, settings, sponsors, spotlights, store, team,
+                accelerator, analytics, book_exchange, coffee_meet, events, integrations,
+                intentional_dating, members, settings, sponsors, spotlights, store, team,
             },
         },
         filters,
@@ -89,10 +89,12 @@ pub(crate) enum Content {
     Events(Box<events::ListPage>),
     /// `CoffeeMeet` subscriber page.
     CoffeeMeet(coffee_meet::ListPage),
-    /// Private book exchange page.
+    /// Group book exchange page.
     BookExchange(book_exchange::ListPage),
     /// Private intentional dating curation page.
     IntentionalDating(intentional_dating::ListPage),
+    /// Event discovery integration settings.
+    Integrations(integrations::Page),
     /// Audit logs page.
     Logs(audit::ListPage),
     /// Members list page.
@@ -138,6 +140,9 @@ impl Content {
     /// Check if the content is the intentional dating page.
     fn is_intentional_dating(&self) -> bool {
         matches!(self, Content::IntentionalDating(_))
+    }
+    fn is_integrations(&self) -> bool {
+        matches!(self, Content::Integrations(_))
     }
 
     /// Check if the content is the logs page.
@@ -185,6 +190,7 @@ impl std::fmt::Display for Content {
             Content::CoffeeMeet(template) => write!(f, "{}", template.render()?),
             Content::Events(template) => write!(f, "{}", template.render()?),
             Content::IntentionalDating(template) => write!(f, "{}", template.render()?),
+            Content::Integrations(template) => write!(f, "{}", template.render()?),
             Content::Logs(template) => write!(f, "{}", template.render()?),
             Content::Members(template) => write!(f, "{}", template.render()?),
             Content::Settings(template) => write!(f, "{}", template.render()?),
@@ -212,10 +218,12 @@ pub(crate) enum Tab {
     Events,
     /// `CoffeeMeet` tab.
     CoffeeMeet,
-    /// Private book exchange tab.
+    /// Book exchange tab.
     BookExchange,
     /// Private intentional dating curation tab.
     IntentionalDating,
+    /// Event discovery integration settings tab.
+    Integrations,
     /// Audit logs tab.
     Logs,
     /// Members list tab.

--- a/ocg-server/src/templates/dashboard/group/integrations.rs
+++ b/ocg-server/src/templates/dashboard/group/integrations.rs
@@ -1,0 +1,42 @@
+//! Templates for group event discovery settings.
+
+use askama::Template;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Event discovery settings and recent run status.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct IntegrationPage {
+    pub can_manage_events: bool,
+    pub city: String,
+    pub enabled: bool,
+    pub latest_run: Option<IntegrationRun>,
+    pub sources: Vec<IntegrationSource>,
+    pub timezone: String,
+}
+
+/// A configured source URL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IntegrationSource {
+    pub enabled: bool,
+    pub group_event_integration_source_id: Uuid,
+    pub url: String,
+}
+
+/// Summary of one ingestion run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IntegrationRun {
+    pub completed_at: Option<i64>,
+    pub created_count: i32,
+    pub discovered_count: i32,
+    pub error_message: Option<String>,
+    pub started_at: i64,
+    pub status: String,
+}
+
+/// Partial template rendered inside the group dashboard.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/group/integrations.html")]
+pub(crate) struct Page {
+    pub integration: IntegrationPage,
+}

--- a/ocg-server/src/templates/dashboard/user/mock_interviews.rs
+++ b/ocg-server/src/templates/dashboard/user/mock_interviews.rs
@@ -35,7 +35,8 @@ impl ListPage {
             .iter()
             .filter(|session| {
                 matches!(session.match_.status.as_str(), "matched" | "scheduled")
-                    && (session.match_.scheduled_at.is_none() || session.match_.meeting_url.is_none())
+                    && (session.match_.scheduled_at.is_none()
+                        || session.match_.meeting_url.is_none())
             })
             .count()
     }

--- a/ocg-server/src/templates/group.rs
+++ b/ocg-server/src/templates/group.rs
@@ -4,6 +4,7 @@ use askama::Template;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    db::dashboard::common::BookExchangeMember,
     templates::dashboard::group::accelerator::AcceleratorDashboard,
     templates::dashboard::group::{
         analytics::GroupDashboardStats, members::GroupMember, spotlights::GroupMemberSpotlight,
@@ -121,6 +122,27 @@ pub(crate) struct MembersPage {
     pub site_settings: SiteSettings,
     /// Total number of members in the group.
     pub total: usize,
+    /// Authenticated user information.
+    pub user: User,
+}
+
+/// Logged-in group member book exchange page template.
+#[derive(Debug, Clone, Template)]
+#[template(path = "group/book_exchange.html")]
+pub(crate) struct BookExchangePage {
+    /// Configured public base URL.
+    pub base_url: String,
+    /// Detailed information about the group.
+    pub group: GroupFull,
+    /// Opted-in book exchange members.
+    pub members: Vec<BookExchangeMember>,
+    /// Identifier for the current page.
+    #[allow(dead_code)]
+    pub page_id: PageId,
+    /// Current URL path.
+    pub path: String,
+    /// Global site settings.
+    pub site_settings: SiteSettings,
     /// Authenticated user information.
     pub user: User,
 }
@@ -332,6 +354,42 @@ impl MembersPage {
     }
 
     /// Returns the `OpenGraph` image URL for the group members page.
+    pub(crate) fn open_graph_image_url(&self) -> Option<String> {
+        self.group
+            .og_image_url
+            .as_deref()
+            .or(self.group.alliance.og_image_url.as_deref())
+            .map(|image_url| helpers::open_graph_image_url(&self.base_url, image_url))
+    }
+}
+
+impl BookExchangePage {
+    /// Returns the canonical URL for the group book exchange page.
+    pub(crate) fn canonical_url(&self) -> String {
+        helpers::absolute_url(
+            &self.base_url,
+            &format!(
+                "/{}/group/{}/book-exchange",
+                self.group.alliance.name,
+                self.group.public_slug()
+            ),
+        )
+    }
+
+    /// Returns the preview title.
+    pub(crate) fn preview_title(&self) -> String {
+        format!("{} Book Exchange", self.group.name)
+    }
+
+    /// Returns the preview description.
+    pub(crate) fn preview_description(&self) -> String {
+        format!(
+            "Opted-in book exchange lists for members of {}.",
+            self.group.name
+        )
+    }
+
+    /// Returns the `OpenGraph` image URL for the group book exchange page.
     pub(crate) fn open_graph_image_url(&self) -> Option<String> {
         self.group
             .og_image_url

--- a/ocg-server/src/types.rs
+++ b/ocg-server/src/types.rs
@@ -8,6 +8,7 @@ pub(crate) mod landscape;
 pub mod location;
 pub(crate) mod mock_interviews;
 pub mod pagination;
+pub(crate) mod partner_integration;
 pub mod payments;
 pub mod permissions;
 pub mod questionnaire;

--- a/ocg-server/src/types/partner_integration.rs
+++ b/ocg-server/src/types/partner_integration.rs
@@ -1,0 +1,15 @@
+//! Partner integration records displayed on alliance pages.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// A partner integration configured for an alliance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct PartnerIntegration {
+    pub attribution_copy: String,
+    pub logo_url: Option<String>,
+    pub name: String,
+    pub partner_integration_id: Uuid,
+    pub public: bool,
+    pub website_url: Option<String>,
+}

--- a/ocg-server/templates/alliance/integrations.html
+++ b/ocg-server/templates/alliance/integrations.html
@@ -1,0 +1,57 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="Integrations available to {{ alliance.display_name }} groups.">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title(),
+  description = "Tools and partners for alliance groups.",
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &alliance.display_name) -}}
+{% endblock open_graph_meta -%}
+
+{% block content -%}
+  <breadcrumb-nav banner-url="{{ alliance.banner_url }}" banner-mobile-url="{{ alliance.banner_mobile_url }}" items='[{"label": "Home", "href": "/", "icon": "home"}, {"label": {{ alliance.display_name|json }}, "href": "/{{ alliance.name }}", "icon": "alliance"}, {"label": "Integrations", "icon": "settings"}]'></breadcrumb-nav>
+  <div class="container mx-auto flex grow px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
+    <div class="w-full rounded-[2rem] border border-stone-200 bg-white px-5 py-8 shadow-xl shadow-stone-200/50 sm:px-8 lg:px-12 lg:py-12">
+      <p class="text-sm font-bold uppercase tracking-[0.18em] text-stone-500">Integrations</p>
+      <h1 class="mt-3 text-3xl font-black tracking-[-0.045em] text-stone-950 lg:text-5xl">Tools for {{ alliance.display_name }}</h1>
+      <section class="mt-8 max-w-3xl rounded-2xl border border-stone-200 bg-stone-50 p-6">
+        <h2 class="text-xl font-black text-stone-950">You.com event discovery</h2>
+        <p class="mt-3 text-base leading-7 text-stone-600">Group organizers can connect approved event-source URLs and use You.com search to discover eligible upcoming events for publication.</p>
+        <p class="mt-4 text-sm text-stone-500">Event discovery is powered by You.com.</p>
+      </section>
+      {% if !integrations.is_empty() -%}
+        <section class="mt-8 grid gap-5 md:grid-cols-2">
+          {% for integration in integrations -%}
+            <article class="rounded-2xl border border-stone-200 bg-stone-50 p-6">
+              <div class="flex items-center gap-4">
+                {% if let Some(logo_url) = &integration.logo_url -%}
+                  <img class="size-12 rounded-xl object-contain bg-white p-1" src="{{ logo_url }}" alt="{{ integration.name }} logo">
+                {% endif -%}
+                <h2 class="text-xl font-black text-stone-950">{{ integration.name }}</h2>
+              </div>
+              {% if !integration.attribution_copy.is_empty() -%}
+                <p class="mt-4 text-sm leading-6 text-stone-600">{{ integration.attribution_copy }}</p>
+              {% endif -%}
+              {% if let Some(website_url) = &integration.website_url -%}
+                <a class="mt-4 inline-flex font-bold text-primary-700 hover:text-primary-900" href="{{ website_url }}" rel="noopener noreferrer" target="_blank">Visit {{ integration.name }}</a>
+              {% endif -%}
+            </article>
+          {% endfor -%}
+        </section>
+      {% endif -%}
+    </div>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/alliance/page.html
+++ b/ocg-server/templates/alliance/page.html
@@ -123,6 +123,10 @@
                hx-boost="true"
                hx-target="body"
                class="btn-secondary-anchor text-md lg:text-lg px-8 font-semibold">Member directory</a>
+            <a href="/{{ alliance.name }}/integrations"
+               hx-boost="true"
+               hx-target="body"
+               class="btn-secondary-anchor text-md lg:text-lg px-8 font-semibold">Integrations</a>
             {% if alliance.report_public_enabled -%}
               <a href="/{{ alliance.name }}/reports"
                  hx-boost="true"

--- a/ocg-server/templates/dashboard/alliance/home.html
+++ b/ocg-server/templates/dashboard/alliance/home.html
@@ -64,6 +64,7 @@
       {{ dashboard::menu_item(name = "Members", icon = "members", is_active = content.is_members() , href = "/dashboard/alliance?tab=members") -}}
       {{ dashboard::menu_item(name = "Book Exchange", icon = "list", is_active = content.is_book_exchange() , href = "/dashboard/alliance?tab=book-exchange") -}}
       {{ dashboard::menu_item(name = "Intentional Dating", icon = "user-plus", is_active = content.is_intentional_dating() , href = "/dashboard/alliance?tab=intentional-dating") -}}
+        {{ dashboard::menu_item(name = "Partner Integrations", icon = "settings", is_active = content.is_partner_integrations() , href = "/dashboard/alliance?tab=partner-integrations") -}}
       {{ dashboard::menu_item(name = "Landscape", icon = "map", is_active = content.is_landscape() , href = "/dashboard/alliance?tab=landscape") -}}
     </div>
     {# End groups -#}
@@ -79,7 +80,7 @@
 
 {% block dashboard_main -%}
   <div id="dashboard-content"
-       hx-get="/dashboard/alliance/{%- if content.is_team() -%}team{%- elif content.is_settings() -%}settings/update{%- elif content.is_email_templates() -%}email-templates{%- elif content.is_regions() -%}regions{%- elif content.is_logs() -%}logs{%- elif content.is_group_categories() -%}group-categories{%- elif content.is_event_categories() -%}event-categories{%- elif content.is_analytics() -%}analytics{%- elif content.is_create_alliance() -%}create{%- elif content.is_book_exchange() -%}book-exchange{%- elif content.is_intentional_dating() -%}intentional-dating{%- elif content.is_landscape() -%}landscape{%- elif content.is_members() -%}members{%- else -%}groups{%- endif -%}"
+       hx-get="/dashboard/alliance/{%- if content.is_team() -%}team{%- elif content.is_settings() -%}settings/update{%- elif content.is_email_templates() -%}email-templates{%- elif content.is_regions() -%}regions{%- elif content.is_logs() -%}logs{%- elif content.is_group_categories() -%}group-categories{%- elif content.is_event_categories() -%}event-categories{%- elif content.is_analytics() -%}analytics{%- elif content.is_create_alliance() -%}create{%- elif content.is_book_exchange() -%}book-exchange{%- elif content.is_intentional_dating() -%}intentional-dating{%- elif content.is_partner_integrations() -%}partner-integrations{%- elif content.is_landscape() -%}landscape{%- elif content.is_members() -%}members{%- else -%}groups{%- endif -%}"
        hx-trigger="refresh-alliance-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/dashboard/alliance/partner_integrations.html
+++ b/ocg-server/templates/dashboard/alliance/partner_integrations.html
@@ -1,0 +1,62 @@
+{% import "macros/dashboard.html" as dashboard -%}
+
+{{ dashboard::page_title(title = "Partner Integrations", description = "Manage partners shown on this alliance's public integrations page.") -}}
+
+{% if !can_manage_settings -%}
+  {{ dashboard::permission_warning(message = "Your role cannot manage partner integrations.") -}}
+{% endif -%}
+
+<section class="mt-8 rounded-2xl border border-stone-200 bg-white p-6 shadow-sm">
+  <h2 class="text-lg font-black text-stone-950">Add partner</h2>
+  <form class="mt-5 grid gap-4 md:grid-cols-2"
+        hx-post="/dashboard/alliance/partner-integrations"
+        hx-target="#dashboard-content"
+        hx-disabled-elt="button[type=submit]"
+        data-htmx-response
+        data-success-message="Partner integration added."
+        {% if !can_manage_settings %}inert{% endif %}>
+    {% let name_value %}value=""{% endlet %}
+    {% let logo_value %}value=""{% endlet %}
+    {% let website_value %}value=""{% endlet %}
+    {% let attribution_value %}{% endlet %}
+    {% let public_checked %}{% endlet %}
+    {% include "dashboard/alliance/partner_integrations_fields.html" -%}
+    <button type="submit" class="btn-primary w-fit" {% if !can_manage_settings %}disabled{% endif %}>Add partner</button>
+  </form>
+</section>
+
+<section class="mt-8 space-y-5">
+  {% if integrations.is_empty() -%}
+    <div class="rounded-2xl border border-dashed border-stone-300 bg-white px-6 py-12 text-center text-stone-500">
+      No partner integrations are configured.
+    </div>
+  {% endif -%}
+  {% for integration in integrations -%}
+    <article class="rounded-2xl border border-stone-200 bg-white p-6 shadow-sm">
+      <form class="grid gap-4 md:grid-cols-2"
+            hx-put="/dashboard/alliance/partner-integrations/{{ integration.partner_integration_id }}"
+            hx-target="#dashboard-content"
+            hx-disabled-elt="button[type=submit]"
+            data-htmx-response
+            data-success-message="Partner integration updated."
+            {% if !can_manage_settings %}inert{% endif %}>
+        {% let name_value %}value="{{ integration.name }}"{% endlet %}
+        {% let logo_value %}value="{{ integration.logo_url.as_deref().unwrap_or("") }}"{% endlet %}
+        {% let website_value %}value="{{ integration.website_url.as_deref().unwrap_or("") }}"{% endlet %}
+        {% let attribution_value %}{{ integration.attribution_copy }}{% endlet %}
+        {% let public_checked %}{% if integration.public %}checked{% endif %}{% endlet %}
+        {% include "dashboard/alliance/partner_integrations_fields.html" -%}
+        <button type="submit" class="btn-primary w-fit" {% if !can_manage_settings %}disabled{% endif %}>Save changes</button>
+      </form>
+      <button class="btn-tertiary mt-4 text-red-700"
+              hx-delete="/dashboard/alliance/partner-integrations/{{ integration.partner_integration_id }}"
+              hx-target="#dashboard-content"
+              hx-trigger="confirmed"
+              hx-disabled-elt="this"
+              data-confirm-action
+              data-confirm-message="Delete {{ integration.name }}?"
+              data-confirm-text="Delete"
+              {% if !can_manage_settings %}disabled{% endif %}>Delete partner</button>
+    </article>
+  {% endfor -%}
+</section>

--- a/ocg-server/templates/dashboard/alliance/partner_integrations_fields.html
+++ b/ocg-server/templates/dashboard/alliance/partner_integrations_fields.html
@@ -1,0 +1,20 @@
+<div>
+  <label class="form-label" for="name">Name <span class="asterisk">*</span></label>
+  <input id="name" name="name" type="text" maxlength="{{ crate::validation::MAX_LEN_ENTITY_NAME }}" class="input-primary mt-2" {{ name_value|safe }} required>
+</div>
+<div>
+  <label class="form-label" for="website_url">Website URL</label>
+  <input id="website_url" name="website_url" type="url" maxlength="{{ crate::validation::MAX_LEN_L }}" class="input-primary mt-2" {{ website_value|safe }}>
+</div>
+<div>
+  <label class="form-label" for="logo_url">Logo URL</label>
+  <input id="logo_url" name="logo_url" type="url" maxlength="{{ crate::validation::MAX_LEN_L }}" class="input-primary mt-2" {{ logo_value|safe }}>
+</div>
+<div>
+  <label class="form-label" for="attribution_copy">Attribution copy</label>
+  <textarea id="attribution_copy" name="attribution_copy" maxlength="{{ crate::validation::MAX_LEN_DESCRIPTION_SHORT }}" class="input-primary mt-2">{{ attribution_value }}</textarea>
+</div>
+<label class="flex items-center gap-3 text-sm font-semibold text-stone-700 md:col-span-2">
+  <input name="public" type="checkbox" class="size-4 rounded border-stone-300 text-primary-600" {{ public_checked }}>
+  Show this partner on the public integrations page
+</label>

--- a/ocg-server/templates/dashboard/group/book_exchange.html
+++ b/ocg-server/templates/dashboard/group/book_exchange.html
@@ -1,16 +1,16 @@
 {% import "macros/dashboard.html" as dashboard -%}
 
-{{ dashboard::page_title(title = "Book Exchange", description = "Privately review opted-in group member book lists.") -}}
+{{ dashboard::page_title(title = "Book Exchange", description = "Discover books opted-in group members want to exchange.") -}}
 
 {% if !can_manage_book_exchange -%}
-  {{ dashboard::permission_warning(message = "Your role cannot review book exchange lists.") -}}
+  {{ dashboard::permission_warning(message = "You can view opted-in book lists for this group. Contact details are only visible to group managers.") -}}
 {% endif -%}
 
 <section class="mt-8 rounded-[1.75rem] border border-primary-100 bg-primary-50/70 p-5 sm:p-6">
   <div class="text-xs font-black uppercase tracking-[0.2em] text-primary-700">Private opt-in</div>
   <h2 class="mt-2 text-xl font-black tracking-tight text-stone-950">Group book lists for exchange</h2>
   <p class="mt-2 max-w-3xl text-sm/6 text-stone-700">
-    Members appear here only when the alliance, this group, and their own account opt-in are all enabled. Book lists are visible to eligible admins only and are not shown on public profiles.
+    Members appear here only when the alliance, this group, and their own account opt-in are all enabled. Book lists are visible to this group's members and are not shown on public profiles.
   </p>
 </section>
 
@@ -28,7 +28,11 @@
         <div class="flex items-start justify-between gap-4">
           <div>
             <h2 class="font-black text-stone-950">{{ member.name.as_deref().unwrap_or(member.username.as_str()) }}</h2>
-            <p class="mt-1 text-sm text-stone-600">{{ member.email.as_deref().unwrap_or("No email") }}</p>
+            {% if can_manage_book_exchange -%}
+              <p class="mt-1 text-sm text-stone-600">{{ member.email.as_deref().unwrap_or("No email") }}</p>
+            {% else -%}
+              <p class="mt-1 text-sm text-stone-600">@{{ member.username }}</p>
+            {% endif -%}
           </div>
           <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-bold text-primary-700">Book exchange</span>
         </div>

--- a/ocg-server/templates/dashboard/group/home.html
+++ b/ocg-server/templates/dashboard/group/home.html
@@ -90,6 +90,7 @@
     <div class="leading-10 pt-6 border-t border-stone-200 grid gap-y-0.5">
       {{ dashboard::menu_title(text = "Events", extra_styles = "py-1.5") -}}
       {{ dashboard::menu_item(name = "Events", icon = "calendar", is_active = content.is_events() , href = "/dashboard/group?tab=events") -}}
+      {{ dashboard::menu_item(name = "Event discovery", icon = "calendar", is_active = content.is_integrations() , href = "/dashboard/group?tab=integrations") -}}
       {{ dashboard::menu_item(name = "Accelerator", icon = "rocket", is_active = content.is_accelerator() , href = "/dashboard/group?tab=accelerator") -}}
     </div>
     {# End events -#}
@@ -127,7 +128,7 @@
        data-alliance-banner-mobile-url="{{ current_selection.0.banner_mobile_url }}"
        data-group-name="{{ current_selection.1.name }}"
        data-group-slug="{{ current_selection.1.public_slug() }}"
-       hx-get="/dashboard/group/{%- if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_coffee_meet() -%}coffee-meet{%- else if content.is_book_exchange() -%}book-exchange{%- else if content.is_intentional_dating() -%}intentional-dating{%- else if content.is_spotlights() -%}spotlights{%- else if content.is_store() -%}store{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else if content.is_accelerator() -%}accelerator{%- else -%}events{%- endif -%}"
+       hx-get="/dashboard/group/{%- if content.is_integrations() -%}integrations{%- else if content.is_team() -%}team{%- else if content.is_settings() -%}settings{%- else if content.is_coffee_meet() -%}coffee-meet{%- else if content.is_book_exchange() -%}book-exchange{%- else if content.is_intentional_dating() -%}intentional-dating{%- else if content.is_spotlights() -%}spotlights{%- else if content.is_store() -%}store{%- else if content.is_sponsors() -%}sponsors{%- else if content.is_logs() -%}logs{%- else if content.is_accelerator() -%}accelerator{%- else -%}events{%- endif -%}"
        hx-trigger="refresh-group-dashboard-table"
        hx-swap="innerHTML show:window:top"
        hx-indicator="#dashboard-spinner"

--- a/ocg-server/templates/dashboard/group/integrations.html
+++ b/ocg-server/templates/dashboard/group/integrations.html
@@ -1,0 +1,49 @@
+{% import "macros/dashboard.html" as dashboard -%}
+<div class="space-y-8 max-w-4xl">
+  {{ dashboard::page_title(title = "Event discovery", description = "Discover and publish eligible events from your approved source URLs.") -}}
+  {% if !integration.can_manage_events -%}
+    {{ dashboard::permission_warning(message = "Your role cannot manage event discovery.") -}}
+  {% endif -%}
+  <form class="inert-form space-y-6"
+        hx-put="/dashboard/group/integrations"
+        hx-target="#dashboard-content"
+        {% if !integration.can_manage_events %}inert{% endif %}>
+    <label class="flex gap-3 items-center"><input type="checkbox" name="enabled" value="true" {% if integration.enabled %}checked{% endif %}> Enable discovery</label>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <label>City<input class="input-primary mt-1" name="city" value="{{ integration.city }}" required></label>
+      <label>Timezone<input class="input-primary mt-1" name="timezone" value="{{ integration.timezone }}" required></label>
+    </div>
+    <button class="button-primary" type="submit">Save discovery settings</button>
+  </form>
+  <section class="border-t pt-6">
+    <h2 class="font-semibold text-lg">Source URLs</h2>
+    <form class="flex gap-3 mt-3" hx-post="/dashboard/group/integrations/sources" hx-target="#dashboard-content">
+      <input class="input-primary flex-1" type="url" name="url" placeholder="https://events.example.com" required {% if !integration.can_manage_events %}disabled{% endif %}>
+      <button class="button-primary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Add source</button>
+    </form>
+    <ul class="mt-4 space-y-2">
+    {% for source in integration.sources %}
+      <li class="flex items-center justify-between gap-3 border rounded p-3">
+        <a class="truncate underline" href="{{ source.url }}" target="_blank" rel="noopener noreferrer">{{ source.url }}</a>
+        <form hx-delete="/dashboard/group/integrations/sources/{{ source.group_event_integration_source_id }}" hx-target="#dashboard-content">
+          <button class="button-secondary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Remove</button>
+        </form>
+      </li>
+    {% endfor %}
+    </ul>
+  </section>
+  <section class="border-t pt-6">
+    <h2 class="font-semibold text-lg">Latest run</h2>
+    <form class="mt-3"
+          hx-post="/dashboard/group/integrations/run"
+          hx-target="#dashboard-content">
+      <button class="button-secondary"
+              type="submit"
+              {% if !integration.can_manage_events %}disabled{% endif %}>Run discovery now</button>
+    </form>
+    {% if let Some(run) = integration.latest_run %}
+      <p class="mt-2">Status: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} published</p>
+      {% if let Some(error) = run.error_message %}<p class="text-red-700 mt-2">{{ error }}</p>{% endif %}
+    {% else %}<p class="mt-2 text-stone-600">No runs yet.</p>{% endif %}
+  </section>
+</div>

--- a/ocg-server/templates/group/book_exchange.html
+++ b/ocg-server/templates/group/book_exchange.html
@@ -1,0 +1,83 @@
+{% extends "common/base.html" -%}
+{% import "macros/meta.html" as meta -%}
+
+{% block head_title -%}
+  <title>{{ self.preview_title() |demoji }}</title>
+{% endblock head_title -%}
+
+{% block head_description -%}
+  <meta name="description" content="{{ self.preview_description() |demoji }}">
+{% endblock head_description -%}
+
+{% block canonical_link -%}
+  <link rel="canonical" href="{{ self.canonical_url() }}">
+{% endblock canonical_link -%}
+
+{% block open_graph_meta -%}
+  {{ meta::open_graph(title = self.preview_title() ,
+  description = self.preview_description(),
+  url = self.canonical_url(),
+  image_url = self.open_graph_image_url(),
+  image_alt = &group.name) -}}
+{% endblock open_graph_meta -%}
+
+{% block twitter_meta -%}
+  {{ meta::twitter(title = self.preview_title() ,
+  description = self.preview_description(),
+  image_url = self.open_graph_image_url()) -}}
+{% endblock twitter_meta -%}
+
+{% block content -%}
+  <div class="container mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+    <div class="rounded-[2rem] border border-stone-200 bg-white p-6 shadow-xl shadow-stone-200/50 sm:p-8 lg:p-10">
+      <div>
+        <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}"
+           class="text-sm font-bold text-stone-700 hover:text-stone-950">← Back to {{ group.name|demoji }}</a>
+        <h1 class="mt-4 text-4xl font-black tracking-[-0.045em] text-stone-950 sm:text-5xl">Book exchange</h1>
+        <p class="mt-3 max-w-2xl text-base leading-7 text-stone-600">
+          Browse books that opted-in {{ group.name|demoji }} members want to exchange. This page is visible only to logged-in members of the group.
+        </p>
+      </div>
+
+      <section class="mt-8 rounded-[1.75rem] border border-primary-100 bg-primary-50/70 p-5 sm:p-6">
+        <div class="text-xs font-black uppercase tracking-[0.2em] text-primary-700">Private opt-in</div>
+        <h2 class="mt-2 text-xl font-black tracking-tight text-stone-950">Group member book lists</h2>
+        <p class="mt-2 max-w-3xl text-sm/6 text-stone-700">
+          Members appear here only when the alliance, this group, and their own account opt-in are all enabled. Book lists are not shown on public profiles.
+        </p>
+      </section>
+
+      {% if members.is_empty() -%}
+        <div class="mt-10 rounded-2xl border border-dashed border-stone-300 bg-stone-50 px-8 py-12 text-center">
+          <div class="mx-auto flex size-12 items-center justify-center rounded-full bg-stone-100">
+            <div class="svg-icon size-6 icon-list bg-stone-700"></div>
+          </div>
+          <h2 class="mt-4 text-lg font-semibold text-stone-950">No book lists yet</h2>
+          <p class="mt-2 text-sm text-stone-600">Check back after more members opt in from account settings.</p>
+        </div>
+      {% else -%}
+        <div class="mt-10 grid gap-5 lg:grid-cols-2">
+          {% for member in members -%}
+            <article class="rounded-[1.75rem] border border-stone-200 bg-stone-50 p-5 shadow-sm">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <h2 class="font-black text-stone-950">{{ member.name.as_deref().unwrap_or(member.username.as_str()) }}</h2>
+                  <p class="mt-1 text-sm text-stone-600">@{{ member.username }}</p>
+                </div>
+                <span class="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-bold text-primary-700">Book exchange</span>
+              </div>
+              <div class="mt-4 grid gap-3 text-sm/6 text-stone-700">
+                {% if let Some(books) = &member.book_exchange_books -%}
+                  <p class="whitespace-pre-line"><span class="font-semibold text-stone-950">Books:</span> {{ books }}</p>
+                {% else -%}
+                  <p class="text-stone-500">No book list details yet.</p>
+                {% endif -%}
+                <p class="text-stone-500">{{ member.title.as_deref().unwrap_or("Member") }}{% if member.company.is_some() %} · {{ member.company.as_deref().unwrap_or("") }}{% endif %}{% if member.city.is_some() %} · {{ member.city.as_deref().unwrap_or("") }}{% endif %}</p>
+              </div>
+            </article>
+          {% endfor -%}
+        </div>
+      {% endif -%}
+    </div>
+  </div>
+{% endblock content -%}

--- a/ocg-server/templates/group/page.html
+++ b/ocg-server/templates/group/page.html
@@ -145,6 +145,13 @@
                     <div class="svg-icon size-4 icon-people bg-stone-600"></div>
                     Members
                   </a>
+                  {% if group.book_exchange_available() -%}
+                    <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/book-exchange"
+                       class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
+                      <div class="svg-icon size-4 icon-list bg-stone-600"></div>
+                      Book exchange
+                    </a>
+                  {% endif -%}
                   <a href="/{{ group.alliance.name }}/group/{{ group.public_slug() }}/spotlights"
                      class="flex w-full items-center gap-2 px-4 py-2 text-sm text-stone-700 hover:bg-stone-50">
                     <div class="svg-icon size-4 icon-star bg-stone-600"></div>


### PR DESCRIPTION
## Summary
- add Baku community event discovery, group source management, and authorized publication workflows
- add alliance partner integration management and public co-marketing attribution
- include the selected book-exchange, accelerator, and dashboard template changes from the working tree

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check --all`
- [ ] `cargo test -p ocg-server --no-run` (native dependency compilation still running)

Made with [Cursor](https://cursor.com)