### PR TITLE
fix: improve explore branding and layout

### DIFF
--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -6,6 +6,16 @@
   <nav class="relative z-50 flex h-[68px] items-center justify-between border-b border-[#eadcc9]/70 bg-white/60 px-4 shadow-sm shadow-[#eadcc9]/40 backdrop-blur-xl sm:px-6 lg:px-11"
        role="navigation"
        aria-label="Main navigation">
+    <a href="/"
+       hx-boost="true"
+       hx-target="body"
+       class="inline-flex shrink-0 items-center gap-2 text-[#1A1510]"
+       aria-label="GOUP home">
+      {% if let Some(logo_url) = &site_settings.favicon_url -%}
+        <img class="size-8 rounded-lg object-contain" src="{{ logo_url }}" alt="" aria-hidden="true">
+      {% endif -%}
+      <span class="font-metrophobic text-lg font-semibold tracking-[-0.04em]">GOUP</span>
+    </a>
     <div class="hidden items-center gap-7 lg:flex">
       <a href="/"
          hx-boost="true"

--- a/ocg-server/templates/site/explore/page.html
+++ b/ocg-server/templates/site/explore/page.html
@@ -16,8 +16,8 @@
     </div>
     {# End background hairlines -#}
 
-    <div class="relative mx-auto max-w-7xl px-4 pt-14 pb-16 sm:px-6 lg:px-8 lg:pt-20 lg:pb-[4.5rem]">
-      <p class="mb-6 inline-flex rounded-full border border-white/20 px-4 py-1.5 text-[10px] font-bold uppercase tracking-[0.28em] text-white/60">
+    <div class="relative mx-auto max-w-7xl px-4 pt-10 pb-10 sm:px-6 lg:px-8 lg:pt-12 lg:pb-12">
+      <p class="mb-4 inline-flex rounded-full border border-white/20 px-4 py-1.5 text-[10px] font-bold uppercase tracking-[0.28em] text-white/60">
         Explore GOUP
       </p>
 
@@ -25,7 +25,7 @@
         {{ title }}
       </h1>
 
-      <p class="font-metrophobic mt-6 max-w-xl text-balance text-base leading-[1.65] text-white/65 lg:text-lg">
+      <p class="font-metrophobic mt-4 max-w-xl text-balance text-base leading-[1.65] text-white/65 lg:text-lg">
         Discover builder meetups, coffeehouses and community gatherings across the GOUP network.
       </p>
     </div>


### PR DESCRIPTION
## Summary
- add the configured GOUP logo and wordmark to the public header
- preserve the redesigned explore page while reducing hero whitespace

## Test plan
- [x] `cargo check -p ocg-server`

Made with [Cursor](https://cursor.com)