### PR TITLE
fix: refine public site branding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,12 @@ If you are unsure if the change will be welcome you may want to file an issue fi
 
 You can find the existing pull requests at <https://github.com/goup/open-alliance-groups/pulls>.
 
+## Adding an integration
+
+Third-party services belong in [`ocg-server/src/integrations/`](ocg-server/src/integrations/). Follow the
+[Integration Contributor Guide](docs/guides/integrations.md) for configuration, security, database, UI,
+and testing expectations.
+
 ## Developer Certificate of Origin
 
 The Open Alliance Groups project uses a [Developers Certificate of Origin (DCO)](https://developercertificate.org/) to sign-off that you have the right to contribute the code being contributed. The full text of the DCO reads:

--- a/docs/guides/integrations.md
+++ b/docs/guides/integrations.md
@@ -1,0 +1,68 @@
+<!-- markdownlint-disable MD013 -->
+
+# Integration Contributor Guide
+
+Use this guide when adding a third-party provider, partner service, or external content source to GOUP.
+
+## Code Location
+
+Put provider-specific clients and normalized types in `ocg-server/src/integrations/`. Add a module export in
+`ocg-server/src/integrations.rs`; keep HTTP request details, response decoding, and provider validation there.
+
+Keep handlers focused on authorization and HTTP responses. Put recurring work in `ocg-server/src/services/` and
+start it from `ocg-server/src/main.rs`.
+
+## Configuration and Secrets
+
+1. Add an optional, typed configuration block in `ocg-server/src/config.rs`.
+2. Validate enabled integrations at startup, including valid URLs, scheduling values, and required credentials.
+3. Add only non-secret example values to `.config/ocg/server.yml`.
+4. Load secrets from `OCG_` environment variables, such as
+   `OCG_INTEGRATIONS__PROVIDER__API_KEY`.
+5. Never commit API keys, tokens, webhook secrets, or customer URLs that are not intended to be public.
+
+The local server configuration is ignored by Git so developers can safely set their own credentials.
+
+## Data and Permissions
+
+When an integration persists data:
+
+1. Create a schema migration under `database/migrations/schema/`.
+2. Add SQL functions under `database/migrations/functions/` and register them in
+   `database/migrations/functions/001_load_functions.sql`.
+3. Extend the appropriate database trait and its mock in `ocg-server/src/db/`.
+4. Enforce the existing alliance or group permission in the handler before mutating data.
+5. Record source URLs, external identifiers, run status, and deduplication keys so retries are safe.
+
+Do not let a background worker bypass authorization. Store the authorized actor that configured the integration and
+reuse existing domain flows for side effects such as event publication and notifications.
+
+## User Experience
+
+- Add group-scoped controls to the Group Dashboard and alliance-scoped controls to the Alliance Dashboard.
+- Surface last-run status and actionable failures without exposing provider secrets.
+- Put public partner attribution on the relevant alliance page only when the partner is marked public.
+- Reuse Askama templates and HTMX routes instead of embedding provider logic in browser code.
+
+## HTTP and Worker Safety
+
+- Use explicit request timeouts, bounded retries, and structured error logs.
+- Validate user-entered URLs before storing them.
+- Treat fetched data as untrusted; require the fields needed by the target GOUP entity.
+- Deduplicate provider records before creating entities.
+- Make scheduled and manual runs idempotent.
+- Keep webhooks authenticated and verify provider signatures when the provider supports them.
+
+## Tests and Review
+
+At minimum, cover configuration validation, provider response parsing, permission checks, deduplication, and failure
+handling. Run:
+
+```bash
+cargo fmt --all -- --check
+cargo check -p ocg-server
+cargo test -p ocg-server
+```
+
+For migrations or dashboard changes, also run the relevant database and browser checks described in the
+[Project Contributors Runbook](project-contributors-runbook.md).

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -9,7 +9,7 @@
     <a href="/"
        hx-boost="true"
        hx-target="body"
-       class="inline-flex shrink-0 items-center gap-2 text-[#1A1510]"
+       class="mr-5 inline-flex shrink-0 items-center gap-2 text-[#1A1510] sm:mr-7"
        aria-label="GOUP home">
       {% if let Some(logo_url) = &site_settings.favicon_url -%}
         <img class="size-8 rounded-lg object-contain" src="{{ logo_url }}" alt="" aria-hidden="true">

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -6,6 +6,16 @@
   <nav class="relative z-50 flex h-[68px] items-center justify-between border-b border-[#eadcc9]/70 bg-white/60 px-4 shadow-sm shadow-[#eadcc9]/40 backdrop-blur-xl sm:px-6 lg:px-11"
        role="navigation"
        aria-label="Main navigation">
+    <a href="/"
+       hx-boost="true"
+       hx-target="body"
+       class="inline-flex shrink-0 items-center gap-2 text-[#1A1510]"
+       aria-label="GOUP home">
+      {% if let Some(logo_url) = &site_settings.favicon_url -%}
+        <img class="size-8 rounded-lg object-contain" src="{{ logo_url }}" alt="" aria-hidden="true">
+      {% endif -%}
+      <span class="font-metrophobic text-lg font-semibold tracking-[-0.04em]">GOUP</span>
+    </a>
     <div class="hidden items-center gap-7 lg:flex">
       <a href="/"
          hx-boost="true"

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -9,7 +9,7 @@
     <a href="/"
        hx-boost="true"
        hx-target="body"
-       class="mr-5 inline-flex shrink-0 items-center gap-2 text-[#1A1510] sm:mr-7"
+       class="inline-flex shrink-0 items-center gap-2 text-[#1A1510]"
        aria-label="GOUP home">
       {% if let Some(logo_url) = &site_settings.favicon_url -%}
         <img class="size-8 rounded-lg object-contain" src="{{ logo_url }}" alt="" aria-hidden="true">
@@ -17,10 +17,6 @@
       <span class="font-metrophobic text-lg font-semibold tracking-[-0.04em]">GOUP</span>
     </a>
     <div class="hidden items-center gap-7 lg:flex">
-      <a href="/"
-         hx-boost="true"
-         hx-target="body"
-         class="text-[15px] text-[#3a2f25]/75 transition hover:text-[#1A1510]">Home</a>
       <a href="{{ explore_events }}"
          hx-boost="true"
          hx-target="body"

--- a/ocg-server/templates/site/explore/page.html
+++ b/ocg-server/templates/site/explore/page.html
@@ -16,8 +16,8 @@
     </div>
     {# End background hairlines -#}
 
-    <div class="relative mx-auto max-w-7xl px-4 pt-14 pb-16 sm:px-6 lg:px-8 lg:pt-20 lg:pb-[4.5rem]">
-      <p class="mb-6 inline-flex rounded-full border border-white/20 px-4 py-1.5 text-[10px] font-bold uppercase tracking-[0.28em] text-white/60">
+    <div class="relative mx-auto max-w-7xl px-4 pt-10 pb-10 sm:px-6 lg:px-8 lg:pt-12 lg:pb-12">
+      <p class="mb-4 inline-flex rounded-full border border-white/20 px-4 py-1.5 text-[10px] font-bold uppercase tracking-[0.28em] text-white/60">
         Explore GOUP
       </p>
 
@@ -25,7 +25,7 @@
         {{ title }}
       </h1>
 
-      <p class="font-metrophobic mt-6 max-w-xl text-balance text-base leading-[1.65] text-white/65 lg:text-lg">
+      <p class="font-metrophobic mt-4 max-w-xl text-balance text-base leading-[1.65] text-white/65 lg:text-lg">
         Discover builder meetups, coffeehouses and community gatherings across the GOUP network.
       </p>
     </div>

--- a/ocg-server/templates/site/explore/page.html
+++ b/ocg-server/templates/site/explore/page.html
@@ -21,7 +21,7 @@
         Explore GOUP
       </p>
 
-      <h1 class="font-amethysta max-w-3xl text-balance text-5xl font-bold leading-[0.95] text-[#FAF5EE] sm:text-6xl lg:text-[5.5rem]">
+      <h1 class="font-amethysta max-w-3xl text-balance text-4xl font-bold leading-[0.98] text-[#FAF5EE] sm:text-5xl lg:text-6xl">
         {{ title }}
       </h1>
 

--- a/ocg-server/templates/site/wiki/page.html
+++ b/ocg-server/templates/site/wiki/page.html
@@ -18,21 +18,21 @@
   <div class="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
     <div class="lg:grid lg:grid-cols-[1fr_400px] lg:items-stretch">
       {# Left column: intro (dark shows through) -#}
-      <div class="relative pt-14 pb-16 lg:pt-20 lg:pb-[4.5rem] lg:pr-12">
+      <div class="relative pt-10 pb-10 lg:pt-12 lg:pb-12 lg:pr-12">
         <h1
-          class="font-amethysta max-w-lg text-balance text-5xl font-bold leading-[0.95] text-[#FAF5EE] sm:text-6xl lg:text-[4.5rem]"
+          class="font-amethysta max-w-lg text-balance text-4xl font-bold leading-[0.98] text-[#FAF5EE] sm:text-5xl lg:text-[4rem]"
         >
           Guides and signal<br class="hidden lg:block" />
           for the GOUP<br class="hidden lg:block" />
           community.
         </h1>
-        <p class="mt-6 max-w-[420px] text-[15px] leading-relaxed text-white/35">
+        <p class="mt-4 max-w-[420px] text-[15px] leading-relaxed text-white/55">
           Start with the member onboarding guide, then scan the live reading
           desk for AI, open source, and company-building links.
         </p>
       </div>
       {# End left column -#} {# Right column: feature list -#}
-      <div class="relative pt-14 pb-16 lg:pt-20 lg:pb-[4.5rem] lg:pl-12">
+      <div class="relative pt-10 pb-10 lg:pt-12 lg:pb-12 lg:pl-12">
         {# Cream panel, bleeds to the screen edges -#}
         <div
           class="pointer-events-none absolute inset-y-0 left-[-1rem] right-[-9999px] bg-[#FAFAF7] sm:left-[-1.5rem] lg:left-0"


### PR DESCRIPTION
## Summary
- add GOUP branding to the shared public header
- streamline public navigation and reduce oversized Explore and Wiki heroes
- document how contributors should add external integrations

## Test plan
- [x] `cargo check -p ocg-server`
- [x] `npx markdownlint-cli2 \"CONTRIBUTING.md\" \"docs/guides/integrations.md\"`

Made with [Cursor](https://cursor.com)