### PR TITLE
fix: scope You.com discovery searches to source domains

### DIFF
--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -121,14 +121,21 @@ pub(crate) fn unique_baku_results(results: Vec<SearchResult>) -> Vec<SearchResul
 
 /// Validates a source URL entered in a group dashboard.
 pub(crate) fn validate_source_url(url: &str) -> Result<()> {
+    source_search_domain(url).map(|_| ())
+}
+
+/// Returns the hostname suitable for a You.com `site:` search operator.
+///
+/// Dashboard sources are full URLs, while `site:` accepts only a domain.
+pub(crate) fn source_search_domain(url: &str) -> Result<String> {
     let parsed = reqwest::Url::parse(url).context("source URL must be absolute")?;
     if !matches!(parsed.scheme(), "http" | "https") {
         bail!("source URL must use HTTP or HTTPS");
     }
-    if parsed.host_str().is_none() {
-        bail!("source URL must include a host");
-    }
-    Ok(())
+    parsed
+        .host_str()
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("source URL must include a host"))
 }
 
 #[cfg(test)]
@@ -153,6 +160,15 @@ mod tests {
             result("Tbilisi meetup", "https://example.test/events/2", None),
         ]);
         assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn extracts_search_domain_from_source_url() {
+        assert_eq!(
+            source_search_domain("https://careers.example.com/open-roles?team=engineering")
+                .unwrap(),
+            "careers.example.com"
+        );
     }
 
     #[test]

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -13,7 +13,9 @@ use uuid::Uuid;
 use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, dashboard::group::DBDashboardGroup},
-    integrations::you_com::{DiscoveredEvent, SearchResult, YouComClient, unique_baku_results},
+    integrations::you_com::{
+        DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_baku_results,
+    },
 };
 
 /// Executes authorized, on-demand discovery runs from the dashboard.
@@ -168,9 +170,10 @@ async fn ingest_sources(
     let mut counts = std::collections::HashMap::<Uuid, (i32, i32)>::new();
     let result = async {
     for source in sources {
+        let search_domain = source_search_domain(&source.url)?;
         let results = unique_baku_results(
             client
-                .search(&format!("Baku Azerbaijan events site:{}", source.url))
+                .search(&format!("Baku Azerbaijan events site:{search_domain}"))
                 .await?,
         );
         for result in results {

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, jobs::DBJobs},
-    integrations::you_com::{SearchResult, YouComClient},
+    integrations::you_com::{SearchResult, YouComClient, source_search_domain},
     types::jobs::JobInput,
 };
 
@@ -112,7 +112,11 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
             let mut created = 0;
             for source_url in sources {
                 let mut seen = HashSet::new();
-                for result in client.search(&format!("jobs hiring careers site:{source_url}")).await? {
+                let search_domain = source_search_domain(&source_url)?;
+                for result in client
+                    .search(&format!("jobs hiring careers site:{search_domain}"))
+                    .await?
+                {
                     let Some(input) = parse_discovered_job(&result) else { continue };
                     if !seen.insert(result.url.trim().to_lowercase()) { continue; }
                     let fingerprint = fingerprint(&input, &result.url);


### PR DESCRIPTION
## Summary
- extract the hostname from approved job and event source URLs before building You.com `site:` queries
- keep source URL validation centralized and cover hostname extraction with a unit test

## Test plan
- [x] `cargo fmt --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/Cargo.toml --all`
- [x] `cargo check --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/Cargo.toml -p ocg-server`
- [ ] `cargo test --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/Cargo.toml -p ocg-server you_com` (blocked by pre-existing missing `TemplateUser` fields in `handlers/tests.rs`)

Made with [Cursor](https://cursor.com)