### PR TITLE
Add AI agent discovery resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,9 +446,9 @@ cd mcp
 npm start
 ```
 
-For remote deployments, protect it with `MCP_BEARER_TOKEN` and expose it behind
-HTTPS. See [`mcp/README.md`](./mcp/README.md) for setup, client config, and how
-to add more tools.
+`MCP_BEARER_TOKEN` is required for remote and local deployments. Expose the
+service only behind HTTPS. See [`mcp/README.md`](./mcp/README.md) for setup,
+client config, and how to add more tools.
 
 To set up the remote MCP server on EC2 with a generated bearer token and a
 systemd service:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -23,7 +23,7 @@ the default value is rendered.
 
 ```bash
 cd mcp
-npm start
+MCP_BEARER_TOKEN='replace-with-a-strong-token' npm start
 ```
 
 The server listens on `http://127.0.0.1:8787/mcp` by default.

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -12,6 +12,10 @@ const ENABLE_MUTATIONS = process.env.MCP_ENABLE_MUTATIONS === "true";
 const PROTOCOL_VERSION = "2024-11-05";
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const LANDSCAPE_KINDS = ["startup", "github_project", "partner_community", "podcast_lead"];
+
+if (!BEARER_TOKEN) {
+  throw new Error("MCP_BEARER_TOKEN must be configured");
+}
 const WIKI_SECTIONS = [
   {
     id: "ai",
@@ -129,10 +133,6 @@ async function loadTools() {
 }
 
 function isAuthorized(req) {
-  if (!BEARER_TOKEN) {
-    return true;
-  }
-
   return req.headers.authorization === `Bearer ${BEARER_TOKEN}`;
 }
 

--- a/ocg-server/src/handlers/site.rs
+++ b/ocg-server/src/handlers/site.rs
@@ -1,6 +1,7 @@
 //! HTTP handlers for the global site.
 
 pub(crate) mod about;
+pub(crate) mod agent_discovery;
 pub(crate) mod docs;
 pub(crate) mod explore;
 pub(crate) mod home;

--- a/ocg-server/src/handlers/site/agent_discovery.rs
+++ b/ocg-server/src/handlers/site/agent_discovery.rs
@@ -1,0 +1,184 @@
+//! Machine-readable discovery resources for public and agent clients.
+
+use axum::{
+    extract::State,
+    http::header::CONTENT_TYPE,
+    response::{IntoResponse, Response},
+};
+use rust_embed::Embed;
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+use crate::{
+    handlers::{error::HandlerError, extend_public_shared_cache_headers},
+    router::State as RouterState,
+};
+
+const CONTENT_TYPE_LINKSET_JSON: &str = "application/linkset+json; charset=utf-8";
+const CONTENT_TYPE_MARKDOWN: &str = "text/markdown; charset=utf-8";
+const CONTENT_TYPE_XML: &str = "application/xml; charset=utf-8";
+const CONTENT_TYPE_TEXT: &str = "text/plain; charset=utf-8";
+
+#[derive(Embed)]
+#[folder = "../docs"]
+struct DocsAsset;
+
+/// Serves crawler policy and public AI-content preferences.
+pub(crate) async fn robots(State(state): State<RouterState>) -> Result<Response, HandlerError> {
+    let base_url = canonical_base_url(&state.server_cfg.base_url);
+    let body = format!(
+        "User-agent: *\nAllow: /\nDisallow: /dashboard/\nDisallow: /api/\nDisallow: /log-in\nDisallow: /sign-up\nDisallow: /webhooks/\n\nUser-agent: GPTBot\nAllow: /\n\nUser-agent: OAI-SearchBot\nAllow: /\n\nUser-agent: Claude-Web\nAllow: /\n\nUser-agent: Google-Extended\nAllow: /\n\nContent-Signal: ai-train=no, search=yes, ai-input=no\nSitemap: {base_url}/sitemap.xml\n"
+    );
+    text_response(CONTENT_TYPE_TEXT, body)
+}
+
+/// Serves a canonical sitemap for static public pages and embedded documentation.
+pub(crate) async fn sitemap(State(state): State<RouterState>) -> Result<Response, HandlerError> {
+    let base_url = canonical_base_url(&state.server_cfg.base_url);
+    let mut paths = vec![
+        "/".to_string(),
+        "/about".to_string(),
+        "/docs".to_string(),
+        "/explore".to_string(),
+        "/jobs".to_string(),
+        "/landscape".to_string(),
+        "/privacy".to_string(),
+        "/stats".to_string(),
+        "/wiki".to_string(),
+    ];
+    paths.extend(documentation_paths());
+    paths.sort();
+    paths.dedup();
+
+    let urls = paths
+        .iter()
+        .map(|path| {
+            format!(
+                "  <url><loc>{}</loc></url>",
+                xml_escape(&format!("{base_url}{path}"))
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    text_response(
+        CONTENT_TYPE_XML,
+        format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n{urls}\n</urlset>\n"
+        ),
+    )
+}
+
+/// Serves the existing OpenAPI description at a stable public URL.
+pub(crate) async fn openapi() -> Result<Response, HandlerError> {
+    let Some(file) = DocsAsset::get("openapi.yaml") else {
+        return Err(HandlerError::NotFound);
+    };
+    text_response(
+        "application/vnd.oai.openapi;version=3.0.3; charset=utf-8",
+        String::from_utf8(file.data.into_owned())
+            .map_err(|error| HandlerError::Other(anyhow::anyhow!(error)))?,
+    )
+}
+
+/// Serves API Catalog metadata for API-aware clients.
+pub(crate) async fn api_catalog(
+    State(state): State<RouterState>,
+) -> Result<Response, HandlerError> {
+    let base_url = canonical_base_url(&state.server_cfg.base_url);
+    let body = serde_json::to_string_pretty(&json!({
+        "linkset": [{
+            "anchor": format!("{base_url}/api/v1"),
+            "service-desc": [{"href": format!("{base_url}/openapi.yaml"), "type": "application/vnd.oai.openapi"}],
+            "service-doc": [{"href": format!("{base_url}/docs/api")}],
+            "status": [{"href": format!("{base_url}/api/v1/health")}]
+        }]
+    }))
+    .map_err(|error| HandlerError::Other(anyhow::anyhow!(error)))?;
+    text_response(CONTENT_TYPE_LINKSET_JSON, body)
+}
+
+/// Describes the authenticated operational MCP endpoint.
+pub(crate) async fn mcp_server_card(
+    State(state): State<RouterState>,
+) -> Result<Response, HandlerError> {
+    let base_url = canonical_base_url(&state.server_cfg.base_url);
+    let body = serde_json::to_string_pretty(&json!({
+        "serverInfo": {"name": "goup-vc", "version": env!("CARGO_PKG_VERSION")},
+        "description": "GOUP Alliance operational tools. A bearer token is required.",
+        "transport": {"type": "streamable-http", "url": format!("{base_url}/mcp")},
+        "capabilities": {"tools": {"listChanged": false}},
+        "authentication": {"schemes": ["bearer"]}
+    }))
+    .map_err(|error| HandlerError::Other(anyhow::anyhow!(error)))?;
+    text_response("application/json; charset=utf-8", body)
+}
+
+/// Serves the Agent Skills discovery index for the MCP connection guide.
+pub(crate) async fn agent_skills_index(
+    State(state): State<RouterState>,
+) -> Result<Response, HandlerError> {
+    let base_url = canonical_base_url(&state.server_cfg.base_url);
+    let skill = mcp_skill_document(&base_url);
+    let digest = hex::encode(Sha256::digest(skill.as_bytes()));
+    let body = serde_json::to_string_pretty(&json!({
+        "$schema": "https://agentskills.io/schemas/agent-skills-index-v0.2.0.json",
+        "skills": [{
+            "name": "goup-mcp",
+            "type": "skill-md",
+            "description": "Connect to GOUP's authenticated operational MCP server.",
+            "url": format!("{base_url}/.well-known/agent-skills/goup-mcp/SKILL.md"),
+            "sha256": digest
+        }]
+    }))
+    .map_err(|error| HandlerError::Other(anyhow::anyhow!(error)))?;
+    text_response("application/json; charset=utf-8", body)
+}
+
+/// Serves the MCP connection guide referenced by the skills index.
+pub(crate) async fn mcp_skill(State(state): State<RouterState>) -> Result<Response, HandlerError> {
+    text_response(
+        CONTENT_TYPE_MARKDOWN,
+        mcp_skill_document(&canonical_base_url(&state.server_cfg.base_url)),
+    )
+}
+
+fn text_response(content_type: &'static str, body: String) -> Result<Response, HandlerError> {
+    Ok((
+        extend_public_shared_cache_headers(&[(CONTENT_TYPE.as_str(), content_type)])?,
+        body,
+    )
+        .into_response())
+}
+
+fn canonical_base_url(base_url: &str) -> String {
+    base_url.trim_end_matches('/').to_string()
+}
+
+fn documentation_paths() -> Vec<String> {
+    DocsAsset::iter()
+        .filter_map(|path| {
+            let path = path.as_ref();
+            let stem = path.strip_suffix(".md")?;
+            Some(if stem == "index" {
+                "/docs".to_string()
+            } else {
+                format!("/docs/{stem}")
+            })
+        })
+        .collect()
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+fn mcp_skill_document(base_url: &str) -> String {
+    format!(
+        "# GOUP MCP\n\nUse GOUP's operational MCP endpoint only with an authorized bearer token.\n\n- Endpoint: `{base_url}/mcp`\n- Transport: Streamable HTTP JSON-RPC\n- Authentication: `Authorization: Bearer <token>`\n- Read-only operations are available by default; mutations depend on server policy.\n\nUse `tools/list` before calling tools. Do not send credentials or personal data to any other endpoint.\n"
+    )
+}

--- a/ocg-server/src/handlers/site/home.rs
+++ b/ocg-server/src/handlers/site/home.rs
@@ -3,8 +3,11 @@
 use askama::Template;
 use axum::{
     extract::State,
-    http::{Uri, header::CACHE_CONTROL},
-    response::{Html, IntoResponse},
+    http::{
+        HeaderMap, Uri,
+        header::{ACCEPT, CACHE_CONTROL, CONTENT_TYPE, VARY},
+    },
+    response::{Html, IntoResponse, Response},
 };
 use tracing::{instrument, warn};
 
@@ -29,8 +32,21 @@ mod tests;
 pub(crate) async fn page(
     auth_session: AuthSession,
     State(db): State<DynDB>,
+    headers: HeaderMap,
     uri: Uri,
-) -> Result<impl IntoResponse, HandlerError> {
+) -> Result<Response, HandlerError> {
+    if accepts_markdown(&headers) {
+        return Ok((
+            [
+                (CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE),
+                (CONTENT_TYPE, "text/markdown; charset=utf-8"),
+                (VARY, "Accept"),
+            ],
+            "# GOUP Alliance\n\nGOUP Alliance is a community platform for builders, founders, and open-source contributors.\n\n- [Explore groups and events](/explore)\n- [Browse jobs](/jobs)\n- [Browse the landscape](/landscape)\n- [Read the documentation](/docs)\n- [Public API documentation](/docs/api)\n",
+        )
+            .into_response());
+    }
+
     // Prepare template
     let (
         alliances,
@@ -74,7 +90,23 @@ pub(crate) async fn page(
     Ok((
         [(CACHE_CONTROL, CACHE_CONTROL_PRIVATE_NO_STORE)],
         Html(template.render()?),
-    ))
+    )
+        .into_response())
+}
+
+fn accepts_markdown(headers: &HeaderMap) -> bool {
+    headers
+        .get(ACCEPT)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value.split(',').any(|media_type| {
+                media_type
+                    .trim()
+                    .split(';')
+                    .next()
+                    .is_some_and(|media_type| media_type.eq_ignore_ascii_case("text/markdown"))
+            })
+        })
 }
 
 async fn load_latest_feed(

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -382,6 +382,25 @@ pub(crate) async fn setup(
         .route("/explore/groups/search", get(site::explore::search_groups))
         .route("/favicon.ico", get(favicon))
         .route("/health-check", get(health_check))
+        .route("/robots.txt", get(site::agent_discovery::robots))
+        .route("/sitemap.xml", get(site::agent_discovery::sitemap))
+        .route("/openapi.yaml", get(site::agent_discovery::openapi))
+        .route(
+            "/.well-known/api-catalog",
+            get(site::agent_discovery::api_catalog),
+        )
+        .route(
+            "/.well-known/mcp/server-card.json",
+            get(site::agent_discovery::mcp_server_card),
+        )
+        .route(
+            "/.well-known/agent-skills/index.json",
+            get(site::agent_discovery::agent_skills_index),
+        )
+        .route(
+            "/.well-known/agent-skills/goup-mcp/SKILL.md",
+            get(site::agent_discovery::mcp_skill),
+        )
         .route("/images/og/{file_name}", get(images::serve_open_graph))
         .route("/images/{file_name}", get(images::serve))
         .route("/log-in", get(auth::log_in_page))
@@ -490,6 +509,7 @@ pub(crate) async fn setup(
             state.clone(),
             redirect_old_hosts,
         ))
+        .layer(middleware::from_fn(add_agent_discovery_links))
         .layer(middleware::from_fn(refresh_stale_clients));
 
     Ok(router.with_state(state))
@@ -601,6 +621,31 @@ async fn refresh_stale_clients(request: Request, next: Next) -> impl IntoRespons
     let mut response = next.run(request).await.into_response();
     insert_commit_sha_header(response.headers_mut());
 
+    response
+}
+
+/// Advertises public machine-readable resources on HTML responses.
+async fn add_agent_discovery_links(request: Request, next: Next) -> impl IntoResponse {
+    let mut response = next.run(request).await.into_response();
+    let is_html = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("text/html"));
+    if is_html {
+        let headers = response.headers_mut();
+        let link = HeaderName::from_static("link");
+        for value in [
+            "</.well-known/api-catalog>; rel=\"api-catalog\"",
+            "</openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\"",
+            "</docs/api>; rel=\"service-doc\"",
+            "</sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\"",
+            "</.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"",
+            "</.well-known/agent-skills/index.json>; rel=\"agent-skills\"",
+        ] {
+            headers.append(link.clone(), HeaderValue::from_static(value));
+        }
+    }
     response
 }
 

--- a/ocg-server/src/router/tests.rs
+++ b/ocg-server/src/router/tests.rs
@@ -6,7 +6,8 @@ use axum::{
 use tower::ServiceExt;
 
 use crate::{
-    db::mock::MockDB, handlers::tests::*, services::notifications::MockNotificationsManager,
+    config::HttpServerConfig, db::mock::MockDB, handlers::tests::*,
+    services::notifications::MockNotificationsManager,
 };
 
 use super::*;
@@ -196,6 +197,132 @@ async fn test_health_check_returns_ok() {
     // Check response matches expectations
     assert_eq!(parts.status, StatusCode::OK);
     assert!(to_bytes(body, usize::MAX).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_agent_discovery_resources_are_machine_readable() {
+    let db = MockDB::new();
+    let nm = MockNotificationsManager::new();
+    let router = TestRouterBuilder::new(db, nm)
+        .with_server_cfg(HttpServerConfig {
+            base_url: "https://goup.vc".to_string(),
+            ..HttpServerConfig::default()
+        })
+        .build()
+        .await;
+
+    let robots = router
+        .clone()
+        .oneshot(Request::builder().uri("/robots.txt").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let (parts, body) = robots.into_parts();
+    assert_eq!(parts.status, StatusCode::OK);
+    assert_eq!(
+        parts.headers.get(CONTENT_TYPE).unwrap(),
+        "text/plain; charset=utf-8"
+    );
+    let body = String::from_utf8(to_bytes(body, usize::MAX).await.unwrap().to_vec()).unwrap();
+    assert!(body.contains("User-agent: GPTBot"));
+    assert!(body.contains("Content-Signal: ai-train=no, search=yes, ai-input=no"));
+    assert!(body.contains("Sitemap: https://goup.vc/sitemap.xml"));
+
+    let sitemap = router
+        .clone()
+        .oneshot(Request::builder().uri("/sitemap.xml").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let (parts, body) = sitemap.into_parts();
+    assert_eq!(parts.status, StatusCode::OK);
+    assert_eq!(
+        parts.headers.get(CONTENT_TYPE).unwrap(),
+        "application/xml; charset=utf-8"
+    );
+    let body = String::from_utf8(to_bytes(body, usize::MAX).await.unwrap().to_vec()).unwrap();
+    assert!(body.contains("<loc>https://goup.vc/docs</loc>"));
+
+    let catalog = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/api-catalog")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (parts, body) = catalog.into_parts();
+    assert_eq!(parts.status, StatusCode::OK);
+    assert_eq!(
+        parts.headers.get(CONTENT_TYPE).unwrap(),
+        "application/linkset+json; charset=utf-8"
+    );
+    let body = String::from_utf8(to_bytes(body, usize::MAX).await.unwrap().to_vec()).unwrap();
+    assert!(body.contains("https://goup.vc/openapi.yaml"));
+    assert!(body.contains("https://goup.vc/api/v1/health"));
+
+    let skills = router
+        .oneshot(
+            Request::builder()
+                .uri("/.well-known/agent-skills/index.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(skills.status(), StatusCode::OK);
+    assert_eq!(
+        skills.headers().get(CONTENT_TYPE).unwrap(),
+        "application/json; charset=utf-8"
+    );
+}
+
+#[tokio::test]
+async fn test_homepage_markdown_response_and_discovery_links() {
+    let db = MockDB::new();
+    let nm = MockNotificationsManager::new();
+    let router = TestRouterBuilder::new(db, nm).build().await;
+
+    let markdown = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("Accept", "text/markdown")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let (parts, body) = markdown.into_parts();
+    assert_eq!(parts.status, StatusCode::OK);
+    assert_eq!(
+        parts.headers.get(CONTENT_TYPE).unwrap(),
+        "text/markdown; charset=utf-8"
+    );
+    assert_eq!(parts.headers.get("vary").unwrap(), "Accept");
+    let body = String::from_utf8(to_bytes(body, usize::MAX).await.unwrap().to_vec()).unwrap();
+    assert!(body.starts_with("# GOUP Alliance"));
+
+    let html_router = Router::new()
+        .route("/", get(|| async { axum::response::Html("homepage") }))
+        .layer(middleware::from_fn(add_agent_discovery_links));
+    let html = html_router
+        .oneshot(
+            Request::builder()
+                .uri("/")
+                .header("Accept", "text/html")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(html.status(), StatusCode::OK);
+    assert!(html.headers().get_all("link").iter().any(|value| {
+        value
+            .to_str()
+            .is_ok_and(|value| value.contains("/.well-known/api-catalog"))
+    }));
 }
 
 #[tokio::test]

--- a/scripts/nginx-goup.conf
+++ b/scripts/nginx-goup.conf
@@ -18,6 +18,11 @@ upstream goup_ocg_server {
     keepalive 16;
 }
 
+upstream goup_mcp {
+    server 127.0.0.1:8787;
+    keepalive 8;
+}
+
 server {
     listen 80;
     server_name goup.vc www.goup.vc;
@@ -75,6 +80,17 @@ server {
 
         expires 1y;
         add_header Cache-Control "public, immutable";
+    }
+
+    # The MCP server enforces bearer-token authentication itself.
+    location = /mcp {
+        proxy_pass http://goup_mcp/mcp;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- publish crawler policy, sitemap, API catalog, MCP metadata, and Agent Skills discovery routes
- add agent-discovery Link headers and a Markdown homepage representation
- proxy the bearer-protected MCP endpoint through nginx and require its token at startup

## Test plan
- [x] `cargo check --manifest-path Cargo.toml -p ocg-server`
- [x] `cargo fmt --manifest-path Cargo.toml --all -- --check`
- [x] `node --check mcp/server.mjs`
- [ ] Targeted Rust test build is blocked by an existing `TemplateUser` fixture missing fields in `ocg-server/src/handlers/tests.rs`

Made with [Cursor](https://cursor.com)