### PR TITLE
feat: discover jobs and events from official source pages

### DIFF
--- a/ocg-server/src/integrations/event_page.rs
+++ b/ocg-server/src/integrations/event_page.rs
@@ -44,19 +44,19 @@ impl EventPageClient {
         Ok(extract_event_json_ld(&html, candidate_url))
     }
 
-    /// Reads the public event cards from You.com's official events landing page.
+    /// Reads dated public event cards from an approved source landing page.
     pub(crate) async fn discover_source_events(
         &self,
         source_url: &str,
         city: &str,
+        timezone: chrono_tz::Tz,
     ) -> Result<Vec<DiscoveredEvent>> {
-        if !is_you_events_source(source_url) {
-            return Ok(vec![]);
-        }
         let Some(html) = self.fetch_html(source_url, source_url).await? else {
             return Ok(vec![]);
         };
-        Ok(extract_you_com_events(&html, city))
+        Ok(extract_event_listing_cards(
+            &html, source_url, city, timezone,
+        ))
     }
 
     /// Fetches an approved candidate page for a structured-data extractor.
@@ -103,14 +103,6 @@ impl EventPageClient {
     }
 }
 
-fn is_you_events_source(source_url: &str) -> bool {
-    let Ok(url) = Url::parse(source_url) else {
-        return false;
-    };
-    matches!(url.host_str(), Some("you.com") | Some("www.you.com"))
-        && url.path().trim_end_matches('/') == "/events"
-}
-
 #[derive(Debug, PartialEq, Eq)]
 struct SourceEventCard {
     title: String,
@@ -119,35 +111,40 @@ struct SourceEventCard {
     source_url: String,
 }
 
-/// Extracts current cards from the public Webflow event listing.
+/// Extracts dated cards from a public event listing.
 ///
-/// These cards list a date but not a start time. We represent the date as noon Pacific
-/// so it remains on the advertised local day; organizers review the draft before publishing.
-pub(crate) fn extract_you_com_events(html: &str, city: &str) -> Vec<DiscoveredEvent> {
+/// Listings that omit a start time are represented as noon in the group's configured
+/// timezone so they remain on the advertised local day; organizers review before publishing.
+pub(crate) fn extract_event_listing_cards(
+    html: &str,
+    source_url: &str,
+    city: &str,
+    timezone: chrono_tz::Tz,
+) -> Vec<DiscoveredEvent> {
     let mut remaining = html;
     let mut events = Vec::new();
-    while let Some(start) = remaining.find("events3_item") {
+    while let Some(start) = remaining.find("role=\"listitem\"") {
         let card = &remaining[start..];
-        let next = card["events3_item".len()..]
-            .find("events3_item")
-            .map(|offset| offset + "events3_item".len());
+        let next = card["role=\"listitem\"".len()..]
+            .find("role=\"listitem\"")
+            .map(|offset| offset + "role=\"listitem\"".len());
         let block = &card[..next.unwrap_or(card.len())];
         remaining = &card[block.len()..];
 
-        let Some(url) = html_attribute(block, "href") else {
+        let Some(url) = html_attribute(block, "href")
+            .and_then(|url| Url::parse(source_url).ok()?.join(url).ok())
+            .filter(|url| matches!(url.scheme(), "http" | "https"))
+        else {
             continue;
         };
-        let Some(title) = html_class_text(block, "events3_card_heading") else {
+        let Some(title) = html_tag_text(block, "h2").or_else(|| html_tag_text(block, "h3")) else {
             continue;
         };
-        let labels = html_class_texts(block, "events2_card_label");
-        let (Some(date), Some(location)) = (labels.first(), labels.last()) else {
+        let text = strip_html(block);
+        let Some(date) = event_date_in_text(&text) else {
             continue;
         };
-        let Ok(date) = NaiveDate::parse_from_str(date, "%B %d, %Y") else {
-            continue;
-        };
-        let Some(starts_at) = chrono_tz::US::Pacific
+        let Some(starts_at) = timezone
             .with_ymd_and_hms(date.year(), date.month(), date.day(), 12, 0, 0)
             .single()
             .map(|time| time.with_timezone(&Utc))
@@ -156,14 +153,14 @@ pub(crate) fn extract_you_com_events(html: &str, city: &str) -> Vec<DiscoveredEv
         };
         let card = SourceEventCard {
             title,
-            location: location.to_owned(),
+            location: text,
             starts_at,
-            source_url: url.to_owned(),
+            source_url: url.into(),
         };
-        if city_matches_event(&card.location, city) && card.starts_at > Utc::now() {
+        if card_matches_city(&card.location, city) && card.starts_at > Utc::now() {
             events.push(DiscoveredEvent {
                 title: card.title,
-                description: Some(format!("Official You.com event · {}", card.location)),
+                description: Some("Discovered from an approved event source".into()),
                 starts_at: card.starts_at,
                 source_url: card.source_url,
             });
@@ -172,11 +169,11 @@ pub(crate) fn extract_you_com_events(html: &str, city: &str) -> Vec<DiscoveredEv
     events
 }
 
-fn city_matches_event(location: &str, city: &str) -> bool {
-    location.eq_ignore_ascii_case("remote")
-        || location
-            .to_ascii_lowercase()
-            .contains(&city.trim().to_ascii_lowercase())
+fn card_matches_city(card_text: &str, city: &str) -> bool {
+    let text = card_text.to_ascii_lowercase();
+    text.contains(&city.trim().to_ascii_lowercase())
+        || text.contains("remote")
+        || text.contains("virtual")
 }
 
 fn html_attribute<'a>(html: &'a str, attribute: &str) -> Option<&'a str> {
@@ -185,29 +182,58 @@ fn html_attribute<'a>(html: &'a str, attribute: &str) -> Option<&'a str> {
     value.split_once('"').map(|(value, _)| value)
 }
 
-fn html_class_text(html: &str, class: &str) -> Option<String> {
-    html_class_texts(html, class).into_iter().next()
+fn html_tag_text(html: &str, tag: &str) -> Option<String> {
+    let start = html.find(&format!("<{tag}"))?;
+    let content = html[start..].split_once('>')?.1;
+    let text = content.split_once(&format!("</{tag}>"))?.0;
+    let text = strip_html(text);
+    (!text.is_empty()).then_some(text)
 }
 
-fn html_class_texts(html: &str, class: &str) -> Vec<String> {
-    let marker = format!("class=\"{class}");
-    let mut remaining = html;
-    let mut texts = Vec::new();
-    while let Some(before) = remaining.split_once(&marker) {
-        let after_class = before.1;
-        let Some((_, content)) = after_class.split_once('>') else {
-            break;
-        };
-        let Some((text, rest)) = content.split_once('<') else {
-            break;
-        };
-        let text = text.trim();
-        if !text.is_empty() {
-            texts.push(text.to_owned());
+fn strip_html(html: &str) -> String {
+    let mut text = String::with_capacity(html.len());
+    let mut in_tag = false;
+    for character in html.chars() {
+        match character {
+            '<' => in_tag = true,
+            '>' => {
+                in_tag = false;
+                text.push(' ');
+            }
+            _ if !in_tag => text.push(character),
+            _ => {}
         }
-        remaining = rest;
     }
-    texts
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn event_date_in_text(text: &str) -> Option<NaiveDate> {
+    const MONTHS: &[&str] = &[
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+    MONTHS.iter().find_map(|month| {
+        let value = text.split_once(month)?.1;
+        let candidate = format!("{month}{}", value.chars().take(16).collect::<String>());
+        let end = candidate.find(", ")? + 6;
+        let date = candidate.get(..end)?;
+        date.chars()
+            .rev()
+            .take(4)
+            .all(|character| character.is_ascii_digit())
+            .then(|| NaiveDate::parse_from_str(date, "%B %d, %Y").ok())
+            .flatten()
+    })
 }
 
 /// Checks that a candidate remains within the organizer-approved public domain.
@@ -425,26 +451,28 @@ mod tests {
     }
 
     #[test]
-    fn extracts_you_com_event_cards_for_city_and_remote() {
-        let events = extract_you_com_events(
+    fn extracts_generic_event_cards_for_city_and_remote() {
+        assert_eq!(
+            event_date_in_text("July 31, 2099 | Remote"),
+            NaiveDate::from_ymd_opt(2099, 7, 31)
+        );
+        let events = extract_event_listing_cards(
             r#"
-            <div class="events3_item"><a href="https://luma.com/sf"></a>
-              <div class="events2_card_label">July 30, 2099</div>
-              <div class="events2_card_label">|</div>
-              <div class="events2_card_label">San Francisco</div>
-              <h2 class="events3_card_heading">SF Hackathon</h2>
+            <div role="listitem"><a href="/events/sf"></a>
+              <div>July 30, 2099 | San Francisco</div>
+              <h2>SF Hackathon</h2>
             </div>
-            <div class="events3_item"><a href="https://luma.com/remote"></a>
-              <div class="events2_card_label">July 31, 2099</div>
-              <div class="events2_card_label">|</div>
-              <div class="events2_card_label">Remote</div>
-              <h2 class="events3_card_heading">Virtual workshop</h2>
+            <div role="listitem"><a href="https://events.example.com/remote"></a>
+              <div>July 31, 2099 | Remote</div>
+              <h2>Virtual workshop</h2>
             </div>
             "#,
+            "https://events.example.com/calendar",
             "Baku",
+            chrono_tz::UTC,
         );
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].title, "Virtual workshop");
-        assert_eq!(events[0].source_url, "https://luma.com/remote");
+        assert_eq!(events[0].source_url, "https://events.example.com/remote");
     }
 }

--- a/ocg-server/src/integrations/event_page.rs
+++ b/ocg-server/src/integrations/event_page.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result, bail};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, NaiveDate, TimeZone, Utc};
 use reqwest::{Client, Url, redirect};
 use serde_json::Value;
 
@@ -42,6 +42,21 @@ impl EventPageClient {
             return Ok(None);
         };
         Ok(extract_event_json_ld(&html, candidate_url))
+    }
+
+    /// Reads the public event cards from You.com's official events landing page.
+    pub(crate) async fn discover_source_events(
+        &self,
+        source_url: &str,
+        city: &str,
+    ) -> Result<Vec<DiscoveredEvent>> {
+        if !is_you_events_source(source_url) {
+            return Ok(vec![]);
+        }
+        let Some(html) = self.fetch_html(source_url, source_url).await? else {
+            return Ok(vec![]);
+        };
+        Ok(extract_you_com_events(&html, city))
     }
 
     /// Fetches an approved candidate page for a structured-data extractor.
@@ -86,6 +101,113 @@ impl EventPageClient {
         let html = String::from_utf8(body).context("event candidate page was not UTF-8")?;
         Ok(Some(html))
     }
+}
+
+fn is_you_events_source(source_url: &str) -> bool {
+    let Ok(url) = Url::parse(source_url) else {
+        return false;
+    };
+    matches!(url.host_str(), Some("you.com") | Some("www.you.com"))
+        && url.path().trim_end_matches('/') == "/events"
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SourceEventCard {
+    title: String,
+    location: String,
+    starts_at: DateTime<Utc>,
+    source_url: String,
+}
+
+/// Extracts current cards from the public Webflow event listing.
+///
+/// These cards list a date but not a start time. We represent the date as noon Pacific
+/// so it remains on the advertised local day; organizers review the draft before publishing.
+pub(crate) fn extract_you_com_events(html: &str, city: &str) -> Vec<DiscoveredEvent> {
+    let mut remaining = html;
+    let mut events = Vec::new();
+    while let Some(start) = remaining.find("events3_item") {
+        let card = &remaining[start..];
+        let next = card["events3_item".len()..]
+            .find("events3_item")
+            .map(|offset| offset + "events3_item".len());
+        let block = &card[..next.unwrap_or(card.len())];
+        remaining = &card[block.len()..];
+
+        let Some(url) = html_attribute(block, "href") else {
+            continue;
+        };
+        let Some(title) = html_class_text(block, "events3_card_heading") else {
+            continue;
+        };
+        let labels = html_class_texts(block, "events2_card_label");
+        let (Some(date), Some(location)) = (labels.first(), labels.last()) else {
+            continue;
+        };
+        let Ok(date) = NaiveDate::parse_from_str(date, "%B %d, %Y") else {
+            continue;
+        };
+        let Some(starts_at) = chrono_tz::US::Pacific
+            .with_ymd_and_hms(date.year(), date.month(), date.day(), 12, 0, 0)
+            .single()
+            .map(|time| time.with_timezone(&Utc))
+        else {
+            continue;
+        };
+        let card = SourceEventCard {
+            title,
+            location: location.to_owned(),
+            starts_at,
+            source_url: url.to_owned(),
+        };
+        if city_matches_event(&card.location, city) && card.starts_at > Utc::now() {
+            events.push(DiscoveredEvent {
+                title: card.title,
+                description: Some(format!("Official You.com event · {}", card.location)),
+                starts_at: card.starts_at,
+                source_url: card.source_url,
+            });
+        }
+    }
+    events
+}
+
+fn city_matches_event(location: &str, city: &str) -> bool {
+    location.eq_ignore_ascii_case("remote")
+        || location
+            .to_ascii_lowercase()
+            .contains(&city.trim().to_ascii_lowercase())
+}
+
+fn html_attribute<'a>(html: &'a str, attribute: &str) -> Option<&'a str> {
+    let prefix = format!("{attribute}=\"");
+    let value = html.split_once(&prefix)?.1;
+    value.split_once('"').map(|(value, _)| value)
+}
+
+fn html_class_text(html: &str, class: &str) -> Option<String> {
+    html_class_texts(html, class).into_iter().next()
+}
+
+fn html_class_texts(html: &str, class: &str) -> Vec<String> {
+    let marker = format!("class=\"{class}");
+    let mut remaining = html;
+    let mut texts = Vec::new();
+    while let Some(before) = remaining.split_once(&marker) {
+        let after_class = before.1;
+        let Some((_, content)) = after_class.split_once('>') else {
+            break;
+        };
+        let Some((text, rest)) = content.split_once('<') else {
+            break;
+        };
+        let text = text.trim();
+        if !text.is_empty() {
+            texts.push(text.to_owned());
+        }
+        remaining = rest;
+    }
+    texts
 }
 
 /// Checks that a candidate remains within the organizer-approved public domain.
@@ -300,5 +422,29 @@ mod tests {
         assert!(is_approved_host("www.example.com", "example.com"));
         assert!(is_approved_host("events.example.com", "example.com"));
         assert!(!is_approved_host("events.example.com", "www.example.com"));
+    }
+
+    #[test]
+    fn extracts_you_com_event_cards_for_city_and_remote() {
+        let events = extract_you_com_events(
+            r#"
+            <div class="events3_item"><a href="https://luma.com/sf"></a>
+              <div class="events2_card_label">July 30, 2099</div>
+              <div class="events2_card_label">|</div>
+              <div class="events2_card_label">San Francisco</div>
+              <h2 class="events3_card_heading">SF Hackathon</h2>
+            </div>
+            <div class="events3_item"><a href="https://luma.com/remote"></a>
+              <div class="events2_card_label">July 31, 2099</div>
+              <div class="events2_card_label">|</div>
+              <div class="events2_card_label">Remote</div>
+              <h2 class="events3_card_heading">Virtual workshop</h2>
+            </div>
+            "#,
+            "Baku",
+        );
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].title, "Virtual workshop");
+        assert_eq!(events[0].source_url, "https://luma.com/remote");
     }
 }

--- a/ocg-server/src/integrations/job_page.rs
+++ b/ocg-server/src/integrations/job_page.rs
@@ -1,7 +1,11 @@
 //! Structured JobPosting extraction from safely fetched candidate pages.
 
-use anyhow::Result;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
 use garde::Validate;
+use reqwest::{Client, redirect};
+use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
@@ -12,12 +16,18 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct JobPageClient {
     pages: EventPageClient,
+    http: Client,
 }
 
 impl JobPageClient {
     pub(crate) fn new() -> Result<Self> {
         Ok(Self {
             pages: EventPageClient::new()?,
+            http: Client::builder()
+                .timeout(Duration::from_secs(20))
+                .redirect(redirect::Policy::none())
+                .user_agent("GOUP-job-discovery/1.0")
+                .build()?,
         })
     }
 
@@ -31,6 +41,108 @@ impl JobPageClient {
         };
         Ok(extract_job_json_ld(&html, candidate_url))
     }
+
+    /// Resolves a Greenhouse board explicitly embedded by an approved careers source.
+    pub(crate) async fn discover_greenhouse_jobs(&self, source_url: &str) -> Result<Vec<JobInput>> {
+        let Some(html) = self.pages.fetch_html(source_url, source_url).await? else {
+            return Ok(vec![]);
+        };
+        let Some(board) = greenhouse_board_from_html(&html) else {
+            return Ok(vec![]);
+        };
+        let url = format!("https://boards-api.greenhouse.io/v1/boards/{board}/jobs?content=true");
+        let response: GreenhouseResponse = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .context("requesting embedded Greenhouse job board")?
+            .error_for_status()
+            .context("embedded Greenhouse job board returned an error")?
+            .json()
+            .await
+            .context("decoding embedded Greenhouse job board")?;
+        Ok(response
+            .jobs
+            .into_iter()
+            .filter_map(|job| greenhouse_job_to_input(job, source_url))
+            .collect())
+    }
+}
+
+#[derive(Deserialize)]
+struct GreenhouseResponse {
+    #[serde(default)]
+    jobs: Vec<GreenhouseJob>,
+}
+
+#[derive(Deserialize)]
+struct GreenhouseJob {
+    title: String,
+    absolute_url: String,
+    content: String,
+    #[serde(default)]
+    location: Option<GreenhouseLocation>,
+}
+
+#[derive(Deserialize)]
+struct GreenhouseLocation {
+    name: String,
+}
+
+fn greenhouse_board_from_html(html: &str) -> Option<&str> {
+    const PREFIX: &str = "boards.greenhouse.io/embed/job_board/js?for=";
+    let board = html.split(PREFIX).nth(1)?.split(['&', '"', '\'', '<']).next()?;
+    (!board.is_empty()
+        && board
+            .bytes()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, b'_' | b'-')))
+    .then_some(board)
+}
+
+fn greenhouse_job_to_input(job: GreenhouseJob, source_url: &str) -> Option<JobInput> {
+    let title = job.title.trim();
+    let description = strip_html(&job.content);
+    let company_name = company_name_from_source(source_url)?;
+    let input = JobInput {
+        title: title.to_owned(),
+        company_name,
+        summary: description.chars().take(280).collect(),
+        description,
+        apply_url: job.absolute_url,
+        location: job.location.map(|location| location.name),
+        remote: None,
+        members_only: Some(false),
+        tags: None,
+    };
+    input.validate().ok().map(|_| input)
+}
+
+fn company_name_from_source(source_url: &str) -> Option<String> {
+    let source = reqwest::Url::parse(source_url).ok()?;
+    let host = source.host_str()?.trim_start_matches("www.");
+    let mut company = host.to_owned();
+    if let Some(first) = company.get_mut(..1) {
+        first.make_ascii_uppercase();
+    }
+    Some(company)
+}
+
+fn strip_html(input: &str) -> String {
+    let mut text = String::with_capacity(input.len());
+    let mut inside_tag = false;
+    for character in input.chars() {
+        match character {
+            '<' => inside_tag = true,
+            '>' => {
+                inside_tag = false;
+                text.push(' ');
+            }
+            _ if !inside_tag => text.push(character),
+            _ => {}
+        }
+    }
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 pub(crate) fn extract_job_json_ld(html: &str, candidate_url: &str) -> Option<JobInput> {
@@ -112,5 +224,34 @@ mod tests {
         assert_eq!(job.title, "Rust Engineer");
         assert_eq!(job.company_name, "Acme");
         assert_eq!(job.remote, Some(true));
+    }
+
+    #[test]
+    fn extracts_embedded_greenhouse_board() {
+        assert_eq!(
+            greenhouse_board_from_html(
+                r#"<script src="https://boards.greenhouse.io/embed/job_board/js?for=youcom"></script>"#
+            ),
+            Some("youcom")
+        );
+    }
+
+    #[test]
+    fn maps_greenhouse_job_to_input() {
+        let job = greenhouse_job_to_input(
+            GreenhouseJob {
+                title: "Senior Rust Engineer".into(),
+                absolute_url: "https://job-boards.greenhouse.io/acme/jobs/1".into(),
+                content: "<p>Build reliable systems.</p>".into(),
+                location: Some(GreenhouseLocation {
+                    name: "Remote".into(),
+                }),
+            },
+            "https://www.acme.com/careers",
+        )
+        .unwrap();
+        assert_eq!(job.company_name, "Acme.com");
+        assert_eq!(job.description, "Build reliable systems.");
+        assert_eq!(job.location.as_deref(), Some("Remote"));
     }
 }

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -180,6 +180,9 @@ async fn ingest_sources(
     let event_pages = EventPageClient::new()?;
     for source in sources {
         let search_domain = source_search_domain(&source.url)?;
+        let mut events = event_pages
+            .discover_source_events(&source.url, &source.city)
+            .await?;
         let results = unique_city_results(
             client
                 .search(&format!("{} events site:{search_domain}", source.city))
@@ -198,7 +201,15 @@ async fn ingest_sources(
                     parse_discovered_event(&result, &result.url)
                 }
             };
-            let Some(event) = event else { continue };
+            if let Some(event) = event {
+                events.push(event);
+            }
+        }
+        let mut seen = std::collections::HashSet::new();
+        for event in events {
+            if !seen.insert(event.source_url.trim().to_ascii_lowercase()) {
+                continue;
+            }
             let fingerprint = event.fingerprint();
             let inserted: Option<Uuid> = db
                 .fetch_scalar_opt(

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -180,8 +180,9 @@ async fn ingest_sources(
     let event_pages = EventPageClient::new()?;
     for source in sources {
         let search_domain = source_search_domain(&source.url)?;
+        let timezone = source.timezone.parse()?;
         let mut events = event_pages
-            .discover_source_events(&source.url, &source.city)
+            .discover_source_events(&source.url, &source.city, timezone)
             .await?;
         let results = unique_city_results(
             client

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -123,6 +123,12 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
             for source_url in sources {
                 let mut seen = HashSet::new();
                 let search_domain = source_search_domain(&source_url)?;
+                let mut candidates: Vec<(String, JobInput)> = job_pages
+                    .discover_greenhouse_jobs(&source_url)
+                    .await?
+                    .into_iter()
+                    .map(|input| (input.apply_url.clone(), input))
+                    .collect();
                 for result in client
                     .search(&format!("jobs hiring careers site:{search_domain}"))
                     .await?
@@ -140,9 +146,15 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
                         Ok(input) => input.or_else(|| parse_discovered_job(&result)),
                         Err(_) => parse_discovered_job(&result),
                     };
-                    let Some(input) = input else { continue };
-                    if !seen.insert(result.url.trim().to_lowercase()) { continue; }
-                    let fingerprint = fingerprint(&input, &result.url);
+                    if let Some(input) = input {
+                        candidates.push((result.url, input));
+                    }
+                }
+                for (candidate_url, input) in candidates {
+                    if !seen.insert(candidate_url.trim().to_lowercase()) {
+                        continue;
+                    }
+                    let fingerprint = fingerprint(&input, &candidate_url);
                     let item: Option<Uuid> = db.fetch_scalar_opt(
                         "insert into jobs_discovery_item (
                             user_id, source_url, candidate_url, fingerprint, discovered_payload
@@ -151,7 +163,7 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
                         &[
                             user_id,
                             &source_url,
-                            &result.url,
+                            &candidate_url,
                             &fingerprint,
                             &Json(&input),
                         ],


### PR DESCRIPTION
## Summary
- discover Greenhouse jobs embedded by approved careers pages, including You.com Careers
- parse official You.com event cards, including city-matched and remote events
- preserve source review queues and deduplicate direct-source results with search results

## Test plan
- [x] `cargo test -p ocg-server event_page`
- [x] `cargo test -p ocg-server job_page`
- [x] checked edited-file diagnostics


Made with [Cursor](https://cursor.com)