### PR TITLE
feat: add global job discovery

### DIFF
--- a/database/migrations/schema/0047_jobs_discovery.sql
+++ b/database/migrations/schema/0047_jobs_discovery.sql
@@ -1,0 +1,42 @@
+create table jobs_discovery_integration (
+    user_id uuid primary key references "user"(user_id) on delete cascade,
+    enabled boolean not null default false,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now()
+);
+
+create table jobs_discovery_source (
+    jobs_discovery_source_id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references "user"(user_id) on delete cascade,
+    url text not null,
+    enabled boolean not null default true,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    unique (user_id, url)
+);
+
+create table jobs_discovery_run (
+    jobs_discovery_run_id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references "user"(user_id) on delete cascade,
+    started_at timestamptz not null default now(),
+    completed_at timestamptz,
+    status text not null check (status in ('running', 'succeeded', 'failed')),
+    discovered_count integer not null default 0 check (discovered_count >= 0),
+    created_count integer not null default 0 check (created_count >= 0),
+    error_message text
+);
+
+create table jobs_discovery_item (
+    jobs_discovery_item_id uuid primary key default gen_random_uuid(),
+    user_id uuid not null references "user"(user_id) on delete cascade,
+    source_url text not null,
+    fingerprint text not null,
+    job_id uuid references jobs_job(job_id) on delete set null,
+    created_at timestamptz not null default now(),
+    unique (user_id, fingerprint)
+);
+
+create index jobs_discovery_source_enabled_idx
+    on jobs_discovery_source (user_id) where enabled;
+create index jobs_discovery_run_user_started_idx
+    on jobs_discovery_run (user_id, started_at desc);

--- a/ocg-server/src/db/jobs.rs
+++ b/ocg-server/src/db/jobs.rs
@@ -9,8 +9,8 @@ use uuid::Uuid;
 use crate::{
     db::PgExecutor,
     types::jobs::{
-        DashboardJobsFilters, DashboardJobsOutput, JobApplicationInput, JobFull, JobInput,
-        JobsFilters, JobsOutput, parse_tags,
+        DashboardJobsFilters, DashboardJobsOutput, JobApplicationInput, JobDiscoveryDashboard,
+        JobFull, JobInput, JobsFilters, JobsOutput, parse_tags,
     },
 };
 
@@ -54,6 +54,15 @@ pub(crate) trait DBJobs {
         job_id: Uuid,
         input: &JobApplicationInput,
     ) -> Result<()>;
+
+    /// Load the current user's jobs discovery configuration.
+    async fn get_job_discovery(&self, user_id: Uuid) -> Result<JobDiscoveryDashboard>;
+    /// Enable or disable the current user's discovery.
+    async fn update_job_discovery(&self, user_id: Uuid, enabled: bool) -> Result<()>;
+    /// Add a source URL owned by the current user.
+    async fn add_job_discovery_source(&self, user_id: Uuid, url: &str) -> Result<Uuid>;
+    /// Delete a source URL owned by the current user.
+    async fn delete_job_discovery_source(&self, user_id: Uuid, source_id: Uuid) -> Result<()>;
 }
 
 #[async_trait]
@@ -145,6 +154,54 @@ where
         self.execute(
             "select add_job_application($1::uuid, $2::uuid, $3::jsonb)",
             &[&user_id, &job_id, &Json(input)],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn get_job_discovery(&self, user_id: Uuid) -> Result<JobDiscoveryDashboard> {
+        self.fetch_json_one(
+            "select jsonb_build_object(
+                'enabled', coalesce(i.enabled, false),
+                'sources', coalesce((select jsonb_agg(jsonb_build_object(
+                    'jobs_discovery_source_id', s.jobs_discovery_source_id,
+                    'url', s.url, 'enabled', s.enabled) order by s.created_at)
+                    from jobs_discovery_source s where s.user_id = $1), '[]'::jsonb),
+                'latest_run', (select jsonb_build_object('status', r.status,
+                    'discovered_count', r.discovered_count, 'created_count', r.created_count,
+                    'error_message', r.error_message) from jobs_discovery_run r
+                    where r.user_id = $1 order by r.started_at desc limit 1)
+            ) from (select 1) x left join jobs_discovery_integration i on i.user_id = $1",
+            &[&user_id],
+        )
+        .await
+    }
+
+    async fn update_job_discovery(&self, user_id: Uuid, enabled: bool) -> Result<()> {
+        self.execute(
+            "insert into jobs_discovery_integration (user_id, enabled) values ($1, $2)
+             on conflict (user_id) do update set enabled = excluded.enabled, updated_at = now()",
+            &[&user_id, &enabled],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn add_job_discovery_source(&self, user_id: Uuid, url: &str) -> Result<Uuid> {
+        self.fetch_scalar_one(
+            "insert into jobs_discovery_source (user_id, url) values ($1, $2)
+             on conflict (user_id, url) do update set updated_at = now()
+             returning jobs_discovery_source_id",
+            &[&user_id, &url],
+        )
+        .await
+    }
+
+    async fn delete_job_discovery_source(&self, user_id: Uuid, source_id: Uuid) -> Result<()> {
+        self.execute(
+            "delete from jobs_discovery_source
+             where user_id = $1 and jobs_discovery_source_id = $2",
+            &[&user_id, &source_id],
         )
         .await?;
         Ok(())

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -1224,6 +1224,17 @@ mock! {
             job_id: Uuid,
             input: &crate::types::jobs::JobApplicationInput,
         ) -> Result<()>;
+        async fn get_job_discovery(
+            &self,
+            user_id: Uuid,
+        ) -> Result<crate::types::jobs::JobDiscoveryDashboard>;
+        async fn update_job_discovery(&self, user_id: Uuid, enabled: bool) -> Result<()>;
+        async fn add_job_discovery_source(&self, user_id: Uuid, url: &str) -> Result<Uuid>;
+        async fn delete_job_discovery_source(
+            &self,
+            user_id: Uuid,
+            source_id: Uuid,
+        ) -> Result<()>;
     }
 
     #[async_trait]

--- a/ocg-server/src/handlers/dashboard/jobs.rs
+++ b/ocg-server/src/handlers/dashboard/jobs.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 use axum_messages::Messages;
 use garde::Validate;
+use serde::Deserialize;
 use tracing::{instrument, warn};
 use uuid::Uuid;
 
@@ -18,12 +19,14 @@ use crate::{
         error::HandlerError,
         extractors::{CurrentUser, ValidatedForm},
     },
+    integrations::you_com::validate_source_url,
     router::serde_qs_config,
+    services::job_discovery::ManualJobDiscovery,
     services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
     templates::{
         PageId,
         auth::User,
-        dashboard::jobs::{MockInterviewsPage, Page},
+        dashboard::jobs::{DiscoveryPage, MockInterviewsPage, Page},
         notifications::MockInterviewMatched,
     },
     types::{
@@ -38,6 +41,20 @@ use crate::{
 
 const DASHBOARD_JOBS_URL: &str = "/dashboard/jobs";
 const DASHBOARD_MOCK_INTERVIEWS_URL: &str = "/dashboard/jobs/mock-interviews";
+const DASHBOARD_DISCOVERY_URL: &str = "/dashboard/jobs/discovery";
+
+#[derive(Debug, Deserialize, Validate)]
+pub(crate) struct DiscoverySettingsInput {
+    #[serde(default)]
+    #[garde(skip)]
+    enabled: bool,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(crate) struct DiscoverySourceInput {
+    #[garde(skip)]
+    url: String,
+}
 
 /// Render the jobs dashboard.
 #[instrument(skip_all, err)]
@@ -116,6 +133,96 @@ pub(crate) async fn add(
     db.add_job(user.user_id, &input).await?;
     messages.success("Job posted.");
     Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+}
+
+/// Render user-owned global jobs discovery settings.
+#[instrument(skip_all, err)]
+pub(crate) async fn discovery_page(
+    auth_session: crate::auth::AuthSession,
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    State(manual_job_discovery): State<Option<ManualJobDiscovery>>,
+) -> Result<impl IntoResponse, HandlerError> {
+    Ok(Html(
+        DiscoveryPage {
+            messages: messages.into_iter().collect(),
+            page_id: PageId::JobsDashboard,
+            path: DASHBOARD_DISCOVERY_URL.into(),
+            site_settings: db.get_site_settings().await?,
+            user: User::from_session(auth_session).await?,
+            discovery: db.get_job_discovery(user.user_id).await?,
+            discovery_available: manual_job_discovery.is_some_and(|runner| runner.enabled()),
+        }
+        .render()?,
+    ))
+}
+
+/// Update discovery enabled state.
+#[instrument(skip_all, err)]
+pub(crate) async fn update_discovery(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<DiscoverySettingsInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.update_job_discovery(user.user_id, input.enabled).await?;
+    messages.success("Jobs discovery settings saved.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
+}
+
+/// Add a validated source URL.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_discovery_source(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<DiscoverySourceInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    validate_source_url(input.url.trim()).map_err(HandlerError::from)?;
+    db.add_job_discovery_source(user.user_id, input.url.trim()).await?;
+    messages.success("Discovery source added.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
+}
+
+/// Remove a source URL owned by the current user.
+#[instrument(skip_all, err)]
+pub(crate) async fn delete_discovery_source(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(source_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.delete_job_discovery_source(user.user_id, source_id).await?;
+    messages.success("Discovery source removed.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
+}
+
+/// Queue a manual discovery run.
+#[instrument(skip_all, err)]
+pub(crate) async fn run_discovery(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(manual_job_discovery): State<Option<ManualJobDiscovery>>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let Some(runner) = manual_job_discovery.filter(|runner| runner.enabled()) else {
+        return Err(HandlerError::NotFound);
+    };
+    runner.spawn_user_run(user.user_id);
+    messages.success("Jobs discovery run started.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
 }
 
 /// Update a job.

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -1571,6 +1571,7 @@ pub(crate) fn test_state_with_server_cfg(
         db,
         image_storage,
         manual_event_discovery: None,
+        manual_job_discovery: None,
         meetings_cfg: None,
         notifications_manager,
         payments_cfg: None,

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -73,7 +73,7 @@ impl YouComClient {
             .context("You.com search returned an error")?;
         let payload: SearchResponse =
             response.json().await.context("decoding You.com search response")?;
-        Ok(payload.results)
+        Ok(payload.results.web.into_iter().chain(payload.results.news).collect())
     }
 }
 
@@ -90,8 +90,16 @@ pub(crate) struct SearchResult {
 
 #[derive(Debug, Deserialize)]
 struct SearchResponse {
-    #[serde(default, alias = "hits")]
-    results: Vec<SearchResult>,
+    #[serde(default)]
+    results: SearchResults,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SearchResults {
+    #[serde(default)]
+    web: Vec<SearchResult>,
+    #[serde(default)]
+    news: Vec<SearchResult>,
 }
 
 /// Rejects pages that do not identify Baku or Azerbaijan.
@@ -163,5 +171,21 @@ mod tests {
         let mut rescheduled = event.clone();
         rescheduled.starts_at = Utc.with_ymd_and_hms(2026, 7, 22, 12, 0, 0).unwrap();
         assert_ne!(event.fingerprint(), rescheduled.fingerprint());
+    }
+
+    #[test]
+    fn decodes_web_and_news_results() {
+        let payload: SearchResponse = serde_json::from_str(
+            r#"{
+                "results": {
+                    "web": [{"title": "Baku meetup", "url": "https://example.test/web"}],
+                    "news": [{"title": "Baku news", "url": "https://example.test/news"}]
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(payload.results.web.len(), 1);
+        assert_eq!(payload.results.news.len(), 1);
     }
 }

--- a/ocg-server/src/main.rs
+++ b/ocg-server/src/main.rs
@@ -111,6 +111,7 @@ async fn main() -> Result<()> {
     start_meetings_workers(&cfg, db.clone(), &background_tasks);
     start_recording_publishing_workers(&cfg, &db, &background_tasks);
     start_event_discovery_worker(&cfg, db.clone(), &background_tasks);
+    start_job_discovery_worker(&cfg, db.clone(), &background_tasks);
     let activity_tracker = setup_activity_tracker(db.clone(), &background_tasks);
     let notifications_manager = setup_notifications_manager(&cfg, db.clone(), &background_tasks)?;
     let payments_manager = setup_payments_manager(
@@ -197,6 +198,22 @@ fn start_event_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &
         .and_then(|integrations| integrations.you_com.clone())
     {
         services::event_discovery::start(
+            you_com_cfg,
+            db,
+            &background_tasks.task_tracker,
+            &background_tasks.cancellation_token,
+        );
+    }
+}
+
+/// Starts global job discovery with the same configured You.com account.
+fn start_job_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &BackgroundTasks) {
+    if let Some(you_com_cfg) = cfg
+        .integrations
+        .as_ref()
+        .and_then(|integrations| integrations.you_com.clone())
+    {
+        services::job_discovery::start(
             you_com_cfg,
             db,
             &background_tasks.task_tracker,

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -40,7 +40,8 @@ use crate::{
     },
     services::{
         event_discovery::ManualEventDiscovery, images::DynImageStorage,
-        notifications::DynNotificationsManager, payments::DynPaymentsManager,
+        job_discovery::ManualJobDiscovery, notifications::DynNotificationsManager,
+        payments::DynPaymentsManager,
     },
 };
 
@@ -114,6 +115,8 @@ pub(crate) struct State {
     pub image_storage: DynImageStorage,
     /// Optional You.com discovery runner for authorized dashboard actions.
     pub manual_event_discovery: Option<ManualEventDiscovery>,
+    /// Optional You.com discovery runner for global jobs dashboard actions.
+    pub manual_job_discovery: Option<ManualJobDiscovery>,
     /// Meetings configuration.
     pub meetings_cfg: Option<MeetingsConfig>,
     /// Notifications manager handle.
@@ -162,8 +165,12 @@ pub(crate) async fn setup(
         activity_tracker,
         image_storage,
         manual_event_discovery: you_com_cfg
-            .zip(manual_event_discovery_db)
+            .clone()
+            .zip(manual_event_discovery_db.clone())
             .map(|(cfg, db)| ManualEventDiscovery::new(cfg, db)),
+        manual_job_discovery: you_com_cfg
+            .zip(manual_event_discovery_db)
+            .map(|(cfg, db)| ManualJobDiscovery::new(cfg, db)),
         meetings_cfg,
         notifications_manager,
         payments_cfg,
@@ -287,6 +294,26 @@ pub(crate) async fn setup(
         .route(
             "/dashboard/jobs/mock-interviews",
             get(crate::handlers::dashboard::jobs::mock_interviews_page),
+        )
+        .route(
+            "/dashboard/jobs/discovery",
+            get(crate::handlers::dashboard::jobs::discovery_page),
+        )
+        .route(
+            "/dashboard/jobs/discovery/settings",
+            post(crate::handlers::dashboard::jobs::update_discovery),
+        )
+        .route(
+            "/dashboard/jobs/discovery/sources",
+            post(crate::handlers::dashboard::jobs::add_discovery_source),
+        )
+        .route(
+            "/dashboard/jobs/discovery/sources/{source_id}",
+            delete(crate::handlers::dashboard::jobs::delete_discovery_source),
+        )
+        .route(
+            "/dashboard/jobs/discovery/run",
+            post(crate::handlers::dashboard::jobs::run_discovery),
         )
         .route(
             "/dashboard/jobs/mock-interviews/{request_id}/match",

--- a/ocg-server/src/services.rs
+++ b/ocg-server/src/services.rs
@@ -4,6 +4,8 @@
 pub(crate) mod event_discovery;
 /// Images service module.
 pub(crate) mod images;
+/// Scheduled global jobs discovery.
+pub(crate) mod job_discovery;
 
 /// Meetings service module.
 pub(crate) mod meetings;

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -1,0 +1,239 @@
+//! Scheduled discovery and publication of global jobs from user-approved sources.
+
+use std::{collections::HashSet, sync::Arc, time::Duration};
+
+use anyhow::Result;
+use chrono::{Datelike, TimeZone, Timelike, Utc};
+use garde::Validate;
+use tokio::time::sleep;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+use tracing::{error, info};
+use uuid::Uuid;
+
+use crate::{
+    config::YouComConfig,
+    db::{PgDB, PgExecutor, jobs::DBJobs},
+    integrations::you_com::{SearchResult, YouComClient},
+    types::jobs::JobInput,
+};
+
+/// Runs an authorized user-owned discovery request without blocking HTTP.
+#[derive(Clone)]
+pub(crate) struct ManualJobDiscovery {
+    cfg: YouComConfig,
+    db: Arc<PgDB>,
+}
+
+impl ManualJobDiscovery {
+    pub(crate) fn new(cfg: YouComConfig, db: Arc<PgDB>) -> Self {
+        Self { cfg, db }
+    }
+    pub(crate) fn enabled(&self) -> bool {
+        self.cfg.enabled
+    }
+    pub(crate) fn spawn_user_run(&self, user_id: Uuid) {
+        let cfg = self.cfg.clone();
+        let db = self.db.clone();
+        tokio::spawn(async move {
+            if let Err(err) = run_user(cfg, db, user_id).await {
+                error!(%err, %user_id, "manual You.com job discovery failed");
+            }
+        });
+    }
+}
+
+/// Starts the daily job discovery worker using the shared You.com configuration.
+pub(crate) fn start(
+    cfg: YouComConfig,
+    db: Arc<PgDB>,
+    tasks: &TaskTracker,
+    cancel: &CancellationToken,
+) {
+    if !cfg.enabled {
+        return;
+    }
+    tasks.spawn({
+        let cancel = cancel.clone();
+        async move {
+            let Ok(client) = YouComClient::new(&cfg) else {
+                error!("could not start You.com job discovery");
+                return;
+            };
+            let Ok(timezone) = cfg.schedule_timezone.parse() else {
+                error!("invalid You.com job discovery timezone");
+                return;
+            };
+            loop {
+                tokio::select! {
+                    () = sleep(delay_until_next_run(timezone, cfg.schedule_hour)) => {},
+                    () = cancel.cancelled() => break,
+                }
+                if let Err(err) = ingest_enabled(&db, &client).await {
+                    error!(%err, "scheduled You.com job discovery failed");
+                }
+            }
+        }
+    });
+}
+
+pub(crate) async fn run_user(cfg: YouComConfig, db: Arc<PgDB>, user_id: Uuid) -> Result<()> {
+    anyhow::ensure!(cfg.enabled, "You.com job discovery is disabled");
+    let enabled: bool = db.fetch_scalar_one(
+        "select exists(select 1 from jobs_discovery_integration where user_id = $1 and enabled)",
+        &[&user_id],
+    ).await?;
+    anyhow::ensure!(enabled, "job discovery is not enabled");
+    ingest_users(&db, &YouComClient::new(&cfg)?, &[user_id]).await
+}
+
+async fn ingest_enabled(db: &PgDB, client: &YouComClient) -> Result<()> {
+    let users: Vec<Uuid> = db.fetch_scalar_one(
+        "select coalesce(array_agg(user_id), '{}'::uuid[]) from jobs_discovery_integration where enabled",
+        &[],
+    ).await?;
+    ingest_users(db, client, &users).await
+}
+
+async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Result<()> {
+    for user_id in users {
+        db.execute(
+            "insert into jobs_discovery_run (user_id, status) values ($1, 'running')",
+            &[user_id],
+        )
+        .await?;
+    }
+    let outcome = async {
+        for user_id in users {
+            let sources: Vec<String> = db.fetch_scalar_one(
+                "select coalesce(array_agg(url), '{}'::text[]) from jobs_discovery_source
+                 where user_id = $1 and enabled", &[user_id],
+            ).await?;
+            let mut discovered = 0;
+            let mut created = 0;
+            for source_url in sources {
+                let mut seen = HashSet::new();
+                for result in client.search(&format!("jobs hiring careers site:{source_url}")).await? {
+                    let Some(input) = parse_discovered_job(&result) else { continue };
+                    if !seen.insert(result.url.trim().to_lowercase()) { continue; }
+                    let fingerprint = fingerprint(&input, &result.url);
+                    let item: Option<Uuid> = db.fetch_scalar_opt(
+                        "insert into jobs_discovery_item (user_id, source_url, fingerprint)
+                         values ($1, $2, $3) on conflict (user_id, fingerprint) do nothing
+                         returning jobs_discovery_item_id",
+                        &[user_id, &source_url, &fingerprint],
+                    ).await?;
+                    let Some(_) = item else { continue };
+                    discovered += 1;
+                    let job_id = db.add_job(*user_id, &input).await?;
+                    db.update_job_published(*user_id, job_id, true).await?;
+                    db.execute(
+                        "update jobs_discovery_item set job_id = $1 where user_id = $2 and fingerprint = $3",
+                        &[&job_id, user_id, &fingerprint],
+                    ).await?;
+                    created += 1;
+                }
+            }
+            db.execute(
+                "update jobs_discovery_run set completed_at = now(), status = 'succeeded',
+                 discovered_count = $2, created_count = $3
+                 where jobs_discovery_run_id = (select jobs_discovery_run_id from jobs_discovery_run
+                 where user_id = $1 and status = 'running' order by started_at desc limit 1)",
+                &[user_id, &discovered, &created],
+            ).await?;
+            info!(%user_id, discovered, created, "published discovered jobs");
+        }
+        Result::<()>::Ok(())
+    }.await;
+    if let Err(err) = &outcome {
+        for user_id in users {
+            db.execute(
+                "update jobs_discovery_run set completed_at = now(), status = 'failed', error_message = $2
+                 where jobs_discovery_run_id = (select jobs_discovery_run_id from jobs_discovery_run
+                 where user_id = $1 and status = 'running' order by started_at desc limit 1)",
+                &[user_id, &err.to_string()],
+            ).await?;
+        }
+    }
+    outcome
+}
+
+/// Accept only results with an explicit title, employer, description, and HTTPS application URL.
+fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
+    let title = result.title.trim();
+    let description = result.description.as_deref()?.trim();
+    let apply_url = reqwest::Url::parse(result.url.trim()).ok()?;
+    if !matches!(apply_url.scheme(), "http" | "https") || title.is_empty() || description.is_empty()
+    {
+        return None;
+    }
+    // You.com result titles conventionally expose the employer after " at " or " - ".
+    let (title, company_name) = title
+        .split_once(" at ")
+        .or_else(|| title.split_once(" - "))
+        .filter(|(role, company)| !role.trim().is_empty() && !company.trim().is_empty())?;
+    let summary: String = description.chars().take(280).collect();
+    let input = JobInput {
+        title: title.trim().to_owned(),
+        company_name: company_name.trim().to_owned(),
+        summary,
+        description: description.to_owned(),
+        apply_url: apply_url.into(),
+        location: None,
+        remote: None,
+        members_only: Some(false),
+        tags: None,
+    };
+    input.validate().ok()?;
+    Some(input)
+}
+
+fn fingerprint(input: &JobInput, apply_url: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hash = Sha256::new();
+    hash.update(input.title.trim().to_lowercase());
+    hash.update(b"\0");
+    hash.update(input.company_name.trim().to_lowercase());
+    hash.update(b"\0");
+    hash.update(apply_url.trim().to_lowercase());
+    hex::encode(hash.finalize())
+}
+
+fn delay_until_next_run(timezone: chrono_tz::Tz, hour: u8) -> Duration {
+    let now = Utc::now().with_timezone(&timezone);
+    let today = timezone
+        .with_ymd_and_hms(now.year(), now.month(), now.day(), u32::from(hour), 0, 0)
+        .single()
+        .expect("configured schedule hour must be valid");
+    let next = if now.hour() < u32::from(hour) {
+        today
+    } else {
+        today + chrono::Duration::days(1)
+    };
+    (next.with_timezone(&Utc) - Utc::now()).to_std().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn rejects_incomplete_search_results() {
+        assert!(
+            parse_discovered_job(&SearchResult {
+                title: "Engineer".into(),
+                url: "https://x.test".into(),
+                description: None
+            })
+            .is_none()
+        );
+    }
+    #[test]
+    fn accepts_explicit_job_result() {
+        let job = parse_discovered_job(&SearchResult {
+            title: "Rust Engineer at Acme".into(),
+            url: "https://x.test/jobs/1".into(),
+            description: Some("Build reliable systems.".into()),
+        })
+        .unwrap();
+        assert_eq!(job.company_name, "Acme");
+    }
+}

--- a/ocg-server/src/templates/dashboard/jobs.rs
+++ b/ocg-server/src/templates/dashboard/jobs.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     templates::{PageId, auth::User, filters, helpers::user_initials},
     types::{
-        jobs::{DashboardJobsFilters, JobSummary},
+        jobs::{DashboardJobsFilters, JobDiscoveryDashboard, JobSummary},
         mock_interviews::{
             INTERVIEW_TYPE_OPTIONS, LOCATION_OPTIONS, MockInterviewDashboard, MockInterviewFilters,
             MockInterviewOption, PRACTICE_ROLE_OPTIONS, SENIORITY_OPTIONS, TARGET_COMPANY_OPTIONS,
@@ -41,6 +41,20 @@ pub(crate) struct Page {
     pub total: usize,
     /// Pagination links.
     pub navigation_links: NavigationLinks,
+}
+
+/// Jobs discovery dashboard page.
+#[derive(Debug, Clone, Template, Serialize, Deserialize)]
+#[template(path = "dashboard/jobs/discovery.html")]
+pub(crate) struct DiscoveryPage {
+    pub messages: Vec<Message>,
+    #[allow(dead_code)]
+    pub page_id: PageId,
+    pub path: String,
+    pub site_settings: SiteSettings,
+    pub user: User,
+    pub discovery: JobDiscoveryDashboard,
+    pub discovery_available: bool,
 }
 
 /// Mock interviews dashboard page.

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -142,6 +142,31 @@ pub(crate) struct DashboardJobsOutput {
     pub total: usize,
 }
 
+/// A user-owned source queried for global job discovery.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JobDiscoverySource {
+    pub jobs_discovery_source_id: Uuid,
+    pub url: String,
+    pub enabled: bool,
+}
+
+/// Most recent discovery run shown in the Jobs dashboard.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JobDiscoveryRun {
+    pub status: String,
+    pub discovered_count: i32,
+    pub created_count: i32,
+    pub error_message: Option<String>,
+}
+
+/// Jobs discovery configuration and its owned source URLs.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct JobDiscoveryDashboard {
+    pub enabled: bool,
+    pub sources: Vec<JobDiscoverySource>,
+    pub latest_run: Option<JobDiscoveryRun>,
+}
+
 /// Applicant interest saved for a job.
 #[skip_serializing_none]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/ocg-server/templates/common/header.html
+++ b/ocg-server/templates/common/header.html
@@ -16,7 +16,7 @@
       {% endif -%}
       <span class="font-metrophobic text-lg font-semibold tracking-[-0.04em]">GOUP</span>
     </a>
-    <div class="ml-8 hidden items-center gap-7 lg:flex">
+    <div class="hidden items-center gap-7 lg:flex" style="margin-left: 2rem">
       <a href="{{ explore_events }}"
          hx-boost="true"
          hx-target="body"

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -13,6 +13,7 @@
     <div class="leading-10 grid gap-y-0.5">
       {{ dashboard::menu_title(text = "Manage", extra_styles = "py-1.5") -}}
       {{ dashboard::menu_item(name = "Post & Manage Jobs", icon = "search", is_active = true, href = "/dashboard/jobs") -}}
+      {{ dashboard::menu_item(name = "Jobs Discovery", icon = "search", is_active = false, href = "/dashboard/jobs/discovery") -}}
       {{ dashboard::menu_item(name = "Mock Interview Queue", icon = "user-small", is_active = false, href = "/dashboard/jobs/mock-interviews") -}}
     </div>
     <div class="leading-10 pt-6 border-t border-stone-200 grid gap-y-0.5">

--- a/ocg-server/templates/dashboard/jobs/discovery.html
+++ b/ocg-server/templates/dashboard/jobs/discovery.html
@@ -1,0 +1,43 @@
+{% extends "dashboard/dashboard_base.html" -%}
+{% import "macros/dashboard.html" as dashboard -%}
+{% import "macros/feedback.html" as feedback -%}
+{% block menu -%}
+<div class="mt-3 mb-6 px-3 lg:px-5"><div class="font-semibold text-stone-900 text-sm lg:text-lg">Jobs Dashboard</div></div>
+<div class="px-3 lg:px-5 leading-10 grid gap-y-0.5">
+  {{ dashboard::menu_title(text = "Manage", extra_styles = "py-1.5") -}}
+  {{ dashboard::menu_item(name = "Post & Manage Jobs", icon = "search", is_active = false, href = "/dashboard/jobs") -}}
+  {{ dashboard::menu_item(name = "Jobs Discovery", icon = "search", is_active = true, href = "/dashboard/jobs/discovery") -}}
+  {{ dashboard::menu_item(name = "Mock Interview Queue", icon = "user-small", is_active = false, href = "/dashboard/jobs/mock-interviews") -}}
+</div>
+{% endblock menu -%}
+{% block dashboard_main -%}
+<div class="p-4 sm:p-6 lg:p-12 max-w-4xl">
+  {{ dashboard::page_title(title = "Jobs discovery", description = "Publish validated jobs found through your approved source URLs.") -}}
+  {% if !messages.is_empty() %}<div class="mt-6">{{ feedback::alerts(messages) }}</div>{% endif %}
+  {% if !discovery_available %}
+    <p class="mt-6 text-stone-600">Jobs discovery is not configured by this site.</p>
+  {% else %}
+    <form class="mt-8 space-y-4" action="/dashboard/jobs/discovery/settings" method="post">
+      <label class="flex gap-3 items-center"><input type="checkbox" name="enabled" value="true" {% if discovery.enabled %}checked{% endif %}> Enable jobs discovery</label>
+      <button class="button-primary">Save settings</button>
+    </form>
+    <section class="mt-8 border-t pt-6">
+      <h2 class="font-semibold text-lg">Source URLs</h2>
+      <form class="flex gap-3 mt-3" action="/dashboard/jobs/discovery/sources" method="post">
+        <input class="input-primary flex-1" type="url" name="url" placeholder="https://careers.example.com" required>
+        <button class="button-primary">Add source</button>
+      </form>
+      <ul class="mt-4 space-y-2">{% for source in discovery.sources %}
+        <li class="flex items-center justify-between gap-3 border rounded p-3">
+          <a class="truncate underline" href="{{ source.url }}" target="_blank" rel="noopener noreferrer">{{ source.url }}</a>
+          <form hx-delete="/dashboard/jobs/discovery/sources/{{ source.jobs_discovery_source_id }}" hx-target="body"><button class="button-secondary">Remove</button></form>
+        </li>{% endfor %}
+      </ul>
+    </section>
+    <section class="mt-8 border-t pt-6">
+      <form action="/dashboard/jobs/discovery/run" method="post"><button class="button-secondary" {% if !discovery.enabled %}disabled{% endif %}>Run discovery now</button></form>
+      {% if let Some(run) = discovery.latest_run %}<p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} published</p>{% endif %}
+    </section>
+  {% endif %}
+</div>
+{% endblock dashboard_main -%}


### PR DESCRIPTION
## Summary
- add a Jobs-dashboard source list, settings, manual runs, and run status
- discover, validate, deduplicate, and automatically publish source-scoped You.com jobs globally
- include the documented You.com unified response decoder and header spacing correction

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo test -p ocg-server job_discovery`
- [x] `cargo check -p ocg-server`

Made with [Cursor](https://cursor.com)