### PR TITLE
feat: normalize flexible logo uploads

### DIFF
--- a/docs/features/images.md
+++ b/docs/features/images.md
@@ -31,16 +31,16 @@ pub(crate) type DynImageStorage = Arc<dyn ImageStorage + Send + Sync>;
 
 ## Image targets
 
-The upload handler recognises a `target` form field that controls the accepted dimensions:
+The upload handler recognises a `target` form field that controls image handling:
 
 | Target | Dimensions (px) |
 |---|---|
 | `banner` | 2428 × 192 |
 | `banner_mobile` | 1220 × 192 |
-| `logo` | 360 × 360 |
+| `logo` | Any source size; raster uploads are normalized into a 360 × 360 PNG |
 | `open_graph` | 1200 × 630 |
 
-Dimension validation is performed after decoding the upload using the `image` crate; uploads with incorrect dimensions are rejected with a descriptive error before any storage write.
+Banner and Open Graph dimensions are validated after decoding using the `image` crate. Raster logos are proportionally resized, centered on a transparent 360 × 360 canvas, and stored as PNG without cropping.
 
 ## Supported formats
 
@@ -48,11 +48,11 @@ GIF, JPEG, PNG, SVG, TIFF, WebP. SVG files bypass raster-dimension validation be
 
 ## Upload flow
 
-1. The client sends a `multipart/form-data` POST to `/images/upload` with fields `target` and `file`.
-2. `ocg-server/src/handlers/images.rs` — `upload` handler — extracts and validates the fields; total payload limit is **1 MiB** (`MAX_IMAGE_UPLOAD_BYTES`).
+1. The client sends a `multipart/form-data` POST to `/images` with fields `target` and `file`.
+2. `ocg-server/src/handlers/images.rs` — `upload` handler — extracts and validates the fields. Non-logo uploads are limited to **1 MiB**; logo sources are limited to **10 MiB** and a decoded-pixel guard before normalization.
 3. The referer header is checked against the configured hostname via `request_matches_site`; mismatches return `403 Forbidden`.
 4. The handler computes a content hash of the bytes (via `util::compute_hash`) to produce a deterministic file name, avoiding duplicate storage.
-5. For raster targets the handler decodes the image header to verify dimensions.
+5. The handler verifies banner/Open Graph dimensions and normalizes raster logos before storage.
 6. The `NewImage` struct is handed to `DynImageStorage::save`.
 7. A JSON body containing the resulting file name and public URL is returned to the client.
 

--- a/ocg-server/src/handlers/images.rs
+++ b/ocg-server/src/handlers/images.rs
@@ -13,7 +13,7 @@ use axum::{
     },
     response::IntoResponse,
 };
-use image::{ImageFormat, ImageReader};
+use image::{DynamicImage, ImageFormat, ImageReader, RgbaImage, imageops::FilterType};
 use quick_xml::{Reader, events::Event};
 use serde_json::json;
 use tracing::instrument;
@@ -31,8 +31,14 @@ use crate::{
 #[cfg(test)]
 mod tests;
 
-/// Maximum payload size allowed for image uploads (1 MiB).
+/// Maximum payload size allowed for non-logo image uploads (1 MiB).
 const MAX_IMAGE_SIZE_BYTES: usize = 1024 * 1024;
+/// Maximum source payload size allowed for logo image uploads (10 MiB).
+const MAX_LOGO_IMAGE_SIZE_BYTES: usize = 10 * 1024 * 1024;
+/// Maximum decoded source image size allowed for logo normalization.
+const MAX_LOGO_SOURCE_PIXELS: u64 = 16_000_000;
+/// Normalized logo dimensions.
+const LOGO_SIZE: u32 = 360;
 
 /// Cache-Control header for long-lived responses.
 const CACHE_CONTROL_IMMUTABLE: &str = "public, max-age=31536000, immutable";
@@ -113,9 +119,23 @@ pub(crate) async fn upload(
         return Ok((StatusCode::BAD_REQUEST, "missing file in upload payload").into_response());
     };
 
-    // Enforce maximum file size
-    if data.len() > MAX_IMAGE_SIZE_BYTES {
-        return Ok((StatusCode::PAYLOAD_TOO_LARGE, "image exceeds 1MB limit").into_response());
+    // Allow larger logo source files because they are normalized before storage.
+    let max_upload_size = if matches!(target, Some(ImageTarget::Logo)) {
+        MAX_LOGO_IMAGE_SIZE_BYTES
+    } else {
+        MAX_IMAGE_SIZE_BYTES
+    };
+    if data.len() > max_upload_size {
+        let limit_label = if matches!(target, Some(ImageTarget::Logo)) {
+            "10MB"
+        } else {
+            "1MB"
+        };
+        return Ok((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("image exceeds {limit_label} limit"),
+        )
+            .into_response());
     }
 
     // Detect image format and check extension matches
@@ -129,33 +149,51 @@ pub(crate) async fn upload(
             .into_response());
     }
 
-    // Validate target-specific image requirements
-    if let Some(target) = target {
-        // Validate Open Graph image format
-        if matches!(target, ImageTarget::OpenGraph) && !format.is_open_graph_supported() {
-            return Ok((
-                StatusCode::UNPROCESSABLE_ENTITY,
-                "Open Graph images must be PNG, JPEG, or WebP",
-            )
-                .into_response());
+    // Validate target-specific image requirements and normalize flexible raster
+    // logo uploads to a centered transparent 360x360 PNG.
+    let (stored_data, stored_format, stored_extension) = if matches!(
+        target,
+        Some(ImageTarget::Logo)
+    ) && !matches!(
+        format,
+        SupportedImageFormat::Svg
+    ) {
+        (
+            normalize_logo(data.as_ref())?,
+            SupportedImageFormat::Png,
+            Cow::Borrowed("png"),
+        )
+    } else {
+        // Validate target-specific image requirements
+        if let Some(target) = target {
+            // Validate Open Graph image format
+            if matches!(target, ImageTarget::OpenGraph) && !format.is_open_graph_supported() {
+                return Ok((
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    "Open Graph images must be PNG, JPEG, or WebP",
+                )
+                    .into_response());
+            }
+
+            // SVG logos remain vectors; all other unchanged targets require exact dimensions.
+            if !matches!(format, SupportedImageFormat::Svg)
+                && let Err(e) = validate_image_dimensions(data.as_ref(), target)
+            {
+                return Ok((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response());
+            }
         }
 
-        // Validate target dimensions when the format supports dimension checks
-        if !matches!(format, SupportedImageFormat::Svg)
-            && let Err(e) = validate_image_dimensions(data.as_ref(), target)
-        {
-            return Ok((StatusCode::UNPROCESSABLE_ENTITY, e.to_string()).into_response());
-        }
-    }
+        (data.to_vec(), format, extension)
+    };
 
     // Compute file hash
-    let hash = compute_hash(data.as_ref());
+    let hash = compute_hash(&stored_data);
 
     // Store image using the configured storage provider
     let new_image = NewImage {
-        bytes: data.as_ref(),
-        content_type: mime_type(&format),
-        file_name: &format!("{hash}.{extension}"),
+        bytes: &stored_data,
+        content_type: mime_type(&stored_format),
+        file_name: &format!("{hash}.{stored_extension}"),
         user_id: user.user_id,
     };
     image_storage.save(&new_image).await?;
@@ -166,52 +204,39 @@ pub(crate) async fn upload(
     Ok((StatusCode::CREATED, body).into_response())
 }
 
+/// Normalizes a raster logo to a centered 360x360 transparent PNG without cropping.
+fn normalize_logo(bytes: &[u8]) -> Result<Vec<u8>> {
+    let reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .context("failed to detect image format")?;
+    let (width, height) = reader.into_dimensions().context("failed to read dimensions")?;
+    let pixel_count = u64::from(width) * u64::from(height);
+    if pixel_count > MAX_LOGO_SOURCE_PIXELS {
+        return Err(anyhow!(
+            "logo dimensions {width}x{height} exceed the {MAX_LOGO_SOURCE_PIXELS}-pixel limit"
+        ));
+    }
+
+    let source = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .context("failed to detect image format")?
+        .decode()
+        .context("failed to decode logo image")?;
+    let resized = source.resize(LOGO_SIZE, LOGO_SIZE, FilterType::Lanczos3);
+    let resized = resized.to_rgba8();
+    let mut canvas = RgbaImage::new(LOGO_SIZE, LOGO_SIZE);
+    let x = i64::from((LOGO_SIZE - resized.width()) / 2);
+    let y = i64::from((LOGO_SIZE - resized.height()) / 2);
+    image::imageops::overlay(&mut canvas, &resized, x, y);
+
+    let mut output = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(canvas)
+        .write_to(&mut output, ImageFormat::Png)
+        .context("failed to encode normalized logo")?;
+    Ok(output.into_inner())
+}
+
 // Helpers
-
-/// Detects the image format using the `image` crate with a fallback for SVGs.
-fn detect_image_format(bytes: &[u8], extension: &str) -> Result<SupportedImageFormat> {
-    match image::guess_format(bytes) {
-        Ok(ImageFormat::Gif) => Ok(SupportedImageFormat::Gif),
-        Ok(ImageFormat::Jpeg) => Ok(SupportedImageFormat::Jpeg),
-        Ok(ImageFormat::Png) => Ok(SupportedImageFormat::Png),
-        Ok(ImageFormat::Tiff) => Ok(SupportedImageFormat::Tiff),
-        Ok(ImageFormat::WebP) => Ok(SupportedImageFormat::Webp),
-        Ok(other) => Err(anyhow!("unsupported image format: {other:?}")),
-        Err(_) if is_svg(bytes, extension) => Ok(SupportedImageFormat::Svg),
-        Err(_) => Err(anyhow!("unsupported image format")),
-    }
-}
-
-/// Returns the accepted extensions for the provided format.
-fn expected_extensions(format: &SupportedImageFormat) -> &'static [&'static str] {
-    match format {
-        SupportedImageFormat::Gif => &["gif"],
-        SupportedImageFormat::Jpeg => &["jpg", "jpeg"],
-        SupportedImageFormat::Png => &["png"],
-        SupportedImageFormat::Svg => &["svg"],
-        SupportedImageFormat::Tiff => &["tif", "tiff"],
-        SupportedImageFormat::Webp => &["webp"],
-    }
-}
-
-/// Validates that the extension matches the detected image format.
-fn extension_matches(format: &SupportedImageFormat, extension: &str) -> bool {
-    expected_extensions(format)
-        .iter()
-        .any(|candidate| candidate == &extension)
-}
-
-/// Extracts the lowercase file extension from a file name.
-fn image_extension(file_name: &str) -> Result<Cow<'_, str>> {
-    let extension = file_name
-        .rsplit('.')
-        .next()
-        .ok_or_else(|| anyhow!("missing file extension"))?;
-    if extension.is_empty() {
-        return Err(anyhow!("missing file extension"));
-    }
-    Ok(Cow::from(extension.to_ascii_lowercase()))
-}
 
 /// Determines whether the provided bytes and extension represent a valid SVG asset.
 ///
@@ -351,7 +376,6 @@ async fn serve_image(
 
     // Build the image response body
     let body = Body::from(image.bytes);
-
     Ok((StatusCode::OK, response_headers, body).into_response())
 }
 
@@ -389,7 +413,7 @@ impl ImageTarget {
         match self {
             ImageTarget::Banner => (2428, 192),
             ImageTarget::BannerMobile => (1220, 192),
-            ImageTarget::Logo => (360, 360),
+            ImageTarget::Logo => (LOGO_SIZE, LOGO_SIZE),
             ImageTarget::OpenGraph => (OPEN_GRAPH_IMAGE_WIDTH, OPEN_GRAPH_IMAGE_HEIGHT),
         }
     }
@@ -410,6 +434,7 @@ impl FromStr for ImageTarget {
 }
 
 /// Supported image formats accepted by the upload endpoint.
+#[derive(Clone, Copy)]
 enum SupportedImageFormat {
     Gif,
     Jpeg,
@@ -424,4 +449,49 @@ impl SupportedImageFormat {
     fn is_open_graph_supported(&self) -> bool {
         matches!(self, Self::Jpeg | Self::Png | Self::Webp)
     }
+}
+
+/// Detects the image format using the `image` crate with a fallback for SVGs.
+fn detect_image_format(bytes: &[u8], extension: &str) -> Result<SupportedImageFormat> {
+    match image::guess_format(bytes) {
+        Ok(ImageFormat::Gif) => Ok(SupportedImageFormat::Gif),
+        Ok(ImageFormat::Jpeg) => Ok(SupportedImageFormat::Jpeg),
+        Ok(ImageFormat::Png) => Ok(SupportedImageFormat::Png),
+        Ok(ImageFormat::Tiff) => Ok(SupportedImageFormat::Tiff),
+        Ok(ImageFormat::WebP) => Ok(SupportedImageFormat::Webp),
+        Ok(other) => Err(anyhow!("unsupported image format: {other:?}")),
+        Err(_) if is_svg(bytes, extension) => Ok(SupportedImageFormat::Svg),
+        Err(_) => Err(anyhow!("unsupported image format")),
+    }
+}
+
+/// Returns the accepted extensions for the provided format.
+fn expected_extensions(format: &SupportedImageFormat) -> &'static [&'static str] {
+    match format {
+        SupportedImageFormat::Gif => &["gif"],
+        SupportedImageFormat::Jpeg => &["jpg", "jpeg"],
+        SupportedImageFormat::Png => &["png"],
+        SupportedImageFormat::Svg => &["svg"],
+        SupportedImageFormat::Tiff => &["tif", "tiff"],
+        SupportedImageFormat::Webp => &["webp"],
+    }
+}
+
+/// Validates that the extension matches the detected image format.
+fn extension_matches(format: &SupportedImageFormat, extension: &str) -> bool {
+    expected_extensions(format)
+        .iter()
+        .any(|candidate| candidate == &extension)
+}
+
+/// Extracts the lowercase file extension from a file name.
+fn image_extension(file_name: &str) -> Result<Cow<'_, str>> {
+    let extension = file_name
+        .rsplit('.')
+        .next()
+        .ok_or_else(|| anyhow!("missing file extension"))?;
+    if extension.is_empty() {
+        return Err(anyhow!("missing file extension"));
+    }
+    Ok(Cow::from(extension.to_ascii_lowercase()))
 }

--- a/ocg-server/src/handlers/images/tests.rs
+++ b/ocg-server/src/handlers/images/tests.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{io::Cursor, sync::Arc};
 
 use axum::http::header::{CACHE_CONTROL, CONTENT_TYPE, COOKIE, HOST, REFERER};
 use axum::{
@@ -8,7 +8,7 @@ use axum::{
     routing::get,
 };
 use axum_login::tower_sessions::session;
-use image::{ImageFormat, RgbaImage};
+use image::{GenericImageView, ImageFormat, RgbaImage};
 use serde_json::Value;
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -34,6 +34,27 @@ const PNG_BYTES: &[u8] = &[
     0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
     0x42, 0x60, 0x82,
 ];
+
+#[test]
+fn test_normalize_logo_centers_non_square_raster_image() {
+    // Encode a wide opaque source image to exercise the server normalization path.
+    let source = RgbaImage::from_pixel(720, 360, image::Rgba([12, 34, 56, 255]));
+    let mut source_bytes = Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgba8(source)
+        .write_to(&mut source_bytes, ImageFormat::Png)
+        .unwrap();
+
+    // Normalize the logo, then inspect its dimensions and transparent padding.
+    let normalized = normalize_logo(&source_bytes.into_inner()).unwrap();
+    let image = image::load_from_memory_with_format(&normalized, ImageFormat::Png).unwrap();
+
+    assert_eq!(image.dimensions(), (LOGO_SIZE, LOGO_SIZE));
+    assert_eq!(image.get_pixel(0, 0), image::Rgba([0, 0, 0, 0]));
+    assert_eq!(
+        image.get_pixel(LOGO_SIZE / 2, LOGO_SIZE / 2),
+        image::Rgba([12, 34, 56, 255])
+    );
+}
 
 #[test]
 fn test_is_svg_accepts_valid_svg() {

--- a/ocg-server/static/js/common/media/image-field.js
+++ b/ocg-server/static/js/common/media/image-field.js
@@ -7,6 +7,7 @@ import {
   getImageUploadErrorMessage,
   IMAGE_UPLOAD_MAX_SIZE_TEXT,
   IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT,
+  LOGO_IMAGE_UPLOAD_MAX_SIZE_TEXT,
   OPEN_GRAPH_IMAGE_ACCEPTED_FORMATS,
   uploadImageFile,
 } from "/static/js/common/media/image-upload.js";
@@ -209,7 +210,7 @@ export class ImageField extends LitWrapper {
       const imageUrl = await uploadImageFile(file, { target: this.target });
       this.setValue(imageUrl);
     } catch (error) {
-      showErrorAlert(getImageUploadErrorMessage("image", error.message), true);
+      showErrorAlert(getImageUploadErrorMessage("image", error.message, this.target), true);
     } finally {
       this._isUploading = false;
       if (typeof resetCallback === "function") {
@@ -256,13 +257,16 @@ export class ImageField extends LitWrapper {
     const bannerLikeKinds = [IMAGE_KIND.BANNER];
     const isWide = bannerLikeKinds.includes(this.imageKind);
     const isOpenGraphTarget = this.target === IMAGE_TARGET.OPEN_GRAPH;
+    const isLogoTarget = this.target === IMAGE_KIND.LOGO;
     const removeDisabled = !this._hasImage || this._isUploading;
     const helpPrefixText = (this.helpPrefixText || "").trim();
     const helpText = isOpenGraphTarget
       ? IMAGE_UPLOAD_MAX_SIZE_TEXT
+      : isLogoTarget
+        ? `Images can be any size. Raster logos are fitted inside a 360 x 360 px square without cropping. ${LOGO_IMAGE_UPLOAD_MAX_SIZE_TEXT} ${IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT}`
       : isWide
         ? `${IMAGE_UPLOAD_MAX_SIZE_TEXT} ${IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT}`
-        : `Images must be 360 x 360 px (square). ${IMAGE_UPLOAD_MAX_SIZE_TEXT} ${IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT}`;
+        : `${IMAGE_UPLOAD_MAX_SIZE_TEXT} ${IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT}`;
     const combinedHelpText = helpPrefixText.length > 0 ? `${helpPrefixText} ${helpText}` : helpText;
     const acceptedFormats = isOpenGraphTarget
       ? OPEN_GRAPH_IMAGE_ACCEPTED_FORMATS

--- a/ocg-server/static/js/common/media/image-upload.js
+++ b/ocg-server/static/js/common/media/image-upload.js
@@ -4,6 +4,7 @@ import { ocgFetch } from "/static/js/common/fetch.js";
 export const DEFAULT_IMAGE_ACCEPTED_FORMATS = ".svg,.png,.jpg,.jpeg,.gif,.webp,.tif,.tiff";
 export const OPEN_GRAPH_IMAGE_ACCEPTED_FORMATS = ".png,.jpg,.jpeg,.webp";
 export const IMAGE_UPLOAD_MAX_SIZE_TEXT = "Maximum size: 1MB.";
+export const LOGO_IMAGE_UPLOAD_MAX_SIZE_TEXT = "Maximum source size: 10MB.";
 export const IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT = "Supported formats: SVG, PNG, JPEG, GIF, WEBP and TIFF.";
 export const IMAGE_UPLOAD_ERROR_DETAILS = `${IMAGE_UPLOAD_MAX_SIZE_TEXT} ${IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT}`;
 
@@ -65,14 +66,18 @@ export const uploadImageFile = async (file, { target = "" } = {}) => {
  * Builds the shared upload failure alert body.
  * @param {string} imageLabel - Human-facing noun for the failed upload
  * @param {string} serverMessage - Specific server error message when available
+ * @param {string} target - Optional upload target for target-specific guidance
  * @returns {string} HTML message accepted by the alert helper
  */
-export const getImageUploadErrorMessage = (imageLabel, serverMessage = "") => {
+export const getImageUploadErrorMessage = (imageLabel, serverMessage = "", target = "") => {
   const specificMessage = serverMessage.trim();
   const escapedMessage = specificMessage ? escapeHtml(specificMessage) : "";
   const message = escapedMessage
     ? `${escapedMessage}<br /><br />Something went wrong adding the ${imageLabel}. Please try again later.`
     : `Something went wrong adding the ${imageLabel}. Please try again later.`;
+  const details = target === "logo"
+    ? `${LOGO_IMAGE_UPLOAD_MAX_SIZE_TEXT} ${IMAGE_UPLOAD_SUPPORTED_FORMATS_TEXT}`
+    : IMAGE_UPLOAD_ERROR_DETAILS;
 
-  return `${message}<br /><br /><div class="text-sm text-stone-500">${IMAGE_UPLOAD_ERROR_DETAILS}</div>`;
+  return `${message}<br /><br /><div class="text-sm text-stone-500">${details}</div>`;
 };

--- a/ocg-server/templates/dashboard/alliance/create.html
+++ b/ocg-server/templates/dashboard/alliance/create.html
@@ -73,7 +73,7 @@
       {{ dashboard::form_title(title = "Branding", description = "Provide initial public images. You can update these later in settings.") -}}
 
       <div class="mt-10 grid max-w-5xl grid-cols-1 gap-x-6 gap-y-8 md:grid-cols-6">
-        {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", target = "logo", help_prefix_text = "Size required 360 x 360 px.", extra_attrs = "required") -}}
+        {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", target = "logo", extra_attrs = "required") -}}
         {{ form_fields::image_field(label = "Banner", name = "banner_url", image_kind = "banner", target = "banner", help_prefix_text = "Size required 2428 x 192 px.", extra_attrs = "required") -}}
         {{ form_fields::image_field(label = "Banner Mobile", name = "banner_mobile_url", image_kind = "banner", target = "banner_mobile", help_prefix_text = "Size required 1220 x 192 px.", extra_attrs = "required") -}}
       </div>

--- a/ocg-server/templates/dashboard/alliance/settings_update.html
+++ b/ocg-server/templates/dashboard/alliance/settings_update.html
@@ -235,7 +235,7 @@
           {% let og_image_value -%}value="{%- if let Some(og_image_url) = &alliance.og_image_url -%}{{ og_image_url }}{%- endif -%}"{%- endlet %}
 
           {# Logo URL -#}
-          {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", target = "logo", help_prefix_text = "Size required 360 x 360 px.", value_attr = logo_value, extra_attrs = "required") -}}
+          {{ form_fields::image_field(label = "Logo", name = "logo_url", image_kind = "logo", target = "logo", value_attr = logo_value, extra_attrs = "required") -}}
           {# End logo URL -#}
 
           {# Banner URL -#}

--- a/tests/unit/common/media/image-field.test.js
+++ b/tests/unit/common/media/image-field.test.js
@@ -109,6 +109,22 @@ describe("image-field", () => {
     expect(fileInput.accept).to.equal(".svg,.png,.jpg,.jpeg,.gif,.webp,.tif,.tiff");
   });
 
+  it("explains that logos are automatically fitted into a square", async () => {
+    // Mount a logo image field with the server-side normalization target.
+    const element = await mountLitComponent("image-field", {
+      label: "Logo",
+      name: "logo_url",
+      imageKind: "logo",
+      target: "logo",
+    });
+
+    // Confirm the guidance permits flexible source dimensions without cropping.
+    const helpText = element.querySelector(".form-legend").textContent.trim();
+    expect(helpText).to.include("Images can be any size.");
+    expect(helpText).to.include("360 x 360 px square without cropping.");
+    expect(helpText).to.include("Maximum source size: 10MB.");
+  });
+
   it("shows escaped server messages when image uploads fail", async () => {
     // Mock the upload endpoint with a server validation message.
     fetchMock.setImpl(async () => ({


### PR DESCRIPTION
Accept arbitrary-size raster logos and store centered 360px derivatives so users no longer need to pre-size assets.