### PR TITLE
Fix version 48 schema migration compatibility

### DIFF
--- a/database/migrations/schema/0057_jobs.sql
+++ b/database/migrations/schema/0057_jobs.sql
@@ -1,4 +1,4 @@
-create table jobs_job (
+create table if not exists jobs_job (
     job_id uuid default gen_random_uuid() primary key,
     posted_by_user_id uuid not null references "user" (user_id) on delete cascade,
     title text not null,
@@ -17,19 +17,19 @@ create table jobs_job (
     updated_at timestamp with time zone
 );
 
-create index jobs_job_published_created_at_idx
+create index if not exists jobs_job_published_created_at_idx
 on jobs_job (published, created_at desc);
 
-create index jobs_job_published_expires_at_created_at_idx
+create index if not exists jobs_job_published_expires_at_created_at_idx
 on jobs_job (published, expires_at, created_at desc);
 
-create index jobs_job_posted_by_user_id_created_at_idx
+create index if not exists jobs_job_posted_by_user_id_created_at_idx
 on jobs_job (posted_by_user_id, created_at desc);
 
-create index jobs_job_tags_idx
+create index if not exists jobs_job_tags_idx
 on jobs_job using gin (tags);
 
-create table jobs_application (
+create table if not exists jobs_application (
     job_application_id uuid default gen_random_uuid() primary key,
     job_id uuid not null references jobs_job (job_id) on delete cascade,
     applicant_user_id uuid not null references "user" (user_id) on delete cascade,
@@ -38,5 +38,5 @@ create table jobs_application (
     unique (job_id, applicant_user_id)
 );
 
-create index jobs_application_applicant_user_id_created_at_idx
+create index if not exists jobs_application_applicant_user_id_created_at_idx
 on jobs_application (applicant_user_id, created_at desc);


### PR DESCRIPTION
## Summary
- guard all replay-prone schema table, index, column, and constraint operations in the post-baseline migration chain
- allow an existing database recorded at version 48 to advance through schema version 102 without duplicate-object failures
- add CI coverage that reconstructs the pre-renumbered version-48 schema before applying current migrations

## Test plan
- [x] Version-48 compatibility migration reaches schema version 102 locally
- [x] Fresh schema migration reaches schema version 102 locally
- [x] Verify migration numbers are contiguous from 1 through 102
- [ ] Run the database CI job