### PR TITLE
feat: normalize flexible logo uploads

### DIFF
--- a/database/migrations/schema/0104_discovery_source_scoped_fingerprints.sql
+++ b/database/migrations/schema/0104_discovery_source_scoped_fingerprints.sql
@@ -1,0 +1,23 @@
+-- Keep rejected discovery history per source so replacing a source starts a
+-- fresh review queue. Pending and published candidates remain unique per owner
+-- to prevent duplicate drafts when sources overlap.
+
+alter table jobs_discovery_item
+    drop constraint if exists jobs_discovery_item_user_id_fingerprint_key;
+
+create unique index if not exists jobs_discovery_item_user_source_fingerprint_key
+    on jobs_discovery_item (user_id, source_url, fingerprint);
+
+create unique index if not exists jobs_discovery_item_active_fingerprint_key
+    on jobs_discovery_item (user_id, fingerprint)
+    where review_status in ('pending', 'published');
+
+alter table group_event_integration_item
+    drop constraint if exists group_event_integration_item_group_id_fingerprint_key;
+
+create unique index if not exists group_event_integration_item_group_source_fingerprint_key
+    on group_event_integration_item (group_id, source_url, fingerprint);
+
+create unique index if not exists group_event_integration_item_active_fingerprint_key
+    on group_event_integration_item (group_id, fingerprint)
+    where review_status in ('pending', 'published');

--- a/database/tests/schema/07_discovery_fingerprint_scoping.sql
+++ b/database/tests/schema/07_discovery_fingerprint_scoping.sql
@@ -1,0 +1,91 @@
+begin;
+select plan(8);
+
+insert into "user" (user_id, auth_hash, email, username)
+values (
+    '10000000-0000-0000-0000-000000000001',
+    'discovery-fingerprint-test',
+    'discovery-fingerprint-test@example.com',
+    'discovery-fingerprint-test'
+);
+
+insert into alliance (
+    alliance_id, name, display_name, description, logo_url, banner_url, banner_mobile_url
+) values (
+    '30000000-0000-0000-0000-000000000001',
+    'discovery-fingerprint-test',
+    'Discovery fingerprint test',
+    'Discovery fingerprint test alliance',
+    'https://example.com/logo.png',
+    'https://example.com/banner.png',
+    'https://example.com/banner-mobile.png'
+);
+
+insert into group_category (group_category_id, alliance_id, name)
+values (
+    '40000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    'Discovery fingerprint test'
+);
+
+insert into "group" (group_id, alliance_id, group_category_id, name, slug)
+values (
+    '20000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    '40000000-0000-0000-0000-000000000001',
+    'Discovery fingerprint test',
+    'discovery-fingerprint-test'
+);
+
+select lives_ok(
+    $$insert into jobs_discovery_item (user_id, source_url, fingerprint, review_status)
+      values ('10000000-0000-0000-0000-000000000001', 'https://old.example/jobs', 'job-rejected', 'rejected')$$,
+    'a rejected job candidate is retained'
+);
+select lives_ok(
+    $$insert into jobs_discovery_item (user_id, source_url, fingerprint)
+      values ('10000000-0000-0000-0000-000000000001', 'https://replacement.example/jobs', 'job-rejected')$$,
+    'a replacement job source can queue a previously rejected candidate'
+);
+select throws_ok(
+    $$insert into jobs_discovery_item (user_id, source_url, fingerprint)
+      values ('10000000-0000-0000-0000-000000000001', 'https://replacement.example/jobs', 'job-rejected')$$,
+    '23505',
+    null,
+    'the same job source cannot queue a candidate twice'
+);
+select throws_ok(
+    $$insert into jobs_discovery_item (user_id, source_url, fingerprint)
+      values ('10000000-0000-0000-0000-000000000001', 'https://another.example/jobs', 'job-rejected')$$,
+    '23505',
+    null,
+    'an active job candidate cannot create a duplicate draft from another source'
+);
+
+select lives_ok(
+    $$insert into group_event_integration_item (group_id, source_url, fingerprint, review_status)
+      values ('20000000-0000-0000-0000-000000000001', 'https://old.example/events', 'event-rejected', 'rejected')$$,
+    'a rejected event candidate is retained'
+);
+select lives_ok(
+    $$insert into group_event_integration_item (group_id, source_url, fingerprint)
+      values ('20000000-0000-0000-0000-000000000001', 'https://replacement.example/events', 'event-rejected')$$,
+    'a replacement event source can queue a previously rejected candidate'
+);
+select throws_ok(
+    $$insert into group_event_integration_item (group_id, source_url, fingerprint)
+      values ('20000000-0000-0000-0000-000000000001', 'https://replacement.example/events', 'event-rejected')$$,
+    '23505',
+    null,
+    'the same event source cannot queue a candidate twice'
+);
+select throws_ok(
+    $$insert into group_event_integration_item (group_id, source_url, fingerprint)
+      values ('20000000-0000-0000-0000-000000000001', 'https://another.example/events', 'event-rejected')$$,
+    '23505',
+    null,
+    'an active event candidate cannot create a duplicate draft from another source'
+);
+
+select * from finish();
+rollback;

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -266,7 +266,7 @@ pub(crate) trait DBDashboardGroup {
         group_id: Uuid,
         item_id: Uuid,
     ) -> Result<()>;
-    /// Rejects a pending discovered event while retaining its fingerprint.
+    /// Rejects a pending discovered event while retaining source-scoped audit history.
     async fn reject_group_event_discovery_item(
         &self,
         actor_user_id: Uuid,

--- a/ocg-server/src/db/jobs.rs
+++ b/ocg-server/src/db/jobs.rs
@@ -65,7 +65,7 @@ pub(crate) trait DBJobs {
     async fn delete_job_discovery_source(&self, user_id: Uuid, source_id: Uuid) -> Result<()>;
     /// Publishes a pending discovered job.
     async fn approve_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()>;
-    /// Rejects a pending discovered job while retaining its fingerprint.
+    /// Rejects a pending discovered job while retaining source-scoped audit history.
     async fn reject_job_discovery_item(&self, user_id: Uuid, item_id: Uuid) -> Result<()>;
 }
 

--- a/ocg-server/src/handlers/dashboard/group/integrations.rs
+++ b/ocg-server/src/handlers/dashboard/group/integrations.rs
@@ -138,7 +138,7 @@ pub(crate) async fn approve_item(
     ))
 }
 
-/// Rejects a discovered event and keeps its fingerprint from being re-ingested.
+/// Rejects a discovered event and retains its source-scoped audit history.
 #[instrument(skip_all, err)]
 pub(crate) async fn reject_item(
     CurrentUser(user): CurrentUser,

--- a/ocg-server/src/handlers/dashboard/jobs.rs
+++ b/ocg-server/src/handlers/dashboard/jobs.rs
@@ -244,7 +244,7 @@ pub(crate) async fn approve_discovery_item(
     ))
 }
 
-/// Rejects a discovered job and keeps its fingerprint from being re-ingested.
+/// Rejects a discovered job and retains its source-scoped audit history.
 #[instrument(skip_all, err)]
 pub(crate) async fn reject_discovery_item(
     messages: Messages,

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -216,7 +216,7 @@ async fn ingest_sources(
                 .fetch_scalar_opt(
                     "insert into group_event_integration_item (
                         group_id, source_url, candidate_url, fingerprint, discovered_payload
-                     ) values ($1, $2, $3, $4, $5) on conflict (group_id, fingerprint) do nothing
+                     ) values ($1, $2, $3, $4, $5) on conflict do nothing
                      returning group_event_integration_item_id",
                     &[
                         &source.group_id,

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -158,7 +158,7 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
                     let item: Option<Uuid> = db.fetch_scalar_opt(
                         "insert into jobs_discovery_item (
                             user_id, source_url, candidate_url, fingerprint, discovered_payload
-                         ) values ($1, $2, $3, $4, $5) on conflict (user_id, fingerprint) do nothing
+                         ) values ($1, $2, $3, $4, $5) on conflict do nothing
                          returning jobs_discovery_item_id",
                         &[
                             user_id,

--- a/ocg-server/templates/dashboard/group/events_add.html
+++ b/ocg-server/templates/dashboard/group/events_add.html
@@ -36,8 +36,8 @@
   </div>
 
   <div class="mb-10 grid min-w-0 grid-cols-1 items-stretch gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:gap-x-8">
-    <div class="min-w-0 overflow-x-auto overflow-y-hidden">
-      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium lg:gap-2">
+    <div class="min-w-0 overflow-x-auto">
+      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium [&>li]:w-auto [&>li]:shrink-0 [&>li>div>button]:w-auto [&>li>div>button]:whitespace-nowrap lg:gap-2">
         {{ event_form::tab_button(section = "details", icon = "event", label = "Details", active = true) -}}
         {{ event_form::tab_button(section = "date-venue", icon = "calendar", label = "Date & Venue") -}}
         {{ event_form::tab_button(section = "hosts-sponsors", icon = "user-plus", label = "Hosts & Speakers") -}}

--- a/ocg-server/templates/dashboard/group/events_update.html
+++ b/ocg-server/templates/dashboard/group/events_update.html
@@ -27,8 +27,8 @@
      data-group-banner-url="{%- if let Some(banner_url) = &event.group.banner_url -%}{{ banner_url }}{%- endif -%}"
      data-group-banner-mobile-url="{%- if let Some(banner_mobile_url) = &event.group.banner_mobile_url -%}{{ banner_mobile_url }}{%- endif -%}">
   <div class="mb-10 grid min-w-0 grid-cols-1 items-stretch gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:gap-x-8">
-    <div class="min-w-0 overflow-x-auto overflow-y-hidden">
-      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium lg:gap-2">
+    <div class="min-w-0 overflow-x-auto">
+      <ul class="inline-flex min-w-max flex-nowrap gap-1 border-b border-stone-900/10 text-center font-medium [&>li]:w-auto [&>li]:shrink-0 [&>li>div>button]:w-auto [&>li>div>button]:whitespace-nowrap lg:gap-2">
         {{ event_form::tab_button(section = "details", icon = "event", label = "Details", active = true) -}}
         {{ event_form::tab_button(section = "date-venue", icon = "calendar", label = "Date & Venue") -}}
         {{ event_form::tab_button(section = "hosts-sponsors", icon = "user-plus", label = "Hosts & Speakers") -}}

--- a/tests/unit/dashboard/group/events-add-template.test.js
+++ b/tests/unit/dashboard/group/events-add-template.test.js
@@ -131,4 +131,15 @@ describe("dashboard group event add template", () => {
       '<div class="min-w-0"> <div class="space-y-12">',
     );
   });
+
+  it("keeps top event tabs at their content width", async () => {
+    // Load the event add template before checking tab sizing constraints.
+    const template = normalizeWhitespace(await loadTemplate());
+
+    // Prevent horizontal tabs from inheriting the full-width sidebar tab layout.
+    expect(template).to.include(
+      '[&>li]:w-auto [&>li]:shrink-0 [&>li>div>button]:w-auto [&>li>div>button]:whitespace-nowrap',
+    );
+    expect(template).to.include('class="min-w-0 overflow-x-auto"');
+  });
 });


### PR DESCRIPTION
## Summary
- accept flexible raster logo source dimensions and normalize them into centered 360×360 PNGs without cropping
- raise only the logo source limit to 10 MB, with a decoded-pixel guard
- update logo upload guidance, validation tests, and image documentation

## Test plan
- [x] `cargo fmt --check --manifest-path ocg-server/Cargo.toml`
- [x] `cargo test --manifest-path ocg-server/Cargo.toml handlers::images::tests`
- [ ] `tests/unit/common/media/image-field.test.js` (web-test-runner is not installed locally)

Made with [Cursor](https://cursor.com)