### PR TITLE
fix: reject generic job discovery landing pages

### DIFF
--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -171,6 +171,9 @@ fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
         .split_once(" at ")
         .or_else(|| title.split_once(" - "))
         .filter(|(role, company)| !role.trim().is_empty() && !company.trim().is_empty())?;
+    if is_generic_job_page(title) {
+        return None;
+    }
     let summary: String = description.chars().take(280).collect();
     let input = JobInput {
         title: title.trim().to_owned(),
@@ -185,6 +188,28 @@ fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
     };
     input.validate().ok()?;
     Some(input)
+}
+
+/// Reject search, index, and landing-page titles that do not identify a role.
+fn is_generic_job_page(role: &str) -> bool {
+    const GENERIC_PREFIXES: &[&str] = &[
+        "career opportunities",
+        "job opportunities",
+        "search results",
+        "search result",
+        "search jobs",
+        "job search",
+        "find jobs",
+        "careers",
+        "jobs",
+    ];
+
+    let normalized = role.trim().to_ascii_lowercase();
+    GENERIC_PREFIXES.iter().any(|prefix| {
+        normalized == *prefix
+            || normalized.starts_with(&format!("{prefix} |"))
+            || normalized.starts_with(&format!("{prefix}:"))
+    })
 }
 
 fn fingerprint(input: &JobInput, apply_url: &str) -> String {
@@ -235,5 +260,15 @@ mod tests {
         })
         .unwrap();
         assert_eq!(job.company_name, "Acme");
+    }
+
+    #[test]
+    fn rejects_search_result_landing_pages() {
+        let job = parse_discovered_job(&SearchResult {
+            title: "Search Results | Find available job openings - BCG Careers".into(),
+            url: "https://careers.bcg.com/search-results".into(),
+            description: Some("Have questions about careers at BCG?".into()),
+        });
+        assert!(job.is_none());
     }
 }


### PR DESCRIPTION
## Summary
- reject search, careers, and job-index result titles before publishing discovered jobs
- cover the BCG search-results false positive with a regression test

## Test plan
- [x] `cargo fmt --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/Cargo.toml --all`
- [x] `cargo check --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/Cargo.toml -p ocg-server`
- [ ] `cargo test --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/Cargo.toml -p ocg-server job_discovery` (blocked by pre-existing missing `TemplateUser` fields in `handlers/tests.rs`)

Made with [Cursor](https://cursor.com)