### PR TITLE
fix: prevent event tab labels from clipping

### DIFF
--- a/ocg-server/templates/dashboard/group/events_add.html
+++ b/ocg-server/templates/dashboard/group/events_add.html
@@ -36,8 +36,8 @@
   </div>
 
   <div class="mb-10 grid min-w-0 grid-cols-1 items-stretch gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:gap-x-8">
-    <div class="min-w-0 overflow-x-auto overflow-y-hidden">
-      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium lg:gap-2">
+    <div class="min-w-0 overflow-x-auto">
+      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium [&>li]:w-auto [&>li]:shrink-0 [&>li>div>button]:w-auto [&>li>div>button]:whitespace-nowrap lg:gap-2">
         {{ event_form::tab_button(section = "details", icon = "event", label = "Details", active = true) -}}
         {{ event_form::tab_button(section = "date-venue", icon = "calendar", label = "Date & Venue") -}}
         {{ event_form::tab_button(section = "hosts-sponsors", icon = "user-plus", label = "Hosts & Speakers") -}}

--- a/ocg-server/templates/dashboard/group/events_update.html
+++ b/ocg-server/templates/dashboard/group/events_update.html
@@ -27,8 +27,8 @@
      data-group-banner-url="{%- if let Some(banner_url) = &event.group.banner_url -%}{{ banner_url }}{%- endif -%}"
      data-group-banner-mobile-url="{%- if let Some(banner_mobile_url) = &event.group.banner_mobile_url -%}{{ banner_mobile_url }}{%- endif -%}">
   <div class="mb-10 grid min-w-0 grid-cols-1 items-stretch gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:gap-x-8">
-    <div class="min-w-0 overflow-x-auto overflow-y-hidden">
-      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium lg:gap-2">
+    <div class="min-w-0 overflow-x-auto">
+      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium [&>li]:w-auto [&>li]:shrink-0 [&>li>div>button]:w-auto [&>li>div>button]:whitespace-nowrap lg:gap-2">
         {{ event_form::tab_button(section = "details", icon = "event", label = "Details", active = true) -}}
         {{ event_form::tab_button(section = "date-venue", icon = "calendar", label = "Date & Venue") -}}
         {{ event_form::tab_button(section = "hosts-sponsors", icon = "user-plus", label = "Hosts & Speakers") -}}

--- a/tests/unit/dashboard/group/events-add-template.test.js
+++ b/tests/unit/dashboard/group/events-add-template.test.js
@@ -131,4 +131,15 @@ describe("dashboard group event add template", () => {
       '<div class="min-w-0"> <div class="space-y-12">',
     );
   });
+
+  it("keeps top event tabs at their content width", async () => {
+    // Load the event add template before checking tab sizing constraints.
+    const template = normalizeWhitespace(await loadTemplate());
+
+    // Prevent horizontal tabs from inheriting the full-width sidebar tab layout.
+    expect(template).to.include(
+      '[&>li]:w-auto [&>li]:shrink-0 [&>li>div>button]:w-auto [&>li>div>button]:whitespace-nowrap',
+    );
+    expect(template).to.include('class="min-w-0 overflow-x-auto"');
+  });
 });


### PR DESCRIPTION
Keep horizontal event editor tabs content-sized and single-line so long labels remain visible on narrow layouts.