### PR TITLE
Fix discovery dashboard and job deletion

### DIFF
--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -1111,11 +1111,12 @@ where
                 'pending_items', coalesce((
                     select jsonb_agg(jsonb_build_object(
                         'group_event_integration_item_id', d.group_event_integration_item_id,
-                        'event_id', e.event_id, 'title', e.name,
-                        'source_url', d.candidate_url
+                        'event_id', e.event_id,
+                        'title', coalesce(e.name, d.discovered_payload->>'title', 'Untitled discovered event'),
+                        'source_url', coalesce(nullif(d.candidate_url, ''), d.source_url)
                     ) order by d.created_at desc)
                     from group_event_integration_item d
-                    join event e using (event_id)
+                    left join event e using (event_id)
                     where d.group_id = $1 and d.review_status = 'pending'
                 ), '[]'::jsonb)
             ) from (select 1) x left join group_event_integration i on i.group_id = $1",
@@ -1198,17 +1199,20 @@ where
         group_id: Uuid,
         item_id: Uuid,
     ) -> Result<()> {
-        let event_id: Uuid = self
+        let event_id: Option<Uuid> = self
             .fetch_scalar_one(
                 "update group_event_integration_item
                  set review_status = 'rejected', reviewed_at = now(), reviewed_by = $1
                  where group_event_integration_item_id = $2 and group_id = $3
-                   and review_status = 'pending' and event_id is not null
+                   and review_status = 'pending'
                  returning event_id",
                 &[&actor_user_id, &item_id, &group_id],
             )
             .await?;
-        self.delete_event(actor_user_id, group_id, event_id).await
+        if let Some(event_id) = event_id {
+            self.delete_event(actor_user_id, group_id, event_id).await?;
+        }
+        Ok(())
     }
 
     /// [`DBDashboardGroup::get_group_sponsor`]

--- a/ocg-server/src/db/jobs.rs
+++ b/ocg-server/src/db/jobs.rs
@@ -177,11 +177,16 @@ where
                     where r.user_id = $1 order by r.started_at desc limit 1),
                 'pending_items', coalesce((select jsonb_agg(jsonb_build_object(
                     'jobs_discovery_item_id', d.jobs_discovery_item_id,
-                    'job_id', j.job_id, 'title', j.title, 'company_name', j.company_name,
-                    'apply_url', j.apply_url
+                    'job_id', j.job_id,
+                    'title', coalesce(j.title, d.discovered_payload->>'title', 'Untitled discovered job'),
+                    'company_name', coalesce(j.company_name, d.discovered_payload->>'company_name', 'Unknown company'),
+                    'apply_url', coalesce(
+                        j.apply_url, d.discovered_payload->>'apply_url',
+                        nullif(d.candidate_url, ''), d.source_url
+                    )
                 ) order by d.created_at desc)
                     from jobs_discovery_item d
-                    join jobs_job j using (job_id)
+                    left join jobs_job j using (job_id)
                     where d.user_id = $1 and d.review_status = 'pending'
                 ), '[]'::jsonb)
             ) from (select 1) x left join jobs_discovery_integration i on i.user_id = $1",
@@ -235,16 +240,19 @@ where
     }
 
     async fn reject_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()> {
-        let job_id: Uuid = self
+        let job_id: Option<Uuid> = self
             .fetch_scalar_one(
                 "update jobs_discovery_item
                  set review_status = 'rejected', reviewed_at = now(), reviewed_by = $1
                  where jobs_discovery_item_id = $2 and user_id = $1
-                   and review_status = 'pending' and job_id is not null
+                   and review_status = 'pending'
                  returning job_id",
                 &[&user_id, &item_id],
             )
             .await?;
-        self.delete_job(user_id, job_id).await
+        if let Some(job_id) = job_id {
+            self.delete_job(user_id, job_id).await?;
+        }
+        Ok(())
     }
 }

--- a/ocg-server/src/handlers/dashboard/jobs.rs
+++ b/ocg-server/src/handlers/dashboard/jobs.rs
@@ -39,6 +39,9 @@ use crate::{
     },
 };
 
+#[cfg(test)]
+mod tests;
+
 const DASHBOARD_JOBS_URL: &str = "/dashboard/jobs";
 const DASHBOARD_MOCK_INTERVIEWS_URL: &str = "/dashboard/jobs/mock-interviews";
 const DASHBOARD_DISCOVERY_URL: &str = "/dashboard/jobs/discovery";
@@ -274,14 +277,12 @@ pub(crate) async fn update(
 /// Delete a job.
 #[instrument(skip_all, err)]
 pub(crate) async fn delete(
-    messages: Messages,
     CurrentUser(user): CurrentUser,
     State(db): State<DynDB>,
     Path(job_id): Path<Uuid>,
 ) -> Result<impl IntoResponse, HandlerError> {
     db.delete_job(user.user_id, job_id).await?;
-    messages.success("Job deleted.");
-    Ok((StatusCode::SEE_OTHER, [("Location", DASHBOARD_JOBS_URL)]))
+    Ok((StatusCode::NO_CONTENT, [("HX-Trigger", "refresh-body")]))
 }
 
 /// Publish a job.

--- a/ocg-server/src/handlers/dashboard/jobs/tests.rs
+++ b/ocg-server/src/handlers/dashboard/jobs/tests.rs
@@ -1,0 +1,49 @@
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header::COOKIE},
+};
+use axum_login::tower_sessions::session;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use crate::{
+    db::mock::MockDB, handlers::tests::*, services::notifications::MockNotificationsManager,
+};
+
+#[tokio::test]
+async fn deleting_a_job_refreshes_the_dashboard_body() {
+    let user_id = Uuid::new_v4();
+    let job_id = Uuid::new_v4();
+    let session_id = session::Id::default();
+    let auth_hash = "hash".to_owned();
+    let session_record = sample_session_record(session_id, user_id, &auth_hash, None, None);
+
+    let mut db = MockDB::new();
+    db.expect_get_session()
+        .times(1)
+        .withf(move |id| *id == session_id)
+        .returning(move |_| Ok(Some(session_record.clone())));
+    db.expect_get_user_by_id()
+        .times(1)
+        .withf(move |id| *id == user_id)
+        .returning(move |_| Ok(Some(sample_auth_user(user_id, &auth_hash))));
+    db.expect_delete_job()
+        .times(1)
+        .withf(move |owner_id, deleted_job_id| *owner_id == user_id && *deleted_job_id == job_id)
+        .returning(|_, _| Ok(()));
+
+    let router = TestRouterBuilder::new(db, MockNotificationsManager::new())
+        .build()
+        .await;
+    let request = Request::builder()
+        .method("DELETE")
+        .uri(format!("/dashboard/jobs/{job_id}"))
+        .header(COOKIE, format!("id={session_id}"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.unwrap();
+    let (parts, body) = response.into_parts();
+    let body = to_bytes(body, usize::MAX).await.unwrap();
+
+    assert_empty_hx_trigger_response(&parts, &body, StatusCode::NO_CONTENT, "refresh-body");
+}

--- a/ocg-server/src/templates/dashboard/group/integrations.rs
+++ b/ocg-server/src/templates/dashboard/group/integrations.rs
@@ -35,10 +35,11 @@ pub(crate) struct IntegrationRun {
     pub status: String,
 }
 
-/// A discovered event draft awaiting an organizer decision.
+/// A discovered event awaiting an organizer decision.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct IntegrationPendingItem {
-    pub event_id: Uuid,
+    /// The draft created for this discovery, if group defaults were configured.
+    pub event_id: Option<Uuid>,
     pub group_event_integration_item_id: Uuid,
     pub source_url: String,
     pub title: String,

--- a/ocg-server/src/types/jobs.rs
+++ b/ocg-server/src/types/jobs.rs
@@ -163,7 +163,8 @@ pub(crate) struct JobDiscoveryRun {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct JobDiscoveryPendingItem {
     pub jobs_discovery_item_id: Uuid,
-    pub job_id: Uuid,
+    /// The draft created for this discovery, when creation completed.
+    pub job_id: Option<Uuid>,
     pub title: String,
     pub company_name: String,
     pub apply_url: String,

--- a/ocg-server/templates/dashboard/group/integrations.html
+++ b/ocg-server/templates/dashboard/group/integrations.html
@@ -33,7 +33,7 @@
     </ul>
   </section>
   <section class="border-t pt-6">
-    <h2 class="font-semibold text-lg">Pending review</h2>
+    <h2 class="font-semibold text-lg">Discovery candidates awaiting review</h2>
     {% if integration.pending_items.is_empty() %}
       <p class="mt-2 text-stone-600">No discovered events are awaiting review.</p>
     {% else %}
@@ -42,9 +42,13 @@
         <li class="border rounded p-3">
           <a class="font-semibold underline" href="{{ item.source_url }}" target="_blank" rel="noopener noreferrer">{{ item.title }}</a>
           <div class="mt-3 flex gap-2">
+          {% if item.event_id.is_some() %}
             <form hx-post="/dashboard/group/integrations/items/{{ item.group_event_integration_item_id }}/approve" hx-target="#dashboard-content">
               <button class="button-primary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Publish</button>
             </form>
+          {% else %}
+            <p class="text-sm text-amber-800">No event draft was created because this group has no default event template. Use the source to create an event manually, then reject this candidate to remove it from the queue.</p>
+          {% endif %}
             <form hx-post="/dashboard/group/integrations/items/{{ item.group_event_integration_item_id }}/reject" hx-target="#dashboard-content">
               <button class="button-secondary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Reject</button>
             </form>
@@ -73,7 +77,7 @@
          hx-swap="innerHTML"
          hx-indicator="#dashboard-spinner"></div>
     {% if let Some(run) = integration.latest_run %}
-      <p class="mt-2">Status: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} queued for review</p>
+      <p class="mt-2">Status: {{ run.status }} · {{ run.discovered_count }} candidates discovered · {{ run.created_count }} event drafts created</p>
       {% if let Some(error) = run.error_message %}<p class="text-red-700 mt-2">{{ error }}</p>{% endif %}
       {% if run.status == "running" %}
         <div hx-get="/dashboard/group/integrations"

--- a/ocg-server/templates/dashboard/jobs.html
+++ b/ocg-server/templates/dashboard/jobs.html
@@ -276,7 +276,10 @@
                         type="button"
                         hx-delete="/dashboard/jobs/{{ job.job_id }}"
                         hx-confirm="Delete this job?"
-                        hx-target="body">Delete</button>
+                        hx-target="body"
+                        data-htmx-response
+                        data-success-message="Job deleted."
+                        data-error-message="Could not delete this job. Please try again.">Delete</button>
               </div>
             </form>
 

--- a/ocg-server/templates/dashboard/jobs/discovery.html
+++ b/ocg-server/templates/dashboard/jobs/discovery.html
@@ -35,7 +35,7 @@
       </ul>
     </section>
     <section class="mt-8 border-t pt-6">
-      <h2 class="font-semibold text-lg">Pending review</h2>
+      <h2 class="font-semibold text-lg">Discovery candidates awaiting review</h2>
       {% if discovery.pending_items.is_empty() %}
         <p class="mt-3 text-stone-600">No discovered jobs are awaiting review.</p>
       {% else %}
@@ -45,7 +45,11 @@
             <a class="font-semibold underline" href="{{ item.apply_url }}" target="_blank" rel="noopener noreferrer">{{ item.title }}</a>
             <p class="text-sm text-stone-600">{{ item.company_name }}</p>
             <div class="mt-3 flex gap-2">
+              {% if item.job_id.is_some() %}
               <form action="/dashboard/jobs/discovery/items/{{ item.jobs_discovery_item_id }}/approve" method="post"><button class="button-primary">Publish</button></form>
+              {% else %}
+              <p class="text-sm text-amber-800">No job draft was created, so this candidate cannot be published. Review the source, then reject it to remove it from this queue.</p>
+              {% endif %}
               <form action="/dashboard/jobs/discovery/items/{{ item.jobs_discovery_item_id }}/reject" method="post"><button class="button-secondary">Reject</button></form>
             </div>
           </li>
@@ -55,7 +59,7 @@
     </section>
     <section class="mt-8 border-t pt-6">
       <form action="/dashboard/jobs/discovery/run" method="post"><button class="button-secondary" {% if !discovery.enabled %}disabled{% endif %}>Run discovery now</button></form>
-      {% if let Some(run) = discovery.latest_run %}<p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} discovered · {{ run.created_count }} queued for review</p>{% endif %}
+      {% if let Some(run) = discovery.latest_run %}<p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} candidates discovered · {{ run.created_count }} job drafts created</p>{% endif %}
     </section>
   {% endif %}
 </div>

--- a/tests/unit/dashboard/discovery-templates.test.js
+++ b/tests/unit/dashboard/discovery-templates.test.js
@@ -1,0 +1,43 @@
+import { expect } from "@open-wc/testing";
+
+const loadTemplate = async (path) => {
+  const response = await fetch(path);
+
+  expect(response.ok).to.equal(true);
+
+  return response.text();
+};
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, " ").trim();
+
+describe("discovery dashboard templates", () => {
+  it("keeps job candidates visible when no job draft exists", async () => {
+    const template = normalizeWhitespace(
+      await loadTemplate("/ocg-server/templates/dashboard/jobs/discovery.html"),
+    );
+
+    expect(template).to.include("Discovery candidates awaiting review");
+    expect(template).to.include("item.job_id.is_some()");
+    expect(template).to.include(
+      "No job draft was created, so this candidate cannot be published.",
+    );
+    expect(template).to.include("candidates discovered");
+    expect(template).to.include("job drafts created");
+  });
+
+  it("keeps group candidates visible when no event draft exists", async () => {
+    const template = normalizeWhitespace(
+      await loadTemplate(
+        "/ocg-server/templates/dashboard/group/integrations.html",
+      ),
+    );
+
+    expect(template).to.include("Discovery candidates awaiting review");
+    expect(template).to.include("item.event_id.is_some()");
+    expect(template).to.include(
+      "No event draft was created because this group has no default event template.",
+    );
+    expect(template).to.include("candidates discovered");
+    expect(template).to.include("event drafts created");
+  });
+});

--- a/tests/unit/dashboard/jobs-dashboard-template.test.js
+++ b/tests/unit/dashboard/jobs-dashboard-template.test.js
@@ -1,0 +1,25 @@
+import { expect } from "@open-wc/testing";
+
+const loadTemplate = async () => {
+  const response = await fetch("/ocg-server/templates/dashboard/jobs.html");
+
+  expect(response.ok).to.equal(true);
+
+  return response.text();
+};
+
+const normalizeWhitespace = (value) => value.replace(/\s+/g, " ").trim();
+
+describe("jobs dashboard template", () => {
+  it("refreshes the dashboard after a job is deleted", async () => {
+    const template = normalizeWhitespace(await loadTemplate());
+
+    expect(template).to.include('hx-delete="/dashboard/jobs/{{ job.job_id }}"');
+    expect(template).to.include('hx-target="body"');
+    expect(template).to.include("data-htmx-response");
+    expect(template).to.include('data-success-message="Job deleted."');
+    expect(template).to.include(
+      'data-error-message="Could not delete this job. Please try again."',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Keep discovery candidates visible and reviewable when their job or event draft was not created.
- Refresh the jobs dashboard and show deletion feedback after an HTMX job deletion.

## Test plan
- [x] `cargo test -p ocg-server` (942 tests passed)
- [ ] Browser template tests are blocked: `tests/unit/node_modules` is missing `web-test-runner`.

Made with [Cursor](https://cursor.com)