### PR TITLE
Fix complete database migration path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install PostgreSQL, pgTAP, and tern clients
         run: |
           sudo apt-get update
@@ -194,6 +196,23 @@ jobs:
       - name: Apply database migrations
         working-directory: ./database/migrations
         run: TERN_CONF=/tmp/ocg-tern-tests.conf ./migrate.sh
+      - name: Verify schema migration compatibility from version 48
+        run: |
+          PGPASSWORD=tests createdb \
+            --host 127.0.0.1 \
+            --port ${{ job.services.postgres.ports[5432] }} \
+            --username tests \
+            ocg_legacy_migration_tests
+          cat >/tmp/ocg-tern-legacy-migration-tests.conf <<EOF
+          [database]
+          host = 127.0.0.1
+          port = ${{ job.services.postgres.ports[5432] }}
+          database = ocg_legacy_migration_tests
+          user = tests
+          password = tests
+          EOF
+          database/tests/schema_migration_compatibility.sh \
+            /tmp/ocg-tern-legacy-migration-tests.conf
       - name: Install pgtap database extension
         run: PGPASSWORD=tests psql -h 127.0.0.1 -p ${{ job.services.postgres.ports[5432] }} -U tests tests -c 'create extension pgtap;'
       - name: Run database tests

--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -11,6 +11,7 @@
 {{ template "auth/get_user_by_email_for_external_auth.sql" }}
 {{ template "auth/get_user_by_id_verified.sql" }}
 {{ template "auth/get_user_by_username.sql" }}
+{{ template "auth/get_public_user_provider.sql" }}
 {{ template "auth/is_linkedin_subject_blocked.sql" }}
 {{ template "auth/sign_up_user.sql" }}
 {{ template "auth/update_user_details.sql" }}

--- a/database/migrations/functions/auth/get_public_user_provider.sql
+++ b/database/migrations/functions/auth/get_public_user_provider.sql
@@ -1,0 +1,10 @@
+-- get_public_user_provider removes private external identity metadata.
+create or replace function get_public_user_provider(
+    p_provider jsonb
+) returns jsonb as $$
+    select case
+        when jsonb_typeof(p_provider -> 'github') = 'object'
+            then jsonb_build_object('github', p_provider -> 'github')
+        else null
+    end;
+$$ language sql immutable;

--- a/database/migrations/schema/0059_landscape.sql
+++ b/database/migrations/schema/0059_landscape.sql
@@ -1,4 +1,4 @@
-create table landscape_entry (
+create table if not exists landscape_entry (
     landscape_entry_id uuid default gen_random_uuid() primary key,
     alliance_id uuid not null references alliance (alliance_id) on delete cascade,
     added_by_user_id uuid not null references "user" (user_id) on delete cascade,
@@ -18,14 +18,14 @@ create table landscape_entry (
     unique (alliance_id, slug)
 );
 
-create index landscape_entry_alliance_published_created_at_idx
+create index if not exists landscape_entry_alliance_published_created_at_idx
 on landscape_entry (alliance_id, published, created_at desc);
 
-create index landscape_entry_published_created_at_idx
+create index if not exists landscape_entry_published_created_at_idx
 on landscape_entry (published, created_at desc);
 
-create index landscape_entry_kind_idx
+create index if not exists landscape_entry_kind_idx
 on landscape_entry (kind);
 
-create index landscape_entry_tags_idx
+create index if not exists landscape_entry_tags_idx
 on landscape_entry using gin (tags);

--- a/database/migrations/schema/0061_member_removal_linkedin_blocklist.sql
+++ b/database/migrations/schema/0061_member_removal_linkedin_blocklist.sql
@@ -1,4 +1,4 @@
-create table linkedin_blocklist (
+create table if not exists linkedin_blocklist (
     linkedin_subject text primary key,
     blocked_user_id uuid references "user" (user_id) on delete set null,
     blocked_by_user_id uuid references "user" (user_id) on delete set null,

--- a/database/migrations/schema/0067_add_event_registration_window.sql
+++ b/database/migrations/schema/0067_add_event_registration_window.sql
@@ -1,8 +1,11 @@
 -- Add optional event registration window dates.
 
 alter table event
-    add column registration_starts_at timestamptz,
-    add column registration_ends_at timestamptz,
+    add column if not exists registration_starts_at timestamptz,
+    add column if not exists registration_ends_at timestamptz,
+    drop constraint if exists event_registration_window_order_chk,
+    drop constraint if exists event_registration_end_before_event_start_chk,
+    drop constraint if exists event_registration_start_before_event_start_chk,
     add constraint event_registration_window_order_chk check (
         registration_starts_at is null
         or registration_ends_at is null

--- a/database/migrations/schema/0068_add_user_tsdoc.sql
+++ b/database/migrations/schema/0068_add_user_tsdoc.sql
@@ -1,6 +1,6 @@
 -- Adds an indexed search document for user profile lookup.
 
-alter table "user" add column tsdoc tsvector not null
+alter table "user" add column if not exists tsdoc tsvector not null
     generated always as (
         setweight(to_tsvector('simple', coalesce(name, '')), 'A') ||
         setweight(to_tsvector('simple', username), 'A') ||
@@ -9,4 +9,4 @@ alter table "user" add column tsdoc tsvector not null
         setweight(to_tsvector('simple', coalesce(title, '')), 'C')
     ) stored;
 
-create index user_tsdoc_idx on "user" using gin (tsdoc);
+create index if not exists user_tsdoc_idx on "user" using gin (tsdoc);

--- a/database/migrations/schema/0075_google_meet_youtube_publishing.sql
+++ b/database/migrations/schema/0075_google_meet_youtube_publishing.sql
@@ -1,11 +1,14 @@
 alter table meeting
-    add column recording_publish_claimed_at timestamptz,
-    add column recording_publish_checked_at timestamptz,
-    add column recording_publish_drive_file_id text,
-    add column recording_publish_error text,
-    add column recording_publish_url text;
+    add column if not exists recording_publish_claimed_at timestamptz,
+    add column if not exists recording_publish_checked_at timestamptz,
+    add column if not exists recording_publish_drive_file_id text,
+    add column if not exists recording_publish_error text,
+    add column if not exists recording_publish_url text;
 
 alter table meeting
+    drop constraint if exists meeting_recording_publish_drive_file_id_check,
+    drop constraint if exists meeting_recording_publish_error_check,
+    drop constraint if exists meeting_recording_publish_url_check,
     add constraint meeting_recording_publish_drive_file_id_check
         check (btrim(recording_publish_drive_file_id) <> ''),
     add constraint meeting_recording_publish_error_check
@@ -13,7 +16,7 @@ alter table meeting
     add constraint meeting_recording_publish_url_check
         check (btrim(recording_publish_url) <> '');
 
-create index meeting_google_meet_recording_publish_pending_idx
+create index if not exists meeting_google_meet_recording_publish_pending_idx
     on meeting (recording_publish_checked_at, updated_at)
     where meeting_provider_id = 'google_meet'
       and recording_publish_url is null;

--- a/database/migrations/schema/0076_group_google_photos_url.sql
+++ b/database/migrations/schema/0076_group_google_photos_url.sql
@@ -1,6 +1,7 @@
 alter table "group"
-    add column google_photos_url text;
+    add column if not exists google_photos_url text;
 
 alter table "group"
+    drop constraint if exists group_google_photos_url_check,
     add constraint group_google_photos_url_check
         check (btrim(google_photos_url) <> '');

--- a/database/migrations/schema/0077_group_event_defaults.sql
+++ b/database/migrations/schema/0077_group_event_defaults.sql
@@ -1,2 +1,2 @@
 alter table "group"
-    add column event_defaults jsonb;
+    add column if not exists event_defaults jsonb;

--- a/database/migrations/schema/0079_group_substack_url.sql
+++ b/database/migrations/schema/0079_group_substack_url.sql
@@ -1,6 +1,7 @@
 alter table "group"
-    add column substack_url text;
+    add column if not exists substack_url text;
 
 alter table "group"
+    drop constraint if exists group_substack_url_check,
     add constraint group_substack_url_check
         check (btrim(substack_url) <> '');

--- a/database/migrations/schema/0080_group_join_approval.sql
+++ b/database/migrations/schema/0080_group_join_approval.sql
@@ -1,7 +1,7 @@
 alter table "group"
-    add column membership_approval_required boolean default false not null;
+    add column if not exists membership_approval_required boolean default false not null;
 
-create table group_join_request (
+create table if not exists group_join_request (
     group_id uuid not null references "group" (group_id) on delete cascade,
     user_id uuid not null references "user" (user_id) on delete cascade,
     status text default 'pending' not null,
@@ -16,5 +16,5 @@ create table group_join_request (
     )
 );
 
-create index group_join_request_group_status_created_at_idx
+create index if not exists group_join_request_group_status_created_at_idx
 on group_join_request (group_id, status, created_at desc);

--- a/database/migrations/schema/0092_landscape_accelerators.sql
+++ b/database/migrations/schema/0092_landscape_accelerators.sql
@@ -5,7 +5,7 @@ alter table landscape_entry
 add constraint landscape_entry_kind_check
 check (kind in ('startup', 'github_project', 'partner_community', 'podcast_lead', 'investor', 'accelerator'));
 
-create table landscape_accelerator_profile (
+create table if not exists landscape_accelerator_profile (
     landscape_entry_id uuid primary key references landscape_entry (landscape_entry_id) on delete cascade,
     application_url text,
     curriculum_url text,

--- a/database/migrations/schema/0093_group_accelerators.sql
+++ b/database/migrations/schema/0093_group_accelerators.sql
@@ -1,4 +1,4 @@
-create table group_accelerator_program (
+create table if not exists group_accelerator_program (
     group_accelerator_program_id uuid primary key default gen_random_uuid(),
     group_id uuid not null references "group" (group_id) on delete cascade,
     created_by uuid not null references "user" (user_id),
@@ -17,10 +17,10 @@ create table group_accelerator_program (
     constraint group_accelerator_program_curriculum_url_check check (curriculum_url is null or btrim(curriculum_url) <> '')
 );
 
-create index group_accelerator_program_group_id_idx
+create index if not exists group_accelerator_program_group_id_idx
 on group_accelerator_program (group_id, active desc, created_at desc);
 
-create table group_accelerator_cohort (
+create table if not exists group_accelerator_cohort (
     group_accelerator_cohort_id uuid primary key default gen_random_uuid(),
     group_accelerator_program_id uuid not null references group_accelerator_program (group_accelerator_program_id) on delete cascade,
     created_by uuid not null references "user" (user_id),
@@ -37,10 +37,10 @@ create table group_accelerator_cohort (
     constraint group_accelerator_cohort_dates_check check (starts_on is null or ends_on is null or starts_on <= ends_on)
 );
 
-create index group_accelerator_cohort_program_id_idx
+create index if not exists group_accelerator_cohort_program_id_idx
 on group_accelerator_cohort (group_accelerator_program_id, status, starts_on desc nulls last);
 
-create table group_accelerator_application (
+create table if not exists group_accelerator_application (
     group_accelerator_application_id uuid primary key default gen_random_uuid(),
     group_accelerator_cohort_id uuid not null references group_accelerator_cohort (group_accelerator_cohort_id) on delete cascade,
     user_id uuid references "user" (user_id) on delete set null,
@@ -64,10 +64,10 @@ create table group_accelerator_application (
     constraint group_accelerator_application_goals_check check (goals is null or btrim(goals) <> '')
 );
 
-create index group_accelerator_application_cohort_id_idx
+create index if not exists group_accelerator_application_cohort_id_idx
 on group_accelerator_application (group_accelerator_cohort_id, status, created_at desc);
 
-create table group_accelerator_member (
+create table if not exists group_accelerator_member (
     group_accelerator_member_id uuid primary key default gen_random_uuid(),
     group_accelerator_cohort_id uuid not null references group_accelerator_cohort (group_accelerator_cohort_id) on delete cascade,
     group_accelerator_application_id uuid references group_accelerator_application (group_accelerator_application_id) on delete set null,
@@ -84,10 +84,10 @@ create table group_accelerator_member (
     unique (group_accelerator_cohort_id, group_accelerator_application_id)
 );
 
-create index group_accelerator_member_cohort_id_idx
+create index if not exists group_accelerator_member_cohort_id_idx
 on group_accelerator_member (group_accelerator_cohort_id, status, created_at desc);
 
-create table group_accelerator_week (
+create table if not exists group_accelerator_week (
     group_accelerator_week_id uuid primary key default gen_random_uuid(),
     group_accelerator_cohort_id uuid not null references group_accelerator_cohort (group_accelerator_cohort_id) on delete cascade,
     created_by uuid not null references "user" (user_id),
@@ -109,10 +109,10 @@ create table group_accelerator_week (
     unique (group_accelerator_cohort_id, week_number)
 );
 
-create index group_accelerator_week_cohort_id_idx
+create index if not exists group_accelerator_week_cohort_id_idx
 on group_accelerator_week (group_accelerator_cohort_id, week_number);
 
-create table group_accelerator_weekly_update (
+create table if not exists group_accelerator_weekly_update (
     group_accelerator_weekly_update_id uuid primary key default gen_random_uuid(),
     group_accelerator_member_id uuid not null references group_accelerator_member (group_accelerator_member_id) on delete cascade,
     group_accelerator_week_id uuid not null references group_accelerator_week (group_accelerator_week_id) on delete cascade,
@@ -132,5 +132,5 @@ create table group_accelerator_weekly_update (
     unique (group_accelerator_member_id, group_accelerator_week_id)
 );
 
-create index group_accelerator_weekly_update_week_id_idx
+create index if not exists group_accelerator_weekly_update_week_id_idx
 on group_accelerator_weekly_update (group_accelerator_week_id, status, created_at desc);

--- a/database/migrations/schema/0094_mock_interviews.sql
+++ b/database/migrations/schema/0094_mock_interviews.sql
@@ -1,4 +1,4 @@
-create table mock_interview_request (
+create table if not exists mock_interview_request (
     mock_interview_request_id uuid primary key default gen_random_uuid(),
     requester_user_id uuid not null references "user" (user_id) on delete cascade,
     practice_role text not null check (practice_role in ('interviewee', 'both', 'interviewer', 'not_interested')),
@@ -15,13 +15,13 @@ create table mock_interview_request (
     constraint mock_interview_request_notes_check check (notes is null or btrim(notes) <> '')
 );
 
-create index mock_interview_request_requester_user_id_idx
+create index if not exists mock_interview_request_requester_user_id_idx
 on mock_interview_request (requester_user_id, created_at desc);
 
-create index mock_interview_request_status_idx
+create index if not exists mock_interview_request_status_idx
 on mock_interview_request (status, interview_type, location, created_at desc);
 
-create table mock_interview_match (
+create table if not exists mock_interview_match (
     mock_interview_match_id uuid primary key default gen_random_uuid(),
     mock_interview_request_id uuid not null unique references mock_interview_request (mock_interview_request_id) on delete cascade,
     created_by_user_id uuid not null references "user" (user_id),
@@ -43,5 +43,5 @@ create table mock_interview_match (
     constraint mock_interview_match_interviewer_rating_check check (interviewer_rating is null or interviewer_rating between 1 and 5)
 );
 
-create index mock_interview_match_status_idx
+create index if not exists mock_interview_match_status_idx
 on mock_interview_match (status, scheduled_at desc nulls last);

--- a/database/migrations/schema/0100_event_integrations.sql
+++ b/database/migrations/schema/0100_event_integrations.sql
@@ -1,4 +1,4 @@
-create table group_event_integration (
+create table if not exists group_event_integration (
     group_id uuid primary key references "group"(group_id) on delete cascade,
     created_by_user_id uuid not null references "user"(user_id),
     enabled boolean not null default false,
@@ -8,7 +8,7 @@ create table group_event_integration (
     updated_at timestamptz not null default now()
 );
 
-create table group_event_integration_source (
+create table if not exists group_event_integration_source (
     group_event_integration_source_id uuid primary key default gen_random_uuid(),
     group_id uuid not null references "group"(group_id) on delete cascade,
     url text not null,
@@ -18,7 +18,7 @@ create table group_event_integration_source (
     unique (group_id, url)
 );
 
-create table group_event_integration_run (
+create table if not exists group_event_integration_run (
     group_event_integration_run_id uuid primary key default gen_random_uuid(),
     group_id uuid not null references "group"(group_id) on delete cascade,
     started_at timestamptz not null default now(),
@@ -29,7 +29,7 @@ create table group_event_integration_run (
     error_message text
 );
 
-create table group_event_integration_item (
+create table if not exists group_event_integration_item (
     group_event_integration_item_id uuid primary key default gen_random_uuid(),
     group_id uuid not null references "group"(group_id) on delete cascade,
     source_url text not null,
@@ -39,13 +39,13 @@ create table group_event_integration_item (
     unique (group_id, fingerprint)
 );
 
-create index group_event_integration_source_enabled_idx
+create index if not exists group_event_integration_source_enabled_idx
     on group_event_integration_source (group_id)
     where enabled;
-create index group_event_integration_run_group_started_idx
+create index if not exists group_event_integration_run_group_started_idx
     on group_event_integration_run (group_id, started_at desc);
 
-create table partner_integration (
+create table if not exists partner_integration (
     partner_integration_id uuid primary key default gen_random_uuid(),
     alliance_id uuid not null references alliance(alliance_id) on delete cascade,
     name text not null,

--- a/database/migrations/schema/0101_jobs_discovery.sql
+++ b/database/migrations/schema/0101_jobs_discovery.sql
@@ -1,11 +1,11 @@
-create table jobs_discovery_integration (
+create table if not exists jobs_discovery_integration (
     user_id uuid primary key references "user"(user_id) on delete cascade,
     enabled boolean not null default false,
     created_at timestamptz not null default now(),
     updated_at timestamptz not null default now()
 );
 
-create table jobs_discovery_source (
+create table if not exists jobs_discovery_source (
     jobs_discovery_source_id uuid primary key default gen_random_uuid(),
     user_id uuid not null references "user"(user_id) on delete cascade,
     url text not null,
@@ -15,7 +15,7 @@ create table jobs_discovery_source (
     unique (user_id, url)
 );
 
-create table jobs_discovery_run (
+create table if not exists jobs_discovery_run (
     jobs_discovery_run_id uuid primary key default gen_random_uuid(),
     user_id uuid not null references "user"(user_id) on delete cascade,
     started_at timestamptz not null default now(),
@@ -26,7 +26,7 @@ create table jobs_discovery_run (
     error_message text
 );
 
-create table jobs_discovery_item (
+create table if not exists jobs_discovery_item (
     jobs_discovery_item_id uuid primary key default gen_random_uuid(),
     user_id uuid not null references "user"(user_id) on delete cascade,
     source_url text not null,
@@ -36,7 +36,7 @@ create table jobs_discovery_item (
     unique (user_id, fingerprint)
 );
 
-create index jobs_discovery_source_enabled_idx
+create index if not exists jobs_discovery_source_enabled_idx
     on jobs_discovery_source (user_id) where enabled;
-create index jobs_discovery_run_user_started_idx
+create index if not exists jobs_discovery_run_user_started_idx
     on jobs_discovery_run (user_id, started_at desc);

--- a/database/migrations/schema/0102_add_notification_delivery_retry.sql
+++ b/database/migrations/schema/0102_add_notification_delivery_retry.sql
@@ -1,15 +1,16 @@
 -- Add durable notification delivery retry scheduling.
 
 alter table notification
-    add column next_delivery_attempt_at timestamptz,
+    add column if not exists next_delivery_attempt_at timestamptz,
+    drop constraint if exists notification_next_delivery_attempt_at_chk,
     add constraint notification_next_delivery_attempt_at_chk check (
         next_delivery_attempt_at is null
         or delivery_status = 'pending'
     );
 
-drop index notification_not_processed_idx;
+drop index if exists notification_not_processed_idx;
 
-create index notification_not_processed_idx on notification (
+create index if not exists notification_not_processed_idx on notification (
     created_at,
     next_delivery_attempt_at,
     notification_id

--- a/database/tests/schema_migration_compatibility.sh
+++ b/database/tests/schema_migration_compatibility.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+config=$1
+legacy_ref=${LEGACY_SCHEMA_MIGRATION_REF:-f2d3fd0d}
+repo_root=$(git rev-parse --show-toplevel)
+workspace=$(mktemp -d)
+
+cleanup() {
+    rm -rf "$workspace"
+}
+trap cleanup EXIT
+
+git -C "$repo_root" archive "$legacy_ref" database/migrations/schema |
+    tar -x -C "$workspace"
+
+legacy_schema_dir="$workspace/database/migrations/schema"
+rm -f "$legacy_schema_dir/0061_add_notification_delivery_retry.sql"
+
+# Recreate the schema that was deployed before migration history was
+# renumbered, then advance its recorded version to the production value.
+(
+    cd "$legacy_schema_dir"
+    tern migrate --config "$config" --version-table version_schema --destination 47
+)
+
+psql "$(awk '
+    /^\[database\]/ { next }
+    /^host[[:space:]]*=/ { host=$3 }
+    /^port[[:space:]]*=/ { port=$3 }
+    /^database[[:space:]]*=/ { database=$3 }
+    /^user[[:space:]]*=/ { user=$3 }
+    /^password[[:space:]]*=/ { password=$3 }
+    END { printf "postgresql://%s:%s@%s:%s/%s", user, password, host, port, database }
+' "$config")" \
+    --set ON_ERROR_STOP=1 \
+    --command 'update version_schema set version = 48 where version = 47;'
+
+(
+    cd "$repo_root/database/migrations/schema"
+    tern migrate --config "$config" --version-table version_schema
+    tern status --config "$config" --version-table version_schema
+)


### PR DESCRIPTION
## Summary
- apply the tested version-48 schema compatibility changes directly on top of main
- load the missing `get_public_user_provider` helper required by dashboard group search functions
- retain CI coverage for version-48 schema upgrades

## Test plan
- [x] Version-48 schema migration reaches version 102 locally
- [x] Fresh full schema and functions migration completes locally
- [x] Verify migration numbers are contiguous from 1 through 102
- [ ] Run database CI

Made with [Cursor](https://cursor.com)