### PR TITLE
feat: crawl You.com event search results

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -84,6 +84,23 @@ Keyed by provider name (`google`). Each entry has:
 | `redirect_uri` | Callback URL |
 | `scopes` | Requested scopes |
 
+## You.com event discovery (`integrations.you_com`)
+
+| Key | Env var | Default | Description |
+|-----|---------|---------|-------------|
+| `enabled` | `OCG_INTEGRATIONS__YOU_COM__ENABLED` | `false` | Enable scheduled event discovery |
+| `api_key` | `OCG_INTEGRATIONS__YOU_COM__API_KEY` | — | You.com Search API key |
+| `search_url` | `OCG_INTEGRATIONS__YOU_COM__SEARCH_URL` | `https://api.you.com/v1/search` | You.com Search API endpoint |
+| `livecrawl` | `OCG_INTEGRATIONS__YOU_COM__LIVECRAWL` | `true` | Request crawled HTML from You.com for web results |
+| `livecrawl_count` | `OCG_INTEGRATIONS__YOU_COM__LIVECRAWL_COUNT` | `10` | Maximum web results crawled per discovery query (1–10) |
+| `livecrawl_timeout_secs` | `OCG_INTEGRATIONS__YOU_COM__LIVECRAWL_TIMEOUT_SECS` | `10` | Per-result crawl timeout in seconds (1–60) |
+| `schedule_timezone` | `OCG_INTEGRATIONS__YOU_COM__SCHEDULE_TIMEZONE` | `Asia/Baku` | IANA timezone for the daily discovery run |
+| `schedule_hour` | `OCG_INTEGRATIONS__YOU_COM__SCHEDULE_HOUR` | `9` | Hour of the daily discovery run (0–23) |
+
+Livecrawl is billed per crawled result and can add latency. It is used only for
+web results; when no crawled HTML is available, event discovery falls back to
+the source page fetch and then to strict RFC3339 dates from search snippets.
+
 ## Meetings (`meetings`) — optional
 
 | Key | Description |

--- a/ocg-server/src/config.rs
+++ b/ocg-server/src/config.rs
@@ -133,6 +133,15 @@ pub(crate) struct YouComConfig {
     /// Search endpoint, allowing API-version changes without source changes.
     #[serde(default = "default_you_com_search_url")]
     pub search_url: String,
+    /// Request crawled HTML for web search results.
+    #[serde(default = "default_you_com_livecrawl")]
+    pub livecrawl: bool,
+    /// Maximum web results to crawl for each discovery query.
+    #[serde(default = "default_you_com_livecrawl_count")]
+    pub livecrawl_count: u8,
+    /// Maximum seconds You.com may spend crawling each result.
+    #[serde(default = "default_you_com_livecrawl_timeout_secs")]
+    pub livecrawl_timeout_secs: u8,
     /// IANA timezone used to schedule the daily discovery run.
     #[serde(default = "default_baku_timezone")]
     pub schedule_timezone: String,
@@ -152,6 +161,12 @@ impl YouComConfig {
         self.search_url
             .parse::<reqwest::Url>()
             .map_err(|err| anyhow::anyhow!("invalid integrations.you_com.search_url: {err}"))?;
+        if self.livecrawl_count == 0 || self.livecrawl_count > 10 {
+            bail!("integrations.you_com.livecrawl_count must be between 1 and 10");
+        }
+        if self.livecrawl_timeout_secs == 0 || self.livecrawl_timeout_secs > 60 {
+            bail!("integrations.you_com.livecrawl_timeout_secs must be between 1 and 60");
+        }
         self.schedule_timezone.parse::<chrono_tz::Tz>().map_err(|err| {
             anyhow::anyhow!("invalid integrations.you_com.schedule_timezone: {err}")
         })?;
@@ -161,6 +176,18 @@ impl YouComConfig {
 
 fn default_you_com_search_url() -> String {
     "https://api.you.com/v1/search".into()
+}
+
+const fn default_you_com_livecrawl() -> bool {
+    true
+}
+
+const fn default_you_com_livecrawl_count() -> u8 {
+    10
+}
+
+const fn default_you_com_livecrawl_timeout_secs() -> u8 {
+    10
 }
 
 fn default_baku_timezone() -> String {

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -39,6 +39,9 @@ impl DiscoveredEvent {
 pub(crate) struct YouComClient {
     api_key: String,
     http: Client,
+    livecrawl: bool,
+    livecrawl_count: u8,
+    livecrawl_timeout_secs: u8,
     search_url: String,
 }
 
@@ -48,6 +51,9 @@ impl YouComClient {
         Ok(Self {
             api_key: cfg.api_key.clone(),
             http,
+            livecrawl: cfg.livecrawl,
+            livecrawl_count: cfg.livecrawl_count,
+            livecrawl_timeout_secs: cfg.livecrawl_timeout_secs,
             search_url: cfg.search_url.clone(),
         })
     }
@@ -56,7 +62,18 @@ impl YouComClient {
     pub(crate) async fn search(&self, query: &str) -> Result<Vec<SearchResult>> {
         let mut search_url =
             reqwest::Url::parse(&self.search_url).context("invalid You.com search URL")?;
-        search_url.query_pairs_mut().append_pair("query", query);
+        {
+            let mut query_pairs = search_url.query_pairs_mut();
+            query_pairs
+                .append_pair("query", query)
+                .append_pair("count", &self.livecrawl_count.to_string());
+            if self.livecrawl {
+                query_pairs
+                    .append_pair("livecrawl", "web")
+                    .append_pair("livecrawl_formats", "html")
+                    .append_pair("crawl_timeout", &self.livecrawl_timeout_secs.to_string());
+            }
+        }
         let response = self
             .http
             .get(search_url)
@@ -83,6 +100,15 @@ pub(crate) struct SearchResult {
     pub description: Option<String>,
     #[serde(default)]
     pub snippets: Vec<String>,
+    #[serde(default)]
+    pub contents: Option<SearchResultContents>,
+}
+
+/// Content returned for a result when You.com livecrawl is enabled.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchResultContents {
+    #[serde(default)]
+    pub html: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -157,6 +183,7 @@ mod tests {
             url: url.into(),
             description: description.map(str::to_owned),
             snippets: vec![],
+            contents: None,
         }
     }
 
@@ -208,7 +235,11 @@ mod tests {
         let payload: SearchResponse = serde_json::from_str(
             r#"{
                 "results": {
-                    "web": [{"title": "Baku meetup", "url": "https://example.test/web"}],
+                    "web": [{
+                        "title": "Baku meetup",
+                        "url": "https://example.test/web",
+                        "contents": {"html": "<script type=\"application/ld+json\">{}</script>"}
+                    }],
                     "news": [{"title": "Baku news", "url": "https://example.test/news"}]
                 }
             }"#,
@@ -217,5 +248,12 @@ mod tests {
 
         assert_eq!(payload.results.web.len(), 1);
         assert_eq!(payload.results.news.len(), 1);
+        assert_eq!(
+            payload.results.web[0]
+                .contents
+                .as_ref()
+                .and_then(|contents| contents.html.as_deref()),
+            Some(r#"<script type="application/ld+json">{}</script>"#)
+        );
     }
 }

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -15,12 +15,14 @@ use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, dashboard::group::DBDashboardGroup},
     integrations::{
-        event_page::{EventPageClient, validate_candidate_url},
+        event_page::{EventPageClient, extract_event_json_ld, validate_candidate_url},
         you_com::{
             DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_city_results,
         },
     },
 };
+
+const MAX_LIVECRAWL_HTML_BYTES: usize = 1_000_000;
 
 /// Executes authorized, on-demand discovery runs from the dashboard.
 #[derive(Clone)]
@@ -195,12 +197,15 @@ async fn ingest_sources(
                 info!(%err, candidate_url = %result.url, source_url = %source.url, "skipped unsafe event discovery candidate");
                 continue;
             }
-            let event = match event_pages.fetch(&result.url, &source.url).await {
-                Ok(event) => event.or_else(|| parse_discovered_event(&result, &result.url)),
-                Err(err) => {
-                    info!(%err, candidate_url = %result.url, "could not enrich event discovery candidate");
-                    parse_discovered_event(&result, &result.url)
-                }
+            let event = match event_from_livecrawl(&result) {
+                Some(event) => Some(event),
+                None => match event_pages.fetch(&result.url, &source.url).await {
+                    Ok(event) => event.or_else(|| parse_discovered_event(&result, &result.url)),
+                    Err(err) => {
+                        info!(%err, candidate_url = %result.url, "could not enrich event discovery candidate");
+                        parse_discovered_event(&result, &result.url)
+                    }
+                },
             };
             if let Some(event) = event {
                 events.push(event);
@@ -305,6 +310,17 @@ async fn ingest_sources(
     }
     result?;
     Ok(())
+}
+
+/// Extract an event from bounded HTML returned by You.com livecrawl.
+fn event_from_livecrawl(result: &SearchResult) -> Option<DiscoveredEvent> {
+    result
+        .contents
+        .as_ref()?
+        .html
+        .as_deref()
+        .filter(|html| html.len() <= MAX_LIVECRAWL_HTML_BYTES)
+        .and_then(|html| extract_event_json_ld(html, &result.url))
 }
 
 /// Extract only events with an explicit RFC3339 date from the search response.
@@ -423,6 +439,7 @@ mod tests {
             url: "https://example.test/event".into(),
             description: Some("Join us next Thursday in Baku".into()),
             snippets: vec![],
+            contents: None,
         };
         assert!(parse_discovered_event(&result, "https://example.test").is_none());
     }
@@ -434,8 +451,46 @@ mod tests {
             url: "https://example.test/event".into(),
             description: Some("Starts 2099-07-21T12:00:00Z in Baku".into()),
             snippets: vec![],
+            contents: None,
         };
         let event = parse_discovered_event(&result, "https://example.test").unwrap();
         assert_eq!(event.title, "Baku Rust meetup");
+    }
+
+    #[test]
+    fn prefers_event_json_ld_from_livecrawl_content() {
+        let result = SearchResult {
+            title: "Search result title".into(),
+            url: "https://example.test/event".into(),
+            description: None,
+            snippets: vec![],
+            contents: Some(crate::integrations::you_com::SearchResultContents {
+                html: Some(
+                    r#"<script type="application/ld+json">
+                        {"@type":"Event","name":"Baku Rust meetup","startDate":"2099-07-21T12:00:00Z"}
+                    </script>"#
+                        .into(),
+                ),
+            }),
+        };
+
+        let event = event_from_livecrawl(&result).unwrap();
+        assert_eq!(event.title, "Baku Rust meetup");
+        assert_eq!(event.source_url, "https://example.test/event");
+    }
+
+    #[test]
+    fn rejects_oversized_livecrawl_content() {
+        let result = SearchResult {
+            title: "Search result title".into(),
+            url: "https://example.test/event".into(),
+            description: None,
+            snippets: vec![],
+            contents: Some(crate::integrations::you_com::SearchResultContents {
+                html: Some("x".repeat(MAX_LIVECRAWL_HTML_BYTES + 1)),
+            }),
+        };
+
+        assert!(event_from_livecrawl(&result).is_none());
     }
 }

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -323,6 +323,7 @@ mod tests {
                 url: "https://x.test".into(),
                 description: None,
                 snippets: vec![],
+                contents: None,
             })
             .is_none()
         );
@@ -334,6 +335,7 @@ mod tests {
             url: "https://x.test/jobs/1".into(),
             description: Some("Build reliable systems.".into()),
             snippets: vec![],
+            contents: None,
         })
         .unwrap();
         assert_eq!(job.company_name, "Acme");
@@ -346,6 +348,7 @@ mod tests {
             url: "https://x.test/jobs/1".into(),
             description: None,
             snippets: vec!["Build reliable systems.".into()],
+            contents: None,
         })
         .unwrap();
         assert_eq!(job.summary, "Build reliable systems.");
@@ -358,6 +361,7 @@ mod tests {
             url: "https://careers.bcg.com/search-results".into(),
             description: Some("Have questions about careers at BCG?".into()),
             snippets: vec![],
+            contents: None,
         });
         assert!(job.is_none());
     }


### PR DESCRIPTION
## Summary
- request bounded You.com livecrawl HTML for event search results
- extract structured Event JSON-LD before provider-specific direct fetches
- document livecrawl configuration, cost, and fallback behavior

## Test plan
- [x] `cargo fmt --manifest-path ocg-server/Cargo.toml --check`
- [x] `cargo test --manifest-path ocg-server/Cargo.toml integrations::you_com`
- [x] `cargo test --manifest-path ocg-server/Cargo.toml services::event_discovery`
- [ ] Full clippy (blocked by existing unrelated warnings outside this change)

Made with [Cursor](https://cursor.com)