### PR TITLE
Add review-first You.com discovery

### DIFF
--- a/database/migrations/schema/0103_discovery_review_queue.sql
+++ b/database/migrations/schema/0103_discovery_review_queue.sql
@@ -1,0 +1,23 @@
+alter table jobs_discovery_item
+    add column if not exists review_status text not null default 'pending'
+        check (review_status in ('pending', 'published', 'rejected')),
+    add column if not exists candidate_url text not null default '',
+    add column if not exists discovered_payload jsonb,
+    add column if not exists reviewed_at timestamptz,
+    add column if not exists reviewed_by uuid references "user"(user_id) on delete set null;
+
+create index if not exists jobs_discovery_item_pending_idx
+    on jobs_discovery_item (user_id, created_at desc)
+    where review_status = 'pending';
+
+alter table group_event_integration_item
+    add column if not exists review_status text not null default 'pending'
+        check (review_status in ('pending', 'published', 'rejected')),
+    add column if not exists candidate_url text not null default '',
+    add column if not exists discovered_payload jsonb,
+    add column if not exists reviewed_at timestamptz,
+    add column if not exists reviewed_by uuid references "user"(user_id) on delete set null;
+
+create index if not exists group_event_integration_item_pending_idx
+    on group_event_integration_item (group_id, created_at desc)
+    where review_status = 'pending';

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -62,6 +62,7 @@ services:
     environment:
       OCG_SERVER_CONFIG: /workspace/.config/ocg/server.yml
       OCG_CONFIG: /workspace/.config/ocg
+      OCG_INTEGRATIONS__YOU_COM__API_KEY: ${YDC_API_KEY:-}
       CARGO_TARGET_DIR: /cargo-target
     depends_on:
       db:

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -73,7 +73,7 @@ graph TD
 
 ### Event discovery (You.com)
 
-`services/event_discovery.rs` runs a scheduled daily worker that queries the You.com search API for Baku community event pages and stores discovered events as drafts in the database. A `ManualEventDiscovery` handle is passed to dashboard handlers for on-demand group-specific runs.
+`services/event_discovery.rs` runs a scheduled daily worker that queries the You.com search API for Baku community event pages, validates structured Event data from approved candidate pages, and stores discovered events as drafts for organizer review. A `ManualEventDiscovery` handle is passed to dashboard handlers for on-demand group-specific runs.
 
 ### Recording publishing
 

--- a/docs/features/jobs.md
+++ b/docs/features/jobs.md
@@ -52,7 +52,8 @@ Group organizers post jobs through the dashboard at `/dashboard/alliance/:allian
 1. Queries the database for user-approved job source configurations (`get_job_sources`).
 2. Calls the You.com search API for each source query.
 3. Validates each result against `JobInput` using `garde`.
-4. Stores new jobs in the database (deduplication is handled by the DB layer).
+4. Fetches approved candidate pages and prefers structured `JobPosting` data over search snippets.
+5. Stores valid jobs as drafts in a review queue; the owner publishes or rejects each candidate.
 
 A `ManualJobDiscovery` handle is injected into dashboard handlers so authorized users can trigger an immediate discovery run without waiting for the next scheduled cycle.
 

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -259,6 +259,20 @@ pub(crate) trait DBDashboardGroup {
         group_id: Uuid,
         source_id: Uuid,
     ) -> Result<()>;
+    /// Publishes a pending discovered event.
+    async fn approve_group_event_discovery_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        item_id: Uuid,
+    ) -> Result<()>;
+    /// Rejects a pending discovered event while retaining its fingerprint.
+    async fn reject_group_event_discovery_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        item_id: Uuid,
+    ) -> Result<()>;
 
     /// Gets a single sponsor from the database.
     async fn get_group_sponsor(
@@ -1093,7 +1107,17 @@ where
                         'completed_at', extract(epoch from r.completed_at)::bigint
                     ) from group_event_integration_run r
                     where r.group_id = $1 order by r.started_at desc limit 1
-                )
+                ),
+                'pending_items', coalesce((
+                    select jsonb_agg(jsonb_build_object(
+                        'group_event_integration_item_id', d.group_event_integration_item_id,
+                        'event_id', e.event_id, 'title', e.name,
+                        'source_url', d.candidate_url
+                    ) order by d.created_at desc)
+                    from group_event_integration_item d
+                    join event e using (event_id)
+                    where d.group_id = $1 and d.review_status = 'pending'
+                ), '[]'::jsonb)
             ) from (select 1) x left join group_event_integration i on i.group_id = $1",
             &[&group_id],
         )
@@ -1147,6 +1171,44 @@ where
             &[&group_id, &source_id],
         )
         .await
+    }
+
+    async fn approve_group_event_discovery_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        item_id: Uuid,
+    ) -> Result<()> {
+        let event_id: Uuid = self
+            .fetch_scalar_one(
+                "update group_event_integration_item
+                 set review_status = 'published', reviewed_at = now(), reviewed_by = $1
+                 where group_event_integration_item_id = $2 and group_id = $3
+                   and review_status = 'pending' and event_id is not null
+                 returning event_id",
+                &[&actor_user_id, &item_id, &group_id],
+            )
+            .await?;
+        self.publish_event(actor_user_id, None, group_id, event_id).await
+    }
+
+    async fn reject_group_event_discovery_item(
+        &self,
+        actor_user_id: Uuid,
+        group_id: Uuid,
+        item_id: Uuid,
+    ) -> Result<()> {
+        let event_id: Uuid = self
+            .fetch_scalar_one(
+                "update group_event_integration_item
+                 set review_status = 'rejected', reviewed_at = now(), reviewed_by = $1
+                 where group_event_integration_item_id = $2 and group_id = $3
+                   and review_status = 'pending' and event_id is not null
+                 returning event_id",
+                &[&actor_user_id, &item_id, &group_id],
+            )
+            .await?;
+        self.delete_event(actor_user_id, group_id, event_id).await
     }
 
     /// [`DBDashboardGroup::get_group_sponsor`]

--- a/ocg-server/src/db/jobs.rs
+++ b/ocg-server/src/db/jobs.rs
@@ -63,6 +63,10 @@ pub(crate) trait DBJobs {
     async fn add_job_discovery_source(&self, user_id: Uuid, url: &str) -> Result<Uuid>;
     /// Delete a source URL owned by the current user.
     async fn delete_job_discovery_source(&self, user_id: Uuid, source_id: Uuid) -> Result<()>;
+    /// Publishes a pending discovered job.
+    async fn approve_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()>;
+    /// Rejects a pending discovered job while retaining its fingerprint.
+    async fn reject_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()>;
 }
 
 #[async_trait]
@@ -170,7 +174,16 @@ where
                 'latest_run', (select jsonb_build_object('status', r.status,
                     'discovered_count', r.discovered_count, 'created_count', r.created_count,
                     'error_message', r.error_message) from jobs_discovery_run r
-                    where r.user_id = $1 order by r.started_at desc limit 1)
+                    where r.user_id = $1 order by r.started_at desc limit 1),
+                'pending_items', coalesce((select jsonb_agg(jsonb_build_object(
+                    'jobs_discovery_item_id', d.jobs_discovery_item_id,
+                    'job_id', j.job_id, 'title', j.title, 'company_name', j.company_name,
+                    'apply_url', j.apply_url
+                ) order by d.created_at desc)
+                    from jobs_discovery_item d
+                    join jobs_job j using (job_id)
+                    where d.user_id = $1 and d.review_status = 'pending'
+                ), '[]'::jsonb)
             ) from (select 1) x left join jobs_discovery_integration i on i.user_id = $1",
             &[&user_id],
         )
@@ -205,5 +218,33 @@ where
         )
         .await?;
         Ok(())
+    }
+
+    async fn approve_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()> {
+        let job_id: Uuid = self
+            .fetch_scalar_one(
+                "update jobs_discovery_item
+                 set review_status = 'published', reviewed_at = now(), reviewed_by = $1
+                 where jobs_discovery_item_id = $2 and user_id = $1
+                   and review_status = 'pending' and job_id is not null
+                 returning job_id",
+                &[&user_id, &item_id],
+            )
+            .await?;
+        self.update_job_published(user_id, job_id, true).await
+    }
+
+    async fn reject_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()> {
+        let job_id: Uuid = self
+            .fetch_scalar_one(
+                "update jobs_discovery_item
+                 set review_status = 'rejected', reviewed_at = now(), reviewed_by = $1
+                 where jobs_discovery_item_id = $2 and user_id = $1
+                   and review_status = 'pending' and job_id is not null
+                 returning job_id",
+                &[&user_id, &item_id],
+            )
+            .await?;
+        self.delete_job(user_id, job_id).await
     }
 }

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -639,6 +639,18 @@ mock! {
             group_id: Uuid,
             source_id: Uuid,
         ) -> Result<()>;
+        async fn approve_group_event_discovery_item(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            item_id: Uuid,
+        ) -> Result<()>;
+        async fn reject_group_event_discovery_item(
+            &self,
+            actor_user_id: Uuid,
+            group_id: Uuid,
+            item_id: Uuid,
+        ) -> Result<()>;
         async fn get_group_sponsor(
             &self,
             group_id: Uuid,
@@ -1235,6 +1247,8 @@ mock! {
             user_id: Uuid,
             source_id: Uuid,
         ) -> Result<()>;
+        async fn approve_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()>;
+        async fn reject_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()>;
     }
 
     #[async_trait]

--- a/ocg-server/src/handlers/dashboard/group/integrations.rs
+++ b/ocg-server/src/handlers/dashboard/group/integrations.rs
@@ -2,13 +2,12 @@
 
 use askama::Template;
 use axum::{
-    Json,
     extract::{Path, State},
     http::StatusCode,
     response::{Html, IntoResponse},
 };
 use garde::Validate;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -56,10 +55,6 @@ pub(crate) async fn run(
     Ok((
         StatusCode::ACCEPTED,
         [("HX-Trigger", "event-discovery-run-started")],
-        Json(ManualRunResponse {
-            group_id,
-            status: "accepted",
-        }),
     )
         .into_response())
 }
@@ -125,6 +120,42 @@ pub(crate) async fn delete_source(
     ))
 }
 
+/// Publishes a reviewed discovered event.
+#[instrument(skip_all, err)]
+pub(crate) async fn approve_item(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(item_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.approve_group_event_discovery_item(user.user_id, group_id, item_id)
+        .await?;
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
+/// Rejects a discovered event and keeps its fingerprint from being re-ingested.
+#[instrument(skip_all, err)]
+pub(crate) async fn reject_item(
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    Path(item_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.reject_group_event_discovery_item(user.user_id, group_id, item_id)
+        .await?;
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
 pub(crate) async fn prepare_page(
     db: &DynDB,
     alliance_id: Uuid,
@@ -159,12 +190,6 @@ pub(crate) struct SettingsInput {
 pub(crate) struct SourceInput {
     #[garde(skip)]
     url: String,
-}
-
-#[derive(Debug, Serialize)]
-struct ManualRunResponse {
-    group_id: Uuid,
-    status: &'static str,
 }
 
 fn validate_settings(input: &SettingsInput) -> Result<(), HandlerError> {

--- a/ocg-server/src/handlers/dashboard/jobs.rs
+++ b/ocg-server/src/handlers/dashboard/jobs.rs
@@ -225,6 +225,38 @@ pub(crate) async fn run_discovery(
     ))
 }
 
+/// Publishes a reviewed discovered job.
+#[instrument(skip_all, err)]
+pub(crate) async fn approve_discovery_item(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(item_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.approve_job_discovery_item(user.user_id, item_id).await?;
+    messages.success("Discovered job published.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
+}
+
+/// Rejects a discovered job and keeps its fingerprint from being re-ingested.
+#[instrument(skip_all, err)]
+pub(crate) async fn reject_discovery_item(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    Path(item_id): Path<Uuid>,
+) -> Result<impl IntoResponse, HandlerError> {
+    db.reject_job_discovery_item(user.user_id, item_id).await?;
+    messages.success("Discovered job rejected.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
+}
+
 /// Update a job.
 #[instrument(skip_all, err)]
 pub(crate) async fn update(

--- a/ocg-server/src/handlers/tests.rs
+++ b/ocg-server/src/handlers/tests.rs
@@ -563,6 +563,7 @@ pub(crate) fn sample_dashboard_user_profile(
 
         bio: None,
         bluesky_url: None,
+        coffee_meet_enabled: true,
         company: company.map(str::to_string),
         facebook_url: None,
         github_url: None,
@@ -570,9 +571,11 @@ pub(crate) fn sample_dashboard_user_profile(
         name: name.map(str::to_string),
         photo_url: photo_url.map(str::to_string),
         provider: None,
+        substack_url: None,
         title: title.map(str::to_string),
         twitter_url: None,
         website_url: None,
+        youtube_url: None,
     }
 }
 

--- a/ocg-server/src/integrations.rs
+++ b/ocg-server/src/integrations.rs
@@ -2,4 +2,5 @@
 //!
 //! This module keeps third-party API details outside handlers and domain models.
 
+pub(crate) mod event_page;
 pub(crate) mod you_com;

--- a/ocg-server/src/integrations.rs
+++ b/ocg-server/src/integrations.rs
@@ -3,4 +3,5 @@
 //! This module keeps third-party API details outside handlers and domain models.
 
 pub(crate) mod event_page;
+pub(crate) mod job_page;
 pub(crate) mod you_com;

--- a/ocg-server/src/integrations/event_page.rs
+++ b/ocg-server/src/integrations/event_page.rs
@@ -1,0 +1,274 @@
+//! Safe extraction of structured event metadata from approved discovery sources.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use chrono::{DateTime, Utc};
+use reqwest::{Client, Url, redirect};
+use serde_json::Value;
+
+use crate::integrations::you_com::{DiscoveredEvent, source_search_domain};
+
+const MAX_HTML_BYTES: usize = 1_000_000;
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Fetches structured event metadata without following untrusted redirects.
+#[derive(Clone)]
+pub(crate) struct EventPageClient {
+    http: Client,
+}
+
+impl EventPageClient {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self {
+            http: Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .redirect(redirect::Policy::none())
+                .user_agent("GOUP-event-discovery/1.0")
+                .build()?,
+        })
+    }
+
+    /// Extracts an Event JSON-LD record from a candidate page.
+    pub(crate) async fn fetch(
+        &self,
+        candidate_url: &str,
+        approved_source_url: &str,
+    ) -> Result<Option<DiscoveredEvent>> {
+        validate_candidate_url(candidate_url, approved_source_url).await?;
+        let response = self
+            .http
+            .get(candidate_url)
+            .send()
+            .await
+            .context("requesting event candidate page")?
+            .error_for_status()
+            .context("event candidate page returned an error")?;
+
+        let content_type = response
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default();
+        if !content_type.starts_with("text/html") {
+            return Ok(None);
+        }
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_HTML_BYTES as u64)
+        {
+            return Ok(None);
+        }
+
+        let mut body = Vec::new();
+        let mut response = response;
+        while let Some(chunk) = response.chunk().await.context("reading event candidate page")? {
+            if body.len() + chunk.len() > MAX_HTML_BYTES {
+                return Ok(None);
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let html = String::from_utf8(body).context("event candidate page was not UTF-8")?;
+        Ok(extract_event_json_ld(&html, candidate_url))
+    }
+}
+
+/// Checks that a candidate remains within the organizer-approved public domain.
+pub(crate) async fn validate_candidate_url(
+    candidate_url: &str,
+    approved_source_url: &str,
+) -> Result<()> {
+    let candidate = Url::parse(candidate_url).context("event candidate URL must be absolute")?;
+    if !matches!(candidate.scheme(), "http" | "https") {
+        bail!("event candidate URL must use HTTP or HTTPS");
+    }
+
+    let allowed_domain = source_search_domain(approved_source_url)?;
+    let candidate_host = candidate
+        .host_str()
+        .context("event candidate URL must include a host")?
+        .to_ascii_lowercase();
+    let allowed_domain = allowed_domain.to_ascii_lowercase();
+    if candidate_host != allowed_domain && !candidate_host.ends_with(&format!(".{allowed_domain}"))
+    {
+        bail!("event candidate URL is outside the approved source domain");
+    }
+
+    let port = candidate.port_or_known_default().unwrap_or(443);
+    let addresses: Vec<IpAddr> = tokio::net::lookup_host((candidate_host.as_str(), port))
+        .await
+        .context("resolving event candidate host")?
+        .map(|address| address.ip())
+        .collect();
+    if addresses.is_empty() || addresses.iter().any(|address| !is_public_address(*address)) {
+        bail!("event candidate URL resolves to a non-public address");
+    }
+    Ok(())
+}
+
+fn is_public_address(address: IpAddr) -> bool {
+    match address {
+        IpAddr::V4(address) => {
+            !address.is_private()
+                && !address.is_loopback()
+                && !address.is_link_local()
+                && !address.is_broadcast()
+                && !address.is_unspecified()
+                && !is_documentation_v4(address)
+                && address != Ipv4Addr::new(169, 254, 169, 254)
+        }
+        IpAddr::V6(address) => {
+            !address.is_loopback()
+                && !address.is_unspecified()
+                && !address.is_unicast_link_local()
+                && !address.is_unique_local()
+                && !is_documentation_v6(address)
+                && address != Ipv6Addr::LOCALHOST
+        }
+    }
+}
+
+fn is_documentation_v4(address: Ipv4Addr) -> bool {
+    matches!(
+        address.octets(),
+        [192, 0, 2, _] | [198, 51, 100, _] | [203, 0, 113, _]
+    )
+}
+
+fn is_documentation_v6(address: Ipv6Addr) -> bool {
+    address.segments()[..2] == [0x2001, 0x0db8]
+}
+
+/// Reads schema.org Event JSON-LD scripts from an HTML page.
+pub(crate) fn extract_event_json_ld(html: &str, candidate_url: &str) -> Option<DiscoveredEvent> {
+    json_ld_scripts(html)
+        .filter_map(|json| serde_json::from_str::<Value>(json).ok())
+        .find_map(|value| event_from_json_ld(&value, candidate_url))
+}
+
+fn json_ld_scripts(html: &str) -> impl Iterator<Item = &str> {
+    let mut remaining = html;
+    std::iter::from_fn(move || {
+        loop {
+            let start = remaining.find("<script")?;
+            let after_start = &remaining[start + "<script".len()..];
+            let tag_end = after_start.find('>')?;
+            let attributes = after_start[..tag_end].to_ascii_lowercase();
+            let content = &after_start[tag_end + 1..];
+            let end = content.find("</script>")?;
+            remaining = &content[end + "</script>".len()..];
+            if attributes.contains("type=\"application/ld+json\"")
+                || attributes.contains("type='application/ld+json'")
+            {
+                return Some(&content[..end]);
+            }
+        }
+    })
+}
+
+fn event_from_json_ld(value: &Value, candidate_url: &str) -> Option<DiscoveredEvent> {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .find_map(|value| event_from_json_ld(value, candidate_url)),
+        Value::Object(object) => {
+            if is_event(object.get("@type")) {
+                return event_from_object(object, candidate_url);
+            }
+            object
+                .get("@graph")
+                .and_then(|graph| event_from_json_ld(graph, candidate_url))
+        }
+        _ => None,
+    }
+}
+
+fn is_event(value: Option<&Value>) -> bool {
+    match value {
+        Some(Value::String(kind)) => kind.eq_ignore_ascii_case("Event"),
+        Some(Value::Array(kinds)) => kinds
+            .iter()
+            .any(|kind| kind.as_str().is_some_and(|kind| kind.eq_ignore_ascii_case("Event"))),
+        _ => false,
+    }
+}
+
+fn event_from_object(
+    object: &serde_json::Map<String, Value>,
+    candidate_url: &str,
+) -> Option<DiscoveredEvent> {
+    let title = object.get("name")?.as_str()?.trim();
+    if title.is_empty() || title.len() > 240 {
+        return None;
+    }
+    let starts_at = DateTime::parse_from_rfc3339(object.get("startDate")?.as_str()?)
+        .ok()?
+        .with_timezone(&Utc);
+    if starts_at <= Utc::now() {
+        return None;
+    }
+    let description = object
+        .get("description")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|description| !description.is_empty())
+        .map(str::to_owned);
+
+    Some(DiscoveredEvent {
+        title: title.to_owned(),
+        description,
+        starts_at,
+        source_url: candidate_url.to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_event_from_json_ld_graph() {
+        let event = extract_event_json_ld(
+            r#"<script type="application/ld+json">
+                {"@graph":[{"@type":"Event","name":"Baku Rust meetup","description":"Talks and networking.","startDate":"2099-07-21T19:00:00+04:00"}]}
+            </script>"#,
+            "https://events.example.com/rust-meetup",
+        )
+        .unwrap();
+
+        assert_eq!(event.title, "Baku Rust meetup");
+        assert_eq!(event.source_url, "https://events.example.com/rust-meetup");
+    }
+
+    #[test]
+    fn rejects_event_without_a_timezone() {
+        assert!(
+            extract_event_json_ld(
+                r#"<script type="application/ld+json">{"@type":"Event","name":"Baku meetup","startDate":"2099-07-21T19:00:00"}</script>"#,
+                "https://events.example.com/meetup",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn ignores_non_event_json_ld() {
+        assert!(
+            extract_event_json_ld(
+                r#"<script type="application/ld+json">{"@type":"Organization","name":"GOUP"}</script>"#,
+                "https://events.example.com",
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn rejects_private_addresses() {
+        assert!(!is_public_address(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(!is_public_address(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+        assert!(!is_public_address(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+}

--- a/ocg-server/src/integrations/event_page.rs
+++ b/ocg-server/src/integrations/event_page.rs
@@ -38,6 +38,18 @@ impl EventPageClient {
         candidate_url: &str,
         approved_source_url: &str,
     ) -> Result<Option<DiscoveredEvent>> {
+        let Some(html) = self.fetch_html(candidate_url, approved_source_url).await? else {
+            return Ok(None);
+        };
+        Ok(extract_event_json_ld(&html, candidate_url))
+    }
+
+    /// Fetches an approved candidate page for a structured-data extractor.
+    pub(crate) async fn fetch_html(
+        &self,
+        candidate_url: &str,
+        approved_source_url: &str,
+    ) -> Result<Option<String>> {
         validate_candidate_url(candidate_url, approved_source_url).await?;
         let response = self
             .http
@@ -72,7 +84,7 @@ impl EventPageClient {
             body.extend_from_slice(&chunk);
         }
         let html = String::from_utf8(body).context("event candidate page was not UTF-8")?;
-        Ok(extract_event_json_ld(&html, candidate_url))
+        Ok(Some(html))
     }
 }
 
@@ -92,8 +104,7 @@ pub(crate) async fn validate_candidate_url(
         .context("event candidate URL must include a host")?
         .to_ascii_lowercase();
     let allowed_domain = allowed_domain.to_ascii_lowercase();
-    if candidate_host != allowed_domain && !candidate_host.ends_with(&format!(".{allowed_domain}"))
-    {
+    if !is_approved_host(&candidate_host, &allowed_domain) {
         bail!("event candidate URL is outside the approved source domain");
     }
 
@@ -107,6 +118,17 @@ pub(crate) async fn validate_candidate_url(
         bail!("event candidate URL resolves to a non-public address");
     }
     Ok(())
+}
+
+fn is_approved_host(candidate_host: &str, approved_host: &str) -> bool {
+    candidate_host == approved_host
+        || candidate_host.ends_with(&format!(".{approved_host}"))
+        || approved_host
+            .strip_prefix("www.")
+            .is_some_and(|apex| candidate_host == apex)
+        || candidate_host
+            .strip_prefix("www.")
+            .is_some_and(|apex| apex == approved_host)
 }
 
 fn is_public_address(address: IpAddr) -> bool {
@@ -149,7 +171,7 @@ pub(crate) fn extract_event_json_ld(html: &str, candidate_url: &str) -> Option<D
         .find_map(|value| event_from_json_ld(&value, candidate_url))
 }
 
-fn json_ld_scripts(html: &str) -> impl Iterator<Item = &str> {
+pub(crate) fn json_ld_scripts(html: &str) -> impl Iterator<Item = &str> {
     let mut remaining = html;
     std::iter::from_fn(move || {
         loop {
@@ -270,5 +292,13 @@ mod tests {
         assert!(!is_public_address(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
         assert!(!is_public_address(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
         assert!(!is_public_address(IpAddr::V6(Ipv6Addr::LOCALHOST)));
+    }
+
+    #[test]
+    fn accepts_apex_and_www_equivalents() {
+        assert!(is_approved_host("example.com", "www.example.com"));
+        assert!(is_approved_host("www.example.com", "example.com"));
+        assert!(is_approved_host("events.example.com", "example.com"));
+        assert!(!is_approved_host("events.example.com", "www.example.com"));
     }
 }

--- a/ocg-server/src/integrations/job_page.rs
+++ b/ocg-server/src/integrations/job_page.rs
@@ -1,0 +1,116 @@
+//! Structured JobPosting extraction from safely fetched candidate pages.
+
+use anyhow::Result;
+use garde::Validate;
+use serde_json::Value;
+
+use crate::{
+    integrations::event_page::{EventPageClient, json_ld_scripts},
+    types::jobs::JobInput,
+};
+
+#[derive(Clone)]
+pub(crate) struct JobPageClient {
+    pages: EventPageClient,
+}
+
+impl JobPageClient {
+    pub(crate) fn new() -> Result<Self> {
+        Ok(Self {
+            pages: EventPageClient::new()?,
+        })
+    }
+
+    pub(crate) async fn fetch(
+        &self,
+        candidate_url: &str,
+        approved_source_url: &str,
+    ) -> Result<Option<JobInput>> {
+        let Some(html) = self.pages.fetch_html(candidate_url, approved_source_url).await? else {
+            return Ok(None);
+        };
+        Ok(extract_job_json_ld(&html, candidate_url))
+    }
+}
+
+pub(crate) fn extract_job_json_ld(html: &str, candidate_url: &str) -> Option<JobInput> {
+    json_ld_scripts(html)
+        .filter_map(|json| serde_json::from_str::<Value>(json).ok())
+        .find_map(|value| job_from_json_ld(&value, candidate_url))
+}
+
+fn job_from_json_ld(value: &Value, candidate_url: &str) -> Option<JobInput> {
+    match value {
+        Value::Array(values) => {
+            values.iter().find_map(|value| job_from_json_ld(value, candidate_url))
+        }
+        Value::Object(object) => {
+            if is_job_posting(object.get("@type")) {
+                return job_from_object(object, candidate_url);
+            }
+            object
+                .get("@graph")
+                .and_then(|graph| job_from_json_ld(graph, candidate_url))
+        }
+        _ => None,
+    }
+}
+
+fn is_job_posting(value: Option<&Value>) -> bool {
+    match value {
+        Some(Value::String(kind)) => kind.rsplit('/').next() == Some("JobPosting"),
+        Some(Value::Array(kinds)) => kinds.iter().any(|kind| is_job_posting(Some(kind))),
+        _ => false,
+    }
+}
+
+fn job_from_object(
+    object: &serde_json::Map<String, Value>,
+    candidate_url: &str,
+) -> Option<JobInput> {
+    let title = object.get("title").or_else(|| object.get("name"))?.as_str()?.trim();
+    let company_name = object.get("hiringOrganization")?.get("name")?.as_str()?.trim();
+    let description = object.get("description")?.as_str()?.trim();
+    let location = object
+        .get("jobLocation")
+        .and_then(|value| value.get("address"))
+        .and_then(|value| value.get("addressLocality"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+    let remote = object
+        .get("jobLocationType")
+        .and_then(Value::as_str)
+        .is_some_and(|value| value.eq_ignore_ascii_case("TELECOMMUTE"));
+    let input = JobInput {
+        title: title.to_owned(),
+        company_name: company_name.to_owned(),
+        summary: description.chars().take(280).collect(),
+        description: description.to_owned(),
+        apply_url: candidate_url.to_owned(),
+        location,
+        remote: Some(remote),
+        members_only: Some(false),
+        tags: None,
+    };
+    input.validate().ok().map(|_| input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_job_posting_from_json_ld() {
+        let job = extract_job_json_ld(
+            r#"<script type="application/ld+json">{
+              "@type":"JobPosting","title":"Rust Engineer","description":"Build reliable systems.",
+              "hiringOrganization":{"name":"Acme"},"jobLocationType":"TELECOMMUTE"
+            }</script>"#,
+            "https://jobs.example.com/roles/rust-engineer",
+        )
+        .unwrap();
+        assert_eq!(job.title, "Rust Engineer");
+        assert_eq!(job.company_name, "Acme");
+        assert_eq!(job.remote, Some(true));
+    }
+}

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -121,14 +121,21 @@ pub(crate) fn unique_baku_results(results: Vec<SearchResult>) -> Vec<SearchResul
 
 /// Validates a source URL entered in a group dashboard.
 pub(crate) fn validate_source_url(url: &str) -> Result<()> {
+    source_search_domain(url).map(|_| ())
+}
+
+/// Returns the hostname suitable for a You.com `site:` search operator.
+///
+/// Dashboard sources are full URLs, while `site:` accepts only a domain.
+pub(crate) fn source_search_domain(url: &str) -> Result<String> {
     let parsed = reqwest::Url::parse(url).context("source URL must be absolute")?;
     if !matches!(parsed.scheme(), "http" | "https") {
         bail!("source URL must use HTTP or HTTPS");
     }
-    if parsed.host_str().is_none() {
-        bail!("source URL must include a host");
-    }
-    Ok(())
+    parsed
+        .host_str()
+        .map(str::to_owned)
+        .ok_or_else(|| anyhow::anyhow!("source URL must include a host"))
 }
 
 #[cfg(test)]
@@ -153,6 +160,15 @@ mod tests {
             result("Tbilisi meetup", "https://example.test/events/2", None),
         ]);
         assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn extracts_search_domain_from_source_url() {
+        assert_eq!(
+            source_search_domain("https://careers.example.com/open-roles?team=engineering")
+                .unwrap(),
+            "careers.example.com"
+        );
     }
 
     #[test]

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -81,6 +81,8 @@ pub(crate) struct SearchResult {
     pub url: String,
     #[serde(default, alias = "snippet", alias = "description")]
     pub description: Option<String>,
+    #[serde(default)]
+    pub snippets: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -97,24 +99,29 @@ struct SearchResults {
     news: Vec<SearchResult>,
 }
 
-/// Rejects pages that do not identify Baku or Azerbaijan.
-pub(crate) fn is_baku_relevant(result: &SearchResult) -> bool {
+/// Rejects pages that do not identify the group's configured city.
+pub(crate) fn is_city_relevant(result: &SearchResult, city: &str) -> bool {
+    let city = city.trim().to_lowercase();
+    if city.is_empty() {
+        return false;
+    }
     let text = format!(
-        "{} {} {}",
+        "{} {} {} {}",
         result.title,
         result.description.as_deref().unwrap_or_default(),
+        result.snippets.join(" "),
         result.url
     )
     .to_lowercase();
-    text.contains("baku") || text.contains("azerbaijan") || text.contains("azərbaycan")
+    text.contains(&city)
 }
 
-/// Returns unique, relevant results while preserving discovery order.
-pub(crate) fn unique_baku_results(results: Vec<SearchResult>) -> Vec<SearchResult> {
+/// Returns unique results relevant to the configured city while preserving discovery order.
+pub(crate) fn unique_city_results(results: Vec<SearchResult>, city: &str) -> Vec<SearchResult> {
     let mut urls = HashSet::new();
     results
         .into_iter()
-        .filter(is_baku_relevant)
+        .filter(|result| is_city_relevant(result, city))
         .filter(|result| urls.insert(result.url.trim().to_lowercase()))
         .collect()
 }
@@ -149,16 +156,28 @@ mod tests {
             title: title.into(),
             url: url.into(),
             description: description.map(str::to_owned),
+            snippets: vec![],
         }
     }
 
     #[test]
-    fn retains_unique_baku_results() {
-        let results = unique_baku_results(vec![
-            result("Baku Rust meetup", "https://example.test/events/1", None),
-            result("Baku Rust meetup", "https://example.test/events/1", None),
-            result("Tbilisi meetup", "https://example.test/events/2", None),
-        ]);
+    fn retains_unique_results_for_configured_city() {
+        let results = unique_city_results(
+            vec![
+                result(
+                    "San Francisco Rust meetup",
+                    "https://example.test/events/1",
+                    None,
+                ),
+                result(
+                    "San Francisco Rust meetup",
+                    "https://example.test/events/1",
+                    None,
+                ),
+                result("Tbilisi meetup", "https://example.test/events/2", None),
+            ],
+            "San Francisco",
+        );
         assert_eq!(results.len(), 1);
     }
 

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -316,6 +316,14 @@ pub(crate) async fn setup(
             post(crate::handlers::dashboard::jobs::run_discovery),
         )
         .route(
+            "/dashboard/jobs/discovery/items/{item_id}/approve",
+            post(crate::handlers::dashboard::jobs::approve_discovery_item),
+        )
+        .route(
+            "/dashboard/jobs/discovery/items/{item_id}/reject",
+            post(crate::handlers::dashboard::jobs::reject_discovery_item),
+        )
+        .route(
             "/dashboard/jobs/mock-interviews/{request_id}/match",
             post(crate::handlers::dashboard::jobs::upsert_mock_interview_match),
         )

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -354,6 +354,14 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             post(dashboard::group::integrations::run),
         )
         .route(
+            "/integrations/items/{item_id}/approve",
+            post(dashboard::group::integrations::approve_item),
+        )
+        .route(
+            "/integrations/items/{item_id}/reject",
+            post(dashboard::group::integrations::reject_item),
+        )
+        .route(
             "/integrations/sources",
             post(dashboard::group::integrations::add_source),
         )

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -13,8 +13,11 @@ use uuid::Uuid;
 use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, dashboard::group::DBDashboardGroup},
-    integrations::you_com::{
-        DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_baku_results,
+    integrations::{
+        event_page::{EventPageClient, validate_candidate_url},
+        you_com::{
+            DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_baku_results,
+        },
     },
 };
 
@@ -169,6 +172,7 @@ async fn ingest_sources(
 
     let mut counts = std::collections::HashMap::<Uuid, (i32, i32)>::new();
     let result = async {
+    let event_pages = EventPageClient::new()?;
     for source in sources {
         let search_domain = source_search_domain(&source.url)?;
         let results = unique_baku_results(
@@ -177,9 +181,18 @@ async fn ingest_sources(
                 .await?,
         );
         for result in results {
-            let Some(event) = parse_discovered_event(&result, &source.url) else {
+            if let Err(err) = validate_candidate_url(&result.url, &source.url).await {
+                info!(%err, candidate_url = %result.url, source_url = %source.url, "skipped unsafe event discovery candidate");
                 continue;
+            }
+            let event = match event_pages.fetch(&result.url, &source.url).await {
+                Ok(event) => event.or_else(|| parse_discovered_event(&result, &result.url)),
+                Err(err) => {
+                    info!(%err, candidate_url = %result.url, "could not enrich event discovery candidate");
+                    parse_discovered_event(&result, &result.url)
+                }
             };
+            let Some(event) = event else { continue };
             let fingerprint = event.fingerprint();
             let inserted: Option<Uuid> = db
                 .fetch_scalar_opt(

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -13,7 +13,9 @@ use uuid::Uuid;
 use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, dashboard::group::DBDashboardGroup},
-    integrations::you_com::{DiscoveredEvent, SearchResult, YouComClient, unique_baku_results},
+    integrations::you_com::{
+        DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_baku_results,
+    },
 };
 
 /// Executes authorized, on-demand discovery runs from the dashboard.
@@ -168,9 +170,10 @@ async fn ingest_sources(
     let mut counts = std::collections::HashMap::<Uuid, (i32, i32)>::new();
     let result = async {
     for source in sources {
+        let search_domain = source_search_domain(&source.url)?;
         let results = unique_baku_results(
             client
-                .search(&format!("Baku Azerbaijan events site:{}", source.url))
+                .search(&format!("Baku Azerbaijan events site:{search_domain}"))
                 .await?,
         );
         for result in results {

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Datelike, TimeZone, Timelike, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::time::sleep;
+use tokio_postgres::types::Json;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{error, info};
 use uuid::Uuid;
@@ -16,7 +17,7 @@ use crate::{
     integrations::{
         event_page::{EventPageClient, validate_candidate_url},
         you_com::{
-            DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_baku_results,
+            DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_city_results,
         },
     },
 };
@@ -172,13 +173,18 @@ async fn ingest_sources(
 
     let mut counts = std::collections::HashMap::<Uuid, (i32, i32)>::new();
     let result = async {
+    anyhow::ensure!(
+        !sources.is_empty(),
+        "no enabled event discovery sources are configured"
+    );
     let event_pages = EventPageClient::new()?;
     for source in sources {
         let search_domain = source_search_domain(&source.url)?;
-        let results = unique_baku_results(
+        let results = unique_city_results(
             client
-                .search(&format!("Baku Azerbaijan events site:{search_domain}"))
+                .search(&format!("{} events site:{search_domain}", source.city))
                 .await?,
+            &source.city,
         );
         for result in results {
             if let Err(err) = validate_candidate_url(&result.url, &source.url).await {
@@ -196,10 +202,17 @@ async fn ingest_sources(
             let fingerprint = event.fingerprint();
             let inserted: Option<Uuid> = db
                 .fetch_scalar_opt(
-                    "insert into group_event_integration_item (group_id, source_url, fingerprint)
-                     values ($1, $2, $3) on conflict (group_id, fingerprint) do nothing
+                    "insert into group_event_integration_item (
+                        group_id, source_url, candidate_url, fingerprint, discovered_payload
+                     ) values ($1, $2, $3, $4, $5) on conflict (group_id, fingerprint) do nothing
                      returning group_event_integration_item_id",
-                    &[&source.group_id, &source.url, &fingerprint],
+                    &[
+                        &source.group_id,
+                        &source.url,
+                        &event.source_url,
+                        &fingerprint,
+                        &Json(&event),
+                    ],
                 )
                 .await?;
             if inserted.is_none() {
@@ -207,7 +220,7 @@ async fn ingest_sources(
             }
             let count = counts.entry(source.group_id).or_default();
             count.0 += 1;
-            if let Some(event_id) = create_and_publish_event(db, &source, &event).await? {
+            if let Some(event_id) = create_draft_event(db, &source, &event).await? {
                 db.execute(
                     "update group_event_integration_item set event_id = $1
                      where group_id = $2 and fingerprint = $3",
@@ -292,8 +305,8 @@ fn parse_discovered_event(result: &SearchResult, source_url: &str) -> Option<Dis
     })
 }
 
-/// Creates from an organizer-configured event-default payload, never guessed fields.
-async fn create_and_publish_event(
+/// Creates an organizer-owned event draft from configured defaults.
+async fn create_draft_event(
     db: &PgDB,
     source: &Source,
     discovered: &DiscoveredEvent,
@@ -338,8 +351,6 @@ async fn create_and_publish_event(
             &Default::default(),
         )
         .await?;
-    db.publish_event(source.created_by_user_id, None, source.group_id, event_id)
-        .await?;
     Ok(Some(event_id))
 }
 
@@ -375,6 +386,7 @@ mod tests {
             title: "Baku Rust meetup".into(),
             url: "https://example.test/event".into(),
             description: Some("Join us next Thursday in Baku".into()),
+            snippets: vec![],
         };
         assert!(parse_discovered_event(&result, "https://example.test").is_none());
     }
@@ -385,6 +397,7 @@ mod tests {
             title: "Baku Rust meetup".into(),
             url: "https://example.test/event".into(),
             description: Some("Starts 2099-07-21T12:00:00Z in Baku".into()),
+            snippets: vec![],
         };
         let event = parse_discovered_event(&result, "https://example.test").unwrap();
         assert_eq!(event.title, "Baku Rust meetup");

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, jobs::DBJobs},
-    integrations::you_com::{SearchResult, YouComClient},
+    integrations::you_com::{SearchResult, YouComClient, source_search_domain},
     types::jobs::JobInput,
 };
 
@@ -112,7 +112,11 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
             let mut created = 0;
             for source_url in sources {
                 let mut seen = HashSet::new();
-                for result in client.search(&format!("jobs hiring careers site:{source_url}")).await? {
+                let search_domain = source_search_domain(&source_url)?;
+                for result in client
+                    .search(&format!("jobs hiring careers site:{search_domain}"))
+                    .await?
+                {
                     let Some(input) = parse_discovered_job(&result) else { continue };
                     if !seen.insert(result.url.trim().to_lowercase()) { continue; }
                     let fingerprint = fingerprint(&input, &result.url);

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -175,9 +175,6 @@ fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
         .split_once(" at ")
         .or_else(|| title.split_once(" - "))
         .filter(|(role, company)| !role.trim().is_empty() && !company.trim().is_empty())?;
-    if is_generic_job_page(title) {
-        return None;
-    }
     let summary: String = description.chars().take(280).collect();
     let input = JobInput {
         title: title.trim().to_owned(),
@@ -192,28 +189,6 @@ fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
     };
     input.validate().ok()?;
     Some(input)
-}
-
-/// Reject search, index, and landing-page titles that do not identify a role.
-fn is_generic_job_page(role: &str) -> bool {
-    const GENERIC_PREFIXES: &[&str] = &[
-        "career opportunities",
-        "job opportunities",
-        "search results",
-        "search result",
-        "search jobs",
-        "job search",
-        "find jobs",
-        "careers",
-        "jobs",
-    ];
-
-    let normalized = role.trim().to_ascii_lowercase();
-    GENERIC_PREFIXES.iter().any(|prefix| {
-        normalized == *prefix
-            || normalized.starts_with(&format!("{prefix} |"))
-            || normalized.starts_with(&format!("{prefix}:"))
-    })
 }
 
 fn fingerprint(input: &JobInput, apply_url: &str) -> String {
@@ -264,15 +239,5 @@ mod tests {
         })
         .unwrap();
         assert_eq!(job.company_name, "Acme");
-    }
-
-    #[test]
-    fn rejects_search_result_landing_pages() {
-        let job = parse_discovered_job(&SearchResult {
-            title: "Search Results | Find available job openings - BCG Careers".into(),
-            url: "https://careers.bcg.com/search-results".into(),
-            description: Some("Have questions about careers at BCG?".into()),
-        });
-        assert!(job.is_none());
     }
 }

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use chrono::{Datelike, TimeZone, Timelike, Utc};
 use garde::Validate;
 use tokio::time::sleep;
+use tokio_postgres::types::Json;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{error, info};
 use uuid::Uuid;
@@ -13,7 +14,11 @@ use uuid::Uuid;
 use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, jobs::DBJobs},
-    integrations::you_com::{SearchResult, YouComClient, source_search_domain},
+    integrations::{
+        event_page::validate_candidate_url,
+        job_page::JobPageClient,
+        you_com::{SearchResult, YouComClient, source_search_domain},
+    },
     types::jobs::JobInput,
 };
 
@@ -103,11 +108,16 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
         .await?;
     }
     let outcome = async {
+        let job_pages = JobPageClient::new()?;
         for user_id in users {
             let sources: Vec<String> = db.fetch_scalar_one(
                 "select coalesce(array_agg(url), '{}'::text[]) from jobs_discovery_source
                  where user_id = $1 and enabled", &[user_id],
             ).await?;
+            anyhow::ensure!(
+                !sources.is_empty(),
+                "no enabled job discovery sources are configured"
+            );
             let mut discovered = 0;
             let mut created = 0;
             for source_url in sources {
@@ -117,19 +127,39 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
                     .search(&format!("jobs hiring careers site:{search_domain}"))
                     .await?
                 {
-                    let Some(input) = parse_discovered_job(&result) else { continue };
+                    if let Err(err) = validate_candidate_url(&result.url, &source_url).await {
+                        info!(
+                            %err,
+                            candidate_url = %result.url,
+                            source_url = %source_url,
+                            "skipped unsafe job discovery candidate"
+                        );
+                        continue;
+                    }
+                    let input = match job_pages.fetch(&result.url, &source_url).await {
+                        Ok(input) => input.or_else(|| parse_discovered_job(&result)),
+                        Err(_) => parse_discovered_job(&result),
+                    };
+                    let Some(input) = input else { continue };
                     if !seen.insert(result.url.trim().to_lowercase()) { continue; }
                     let fingerprint = fingerprint(&input, &result.url);
                     let item: Option<Uuid> = db.fetch_scalar_opt(
-                        "insert into jobs_discovery_item (user_id, source_url, fingerprint)
-                         values ($1, $2, $3) on conflict (user_id, fingerprint) do nothing
+                        "insert into jobs_discovery_item (
+                            user_id, source_url, candidate_url, fingerprint, discovered_payload
+                         ) values ($1, $2, $3, $4, $5) on conflict (user_id, fingerprint) do nothing
                          returning jobs_discovery_item_id",
-                        &[user_id, &source_url, &fingerprint],
+                        &[
+                            user_id,
+                            &source_url,
+                            &result.url,
+                            &fingerprint,
+                            &Json(&input),
+                        ],
                     ).await?;
                     let Some(_) = item else { continue };
                     discovered += 1;
                     let job_id = db.add_job(*user_id, &input).await?;
-                    db.update_job_published(*user_id, job_id, true).await?;
+                    db.update_job_published(*user_id, job_id, false).await?;
                     db.execute(
                         "update jobs_discovery_item set job_id = $1 where user_id = $2 and fingerprint = $3",
                         &[&job_id, user_id, &fingerprint],
@@ -164,7 +194,11 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
 /// Accept only results with an explicit title, employer, description, and HTTPS application URL.
 fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
     let title = result.title.trim();
-    let description = result.description.as_deref()?.trim();
+    let description = result
+        .description
+        .as_deref()
+        .or_else(|| result.snippets.first().map(String::as_str))?
+        .trim();
     let apply_url = reqwest::Url::parse(result.url.trim()).ok()?;
     if !matches!(apply_url.scheme(), "http" | "https") || title.is_empty() || description.is_empty()
     {
@@ -225,7 +259,8 @@ mod tests {
             parse_discovered_job(&SearchResult {
                 title: "Engineer".into(),
                 url: "https://x.test".into(),
-                description: None
+                description: None,
+                snippets: vec![],
             })
             .is_none()
         );
@@ -236,8 +271,21 @@ mod tests {
             title: "Rust Engineer at Acme".into(),
             url: "https://x.test/jobs/1".into(),
             description: Some("Build reliable systems.".into()),
+            snippets: vec![],
         })
         .unwrap();
         assert_eq!(job.company_name, "Acme");
+    }
+
+    #[test]
+    fn accepts_snippet_when_description_is_missing() {
+        let job = parse_discovered_job(&SearchResult {
+            title: "Rust Engineer at Acme".into(),
+            url: "https://x.test/jobs/1".into(),
+            description: None,
+            snippets: vec!["Build reliable systems.".into()],
+        })
+        .unwrap();
+        assert_eq!(job.summary, "Build reliable systems.");
     }
 }

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -175,6 +175,9 @@ fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
         .split_once(" at ")
         .or_else(|| title.split_once(" - "))
         .filter(|(role, company)| !role.trim().is_empty() && !company.trim().is_empty())?;
+    if is_generic_job_page(title) {
+        return None;
+    }
     let summary: String = description.chars().take(280).collect();
     let input = JobInput {
         title: title.trim().to_owned(),
@@ -189,6 +192,28 @@ fn parse_discovered_job(result: &SearchResult) -> Option<JobInput> {
     };
     input.validate().ok()?;
     Some(input)
+}
+
+/// Reject search, index, and landing-page titles that do not identify a role.
+fn is_generic_job_page(role: &str) -> bool {
+    const GENERIC_PREFIXES: &[&str] = &[
+        "career opportunities",
+        "job opportunities",
+        "search results",
+        "search result",
+        "search jobs",
+        "job search",
+        "find jobs",
+        "careers",
+        "jobs",
+    ];
+
+    let normalized = role.trim().to_ascii_lowercase();
+    GENERIC_PREFIXES.iter().any(|prefix| {
+        normalized == *prefix
+            || normalized.starts_with(&format!("{prefix} |"))
+            || normalized.starts_with(&format!("{prefix}:"))
+    })
 }
 
 fn fingerprint(input: &JobInput, apply_url: &str) -> String {
@@ -239,5 +264,15 @@ mod tests {
         })
         .unwrap();
         assert_eq!(job.company_name, "Acme");
+    }
+
+    #[test]
+    fn rejects_search_result_landing_pages() {
+        let job = parse_discovered_job(&SearchResult {
+            title: "Search Results | Find available job openings - BCG Careers".into(),
+            url: "https://careers.bcg.com/search-results".into(),
+            description: Some("Have questions about careers at BCG?".into()),
+        });
+        assert!(job.is_none());
     }
 }

--- a/ocg-server/src/templates/dashboard/group/integrations.rs
+++ b/ocg-server/src/templates/dashboard/group/integrations.rs
@@ -11,6 +11,7 @@ pub(crate) struct IntegrationPage {
     pub city: String,
     pub enabled: bool,
     pub latest_run: Option<IntegrationRun>,
+    pub pending_items: Vec<IntegrationPendingItem>,
     pub sources: Vec<IntegrationSource>,
     pub timezone: String,
 }
@@ -32,6 +33,15 @@ pub(crate) struct IntegrationRun {
     pub error_message: Option<String>,
     pub started_at: i64,
     pub status: String,
+}
+
+/// A discovered event draft awaiting an organizer decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IntegrationPendingItem {
+    pub event_id: Uuid,
+    pub group_event_integration_item_id: Uuid,
+    pub source_url: String,
+    pub title: String,
 }
 
 /// Partial template rendered inside the group dashboard.

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -159,12 +159,23 @@ pub(crate) struct JobDiscoveryRun {
     pub error_message: Option<String>,
 }
 
+/// A discovered job awaiting the owner's publication decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JobDiscoveryPendingItem {
+    pub jobs_discovery_item_id: Uuid,
+    pub job_id: Uuid,
+    pub title: String,
+    pub company_name: String,
+    pub apply_url: String,
+}
+
 /// Jobs discovery configuration and its owned source URLs.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) struct JobDiscoveryDashboard {
     pub enabled: bool,
     pub sources: Vec<JobDiscoverySource>,
     pub latest_run: Option<JobDiscoveryRun>,
+    pub pending_items: Vec<JobDiscoveryPendingItem>,
 }
 
 /// Applicant interest saved for a job.

--- a/ocg-server/templates/dashboard/group/integrations.html
+++ b/ocg-server/templates/dashboard/group/integrations.html
@@ -33,6 +33,28 @@
     </ul>
   </section>
   <section class="border-t pt-6">
+    <h2 class="font-semibold text-lg">Pending review</h2>
+    {% if integration.pending_items.is_empty() %}
+      <p class="mt-2 text-stone-600">No discovered events are awaiting review.</p>
+    {% else %}
+      <ul class="mt-3 space-y-3">
+      {% for item in integration.pending_items %}
+        <li class="border rounded p-3">
+          <a class="font-semibold underline" href="{{ item.source_url }}" target="_blank" rel="noopener noreferrer">{{ item.title }}</a>
+          <div class="mt-3 flex gap-2">
+            <form hx-post="/dashboard/group/integrations/items/{{ item.group_event_integration_item_id }}/approve" hx-target="#dashboard-content">
+              <button class="button-primary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Publish</button>
+            </form>
+            <form hx-post="/dashboard/group/integrations/items/{{ item.group_event_integration_item_id }}/reject" hx-target="#dashboard-content">
+              <button class="button-secondary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Reject</button>
+            </form>
+          </div>
+        </li>
+      {% endfor %}
+      </ul>
+    {% endif %}
+  </section>
+  <section class="border-t pt-6">
     <h2 class="font-semibold text-lg">Latest run</h2>
     <form class="mt-3"
           hx-post="/dashboard/group/integrations/run"
@@ -51,7 +73,7 @@
          hx-swap="innerHTML"
          hx-indicator="#dashboard-spinner"></div>
     {% if let Some(run) = integration.latest_run %}
-      <p class="mt-2">Status: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} published</p>
+      <p class="mt-2">Status: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} queued for review</p>
       {% if let Some(error) = run.error_message %}<p class="text-red-700 mt-2">{{ error }}</p>{% endif %}
       {% if run.status == "running" %}
         <div hx-get="/dashboard/group/integrations"

--- a/ocg-server/templates/dashboard/group/integrations.html
+++ b/ocg-server/templates/dashboard/group/integrations.html
@@ -36,14 +36,30 @@
     <h2 class="font-semibold text-lg">Latest run</h2>
     <form class="mt-3"
           hx-post="/dashboard/group/integrations/run"
-          hx-swap="none">
+          hx-swap="none"
+          hx-indicator="#dashboard-spinner"
+          data-htmx-response
+          data-success-message="Discovery run started."
+          data-error-message="Could not start discovery. Please try again later.">
       <button class="button-secondary"
               type="submit"
               {% if !integration.can_manage_events %}disabled{% endif %}>Run discovery now</button>
     </form>
+    <div hx-get="/dashboard/group/integrations"
+         hx-trigger="event-discovery-run-started from:body delay:500ms"
+         hx-target="#dashboard-content"
+         hx-swap="innerHTML"
+         hx-indicator="#dashboard-spinner"></div>
     {% if let Some(run) = integration.latest_run %}
       <p class="mt-2">Status: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} published</p>
       {% if let Some(error) = run.error_message %}<p class="text-red-700 mt-2">{{ error }}</p>{% endif %}
+      {% if run.status == "running" %}
+        <div hx-get="/dashboard/group/integrations"
+             hx-trigger="every 3s"
+             hx-target="#dashboard-content"
+             hx-swap="innerHTML"
+             hx-indicator="#dashboard-spinner"></div>
+      {% endif %}
     {% else %}<p class="mt-2 text-stone-600">No runs yet.</p>{% endif %}
   </section>
 </div>

--- a/ocg-server/templates/dashboard/jobs/discovery.html
+++ b/ocg-server/templates/dashboard/jobs/discovery.html
@@ -35,8 +35,27 @@
       </ul>
     </section>
     <section class="mt-8 border-t pt-6">
+      <h2 class="font-semibold text-lg">Pending review</h2>
+      {% if discovery.pending_items.is_empty() %}
+        <p class="mt-3 text-stone-600">No discovered jobs are awaiting review.</p>
+      {% else %}
+        <ul class="mt-3 space-y-3">
+        {% for item in discovery.pending_items %}
+          <li class="border rounded p-3">
+            <a class="font-semibold underline" href="{{ item.apply_url }}" target="_blank" rel="noopener noreferrer">{{ item.title }}</a>
+            <p class="text-sm text-stone-600">{{ item.company_name }}</p>
+            <div class="mt-3 flex gap-2">
+              <form action="/dashboard/jobs/discovery/items/{{ item.jobs_discovery_item_id }}/approve" method="post"><button class="button-primary">Publish</button></form>
+              <form action="/dashboard/jobs/discovery/items/{{ item.jobs_discovery_item_id }}/reject" method="post"><button class="button-secondary">Reject</button></form>
+            </div>
+          </li>
+        {% endfor %}
+        </ul>
+      {% endif %}
+    </section>
+    <section class="mt-8 border-t pt-6">
       <form action="/dashboard/jobs/discovery/run" method="post"><button class="button-secondary" {% if !discovery.enabled %}disabled{% endif %}>Run discovery now</button></form>
-      {% if let Some(run) = discovery.latest_run %}<p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} published</p>{% endif %}
+      {% if let Some(run) = discovery.latest_run %}<p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} queued for review</p>{% endif %}
     </section>
   {% endif %}
 </div>


### PR DESCRIPTION
## Summary
- enrich source-scoped event and job results with safe structured-data extraction
- queue discoveries for organizer review with publish and reject controls
- make local You.com configuration reliable and surface common zero-result conditions

## Test plan
- [x] `cargo check --manifest-path Cargo.toml -p ocg-server`
- [x] `cargo test --manifest-path Cargo.toml -p ocg-server discovery -- --nocapture`
- [x] `cargo test --manifest-path Cargo.toml -p ocg-server integrations::you_com::tests -- --nocapture`
- [x] Verified configured You.com Search API returns HTTP 200
- [x] Verified local server starts and serves the dashboard routes

Made with [Cursor](https://cursor.com)