### PR TITLE
feat: scale discovery source imports and notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ ocg-server/static/css/styles.css
 .config/ocg/server.yml
 .config/ocg/tern.conf
 .gstack/
+/database/data/discovery/jobs-sources.csv
+/database/data/discovery/events-sources.csv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +196,17 @@ dependencies = [
  "serde_derive",
  "unicode-ident",
  "winnow",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -376,7 +393,7 @@ dependencies = [
  "http-body-util",
  "md-5",
  "pin-project-lite",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "tracing",
 ]
@@ -582,6 +599,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -601,8 +619,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1042,7 +1062,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
+ "futures-core",
  "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1057,6 +1081,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1696,6 +1729,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,21 +1922,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1891,21 +1945,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -3131,6 +3185,7 @@ dependencies = [
  "deadpool-postgres",
  "emojis",
  "figment",
+ "futures-util",
  "garde",
  "hex",
  "hmac 0.13.0",
@@ -3150,6 +3205,7 @@ dependencies = [
  "postgres-openssl",
  "qrcode",
  "quick-xml",
+ "redis",
  "reqwest 0.13.4",
  "rkyv",
  "rust-embed",
@@ -3696,6 +3752,12 @@ dependencies = [
  "serde_json",
  "vlq",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4337,6 +4399,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b9503711b03773e43b31668c7b5bd279ee7cd9b7d18cff7c23a42cc1d08e5a"
+dependencies = [
+ "arcstr",
+ "async-lock",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4961,6 +5048,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -4969,6 +5067,12 @@ dependencies = [
  "cpufeatures 0.3.0",
  "digest 0.11.2",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -5456,6 +5560,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5692,6 +5808,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.1",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1 0.10.7",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typenum"
@@ -6452,6 +6584,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ aws-sdk-s3 = { version = "1.137.0", default-features = false, features = [
     "rt-tokio",
     "sigv4a",
 ] }
-axum = { version = "0.8.9", features = ["macros", "multipart"] }
+axum = { version = "0.8.9", features = ["macros", "multipart", "ws"] }
 axum-login = "0.18.0"
 axum-messages = "0.8.0"
 bytes = "1.12.0"
@@ -35,6 +35,7 @@ csv = "1.4.0"
 deadpool-postgres = { version = "0.14.1", features = ["serde"] }
 emojis = "0.9.0"
 figment = { version = "0.10.19", features = ["yaml", "env"] }
+futures-util = "0.3.33"
 garde = { version = "0.23.0", features = ["derive", "url", "email"] }
 hex = "0.4"
 hmac = "0.13.0"
@@ -55,6 +56,7 @@ postgres-openssl = "0.5.3"
 quick-xml = "0.41.0"
 qrcode = { version = "0.14.1", features = ["svg"] }
 reqwest = { version = "0.13.4", features = ["json"] }
+redis = { version = "1.4.1", features = ["tokio-comp"] }
 # Keep this exact pin so the workspace resolves to patched rkyv 0.7.46.
 # parcel_sourcemap otherwise pulls vulnerable rkyv 0.7.45 (RUSTSEC-2026-0001).
 rkyv = "=0.7.46"

--- a/database/data/discovery/README.md
+++ b/database/data/discovery/README.md
@@ -1,0 +1,44 @@
+# Discovery catalogs
+
+`jobs-sources.csv` and `events-sources.csv` are source catalogs, not job or event
+records. Every row uses this schema:
+
+```text
+url,label,category,region,verified_at,provenance
+```
+
+`verified_at` is the UTC date on which `build_catalogs.py` successfully fetched
+the canonical URL. `provenance` identifies the pinned upstream dataset and the
+live HTTP status observed by that build; it is deliberately not a claim that an
+organizer endorses this catalog.
+
+## Rebuild and validate
+
+```sh
+python3 database/data/discovery/build_catalogs.py --build
+python3 database/data/discovery/build_catalogs.py --validate
+```
+
+The build uses only the Python standard library. It fetches the following pinned
+open datasets, resolves redirects, accepts only successful HTTP(S) responses,
+canonicalizes their URLs, and de-duplicates before writing CSV:
+
+- Jobs: `Feashliaa/job-board-aggregator` at
+  `bc0fa75f98b6151177752f7d1ad54d9bd1b0a355`. The upstream exposes public ATS
+  company identifiers. The build accepts public Greenhouse, Lever, Ashby,
+  BambooHR, and Paylocity career endpoints and assigns the required
+  `enterprise-careers` category. This is ATS/public-career-page data; it does
+  not use a Fortune ranking.
+- Events: `dmitryvinn/tech-conferences` at
+  `dc8cbe0611405a56849e2e7a9c45addde099d6a9`. Its `conferences.json` supplies
+  organizer-maintained conference homepages plus topic and region metadata.
+- Events: `tech-conferences/conference-data` (the confs.tech dataset) at
+  `56efdfcf195b7531ebda8f56a3c514002ddd2973`. The build ingests its 2025–2027
+  topic JSON records, which identify the official conference URL, country, and
+  topic. Historical files are deliberately excluded: they would weaken the
+  recurring-calendar quality of the catalog.
+
+The event catalog combines those independently curated sources, then performs
+the same live verification and URL-level de-duplication as jobs. `--validate` is
+the acceptance gate: exactly 1,000 rows and unique canonical HTTP(S) URLs are
+required in each CSV.

--- a/database/data/discovery/build_catalogs.py
+++ b/database/data/discovery/build_catalogs.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Build and validate the discovery catalog from pinned, public upstream data."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+ROOT = Path(__file__).resolve().parent
+TODAY = dt.date.today().isoformat()
+TIMEOUT_SECONDS = 20
+WORKERS = 24
+
+# These commits are intentionally pinned so rebuilds have stable inputs.
+JOBS_REPOSITORY = "Feashliaa/job-board-aggregator"
+JOBS_COMMIT = "bc0fa75f98b6151177752f7d1ad54d9bd1b0a355"
+EVENTS_REPOSITORY = "dmitryvinn/tech-conferences"
+EVENTS_COMMIT = "dc8cbe0611405a56849e2e7a9c45addde099d6a9"
+CONFS_TECH_REPOSITORY = "tech-conferences/conference-data"
+CONFS_TECH_COMMIT = "56efdfcf195b7531ebda8f56a3c514002ddd2973"
+
+JOBS_INPUTS = {
+    "greenhouse": "data/greenhouse_companies.json",
+    "lever": "data/lever_companies.json",
+    "ashby": "data/ashby_companies.json",
+    "workday": "data/workday_companies.json",
+    "bamboohr": "data/bamboohr_companies.json",
+    "icims": "data/icims_companies.json",
+    "paylocity": "data/paylocity_companies_clean.json",
+}
+
+
+def fetch_json(repository: str, commit: str, path: str) -> object:
+    url = f"https://raw.githubusercontent.com/{repository}/{commit}/{path}"
+    with urllib.request.urlopen(url, timeout=TIMEOUT_SECONDS) as response:
+        return json.load(response)
+
+
+def conference_paths() -> list[str]:
+    """Return current and recent confs.tech topic files at the pinned revision."""
+    tree_url = (
+        f"https://api.github.com/repos/{CONFS_TECH_REPOSITORY}/git/trees/"
+        f"{CONFS_TECH_COMMIT}?recursive=1"
+    )
+    request = urllib.request.Request(tree_url, headers={"User-Agent": "goup-discovery-catalog/1.0"})
+    with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+        tree = json.load(response)
+    return sorted(
+        entry["path"]
+        for entry in tree["tree"]
+        if entry.get("type") == "blob"
+        and re.fullmatch(r"conferences/202[5-7]/[^/]+\.json", entry.get("path", ""))
+    )
+
+
+def canonicalize(url: str) -> str:
+    parsed = urlsplit(url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"not an HTTP(S) URL: {url!r}")
+    return urlunsplit((parsed.scheme, parsed.netloc.lower(), parsed.path.rstrip("/") or "/", "", ""))
+
+
+def validate_url(url: str) -> tuple[str, int] | None:
+    request = urllib.request.Request(url, headers={"User-Agent": "goup-discovery-catalog/1.0"})
+    try:
+        with urllib.request.urlopen(request, timeout=TIMEOUT_SECONDS) as response:
+            return canonicalize(response.url), response.status
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError, TimeoutError, ValueError):
+        return None
+
+
+def slug_label(value: str) -> str:
+    return re.sub(r"[-_.]+", " ", value).strip().title()
+
+
+def job_url(ats: str, slug: str) -> str | None:
+    slug = str(slug).strip()
+    if not slug:
+        return None
+    templates = {
+        "greenhouse": "https://job-boards.greenhouse.io/{slug}",
+        "lever": "https://jobs.lever.co/{slug}",
+        "ashby": "https://jobs.ashbyhq.com/{slug}",
+        "bamboohr": "https://{slug}.bamboohr.com/careers",
+        "paylocity": "https://recruiting.paylocity.com/recruiting/jobs/All/{slug}",
+    }
+    return templates.get(ats, "").format(slug=slug) or None
+
+
+def scalar_values(data: object) -> list[str]:
+    if isinstance(data, list):
+        return [str(item) for item in data if isinstance(item, (str, int))]
+    if isinstance(data, dict):
+        return [str(item) for item in data.values() if isinstance(item, (str, int))]
+    return []
+
+
+def verify_candidates(candidates: list[dict[str, str]], limit: int) -> list[dict[str, str]]:
+    accepted: list[dict[str, str]] = []
+    seen: set[str] = set()
+    # Process in stable batches. executor.map preserves candidate order, so the
+    # selected prefix does not depend on which server happens to reply first.
+    for offset in range(0, len(candidates), 300):
+        batch = candidates[offset : offset + 300]
+        with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+            results = list(pool.map(lambda row: validate_url(row["url"]), batch))
+        for row, result in zip(batch, results):
+            if not result:
+                continue
+            url, status = result
+            if url in seen:
+                continue
+            seen.add(url)
+            accepted_row = row.copy()
+            accepted_row["url"] = url
+            accepted_row["verified_at"] = TODAY
+            accepted_row["provenance"] += f"; live-http={status}"
+            accepted.append(accepted_row)
+            if len(accepted) >= limit:
+                return accepted
+    return accepted
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    fields = ["url", "label", "category", "region", "verified_at", "provenance"]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def build_jobs() -> int:
+    candidates: list[dict[str, str]] = []
+    for ats, source_path in JOBS_INPUTS.items():
+        data = fetch_json(JOBS_REPOSITORY, JOBS_COMMIT, source_path)
+        for slug in scalar_values(data):
+            url = job_url(ats, slug)
+            if url:
+                candidates.append(
+                    {
+                        "url": url,
+                        "label": slug_label(slug),
+                        "category": "enterprise-careers",
+                        "region": "global",
+                        "verified_at": "",
+                        "provenance": f"{JOBS_REPOSITORY}@{JOBS_COMMIT}:{source_path}; ats={ats}",
+                    }
+                )
+    rows = verify_candidates(candidates, 1000)
+    write_csv(ROOT / "jobs-sources.csv", rows)
+    return len(rows)
+
+
+def build_events() -> int:
+    data = fetch_json(EVENTS_REPOSITORY, EVENTS_COMMIT, "conferences.json")
+    if not isinstance(data, list):
+        raise ValueError("conference input is not a list")
+    candidates = []
+    for event in data:
+        if not isinstance(event, dict) or not isinstance(event.get("url"), str):
+            continue
+        topics = event.get("audienceTypes") or event.get("tags") or ["general-tech"]
+        category = str(topics[0]) if isinstance(topics, list) and topics else "general-tech"
+        candidates.append(
+            {
+                "url": event["url"],
+                "label": str(event.get("name") or event["url"]),
+                "category": category,
+                "region": str(event.get("region") or "global"),
+                "verified_at": "",
+                "provenance": f"{EVENTS_REPOSITORY}@{EVENTS_COMMIT}:conferences.json; official-event-url",
+            }
+        )
+    for path in conference_paths():
+        records = fetch_json(CONFS_TECH_REPOSITORY, CONFS_TECH_COMMIT, path)
+        if not isinstance(records, list):
+            continue
+        category = Path(path).stem
+        for event in records:
+            if not isinstance(event, dict) or not isinstance(event.get("url"), str):
+                continue
+            candidates.append(
+                {
+                    "url": event["url"],
+                    "label": str(event.get("name") or event["url"]),
+                    "category": category,
+                    "region": str(event.get("country") or ("online" if event.get("online") else "global")),
+                    "verified_at": "",
+                    "provenance": (
+                        f"{CONFS_TECH_REPOSITORY}@{CONFS_TECH_COMMIT}:{path}; "
+                        "official-event-url"
+                    ),
+                }
+            )
+    rows = verify_candidates(candidates, 1000)
+    write_csv(ROOT / "events-sources.csv", rows)
+    return len(rows)
+
+
+def validate_catalog(path: Path, expected: int, category: str | None = None) -> list[str]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    errors = []
+    if len(rows) != expected:
+        errors.append(f"{path.name}: expected {expected} rows, found {len(rows)}")
+    urls = [row["url"] for row in rows]
+    if len(urls) != len(set(urls)):
+        errors.append(f"{path.name}: URLs are not unique")
+    for row in rows:
+        if category and row.get("category") != category:
+            errors.append(f"{path.name}: invalid category {row.get('category')!r}")
+        try:
+            canonicalize(row["url"])
+        except ValueError as error:
+            errors.append(f"{path.name}: {error}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--build", action="store_true", help="fetch, verify, and write both catalogs")
+    parser.add_argument("--jobs", action="store_true", help="fetch, verify, and write only the jobs catalog")
+    parser.add_argument("--events", action="store_true", help="fetch, verify, and write only the events catalog")
+    parser.add_argument("--validate", action="store_true", help="validate row count and unique HTTP(S) URLs")
+    args = parser.parse_args()
+    if not any((args.build, args.jobs, args.events, args.validate)):
+        parser.error("choose --build, --jobs, --events, or --validate")
+
+    counts: dict[str, int] = {}
+    if args.build or args.jobs:
+        counts["jobs-sources.csv"] = build_jobs()
+    if args.build or args.events:
+        counts["events-sources.csv"] = build_events()
+    if counts:
+        print("built " + ", ".join(f"{name}={count}" for name, count in counts.items()))
+
+    if args.validate:
+        errors = []
+        errors.extend(validate_catalog(ROOT / "jobs-sources.csv", 1000, "enterprise-careers"))
+        errors.extend(validate_catalog(ROOT / "events-sources.csv", 1000))
+        if errors:
+            print("\n".join(errors), file=sys.stderr)
+            return 1
+        print("catalog validation passed: 1,000 unique HTTP(S) URLs per CSV")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/features/events.md
+++ b/docs/features/events.md
@@ -75,6 +75,14 @@ graph TD
 
 `services/event_discovery.rs` runs a scheduled daily worker that queries the You.com search API for Baku community event pages, validates structured Event data from approved candidate pages, and stores discovered events as drafts for organizer review. A `ManualEventDiscovery` handle is passed to dashboard handlers for on-demand group-specific runs.
 
+Organizers can import up to 1,000 approved sources in the Event discovery dashboard
+by pasting newline- or comma-separated URLs. Scheme-less values are normalized to
+`https://`; duplicate and invalid entries are ignored.
+
+The curated source catalog and its provenance are in
+[`database/data/discovery/`](../../database/data/discovery/). Inclusion means a
+source is suitable to search, not that every discovery run produces an event.
+
 ### Recording publishing
 
 `RecordingPublishingManager` polls for events that have a recorded session and uploads the recording to YouTube using configured credentials. The YouTube video URL is saved back to the event record.

--- a/docs/features/jobs.md
+++ b/docs/features/jobs.md
@@ -57,6 +57,18 @@ Group organizers post jobs through the dashboard at `/dashboard/alliance/:allian
 
 A `ManualJobDiscovery` handle is injected into dashboard handlers so authorized users can trigger an immediate discovery run without waiting for the next scheduled cycle.
 
+### Importing discovery sources
+
+The discovery dashboard accepts up to 1,000 source URLs at a time. Paste one URL per
+line or a comma-separated list; entries without a scheme are normalized to
+`https://`. Duplicate URLs in an import are ignored and only HTTP(S) sources
+accepted by the existing source validation are stored.
+
+The editable enterprise-careers reference catalog and its provenance are in
+[`database/data/discovery/`](../../database/data/discovery/). Catalog coverage
+only identifies domains to search; it does not guarantee that a run finds or
+creates a job draft.
+
 ### Public jobs board
 
 The `/jobs` page is handled by `ocg-server/src/handlers/site/jobs.rs`. It queries `DBJobs::get_jobs` and renders a paginated list of active listings.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -84,6 +84,23 @@ Keyed by provider name (`google`). Each entry has:
 | `redirect_uri` | Callback URL |
 | `scopes` | Requested scopes |
 
+## You.com event discovery (`integrations.you_com`)
+
+| Key | Env var | Default | Description |
+|-----|---------|---------|-------------|
+| `enabled` | `OCG_INTEGRATIONS__YOU_COM__ENABLED` | `false` | Enable scheduled event discovery |
+| `api_key` | `OCG_INTEGRATIONS__YOU_COM__API_KEY` | — | You.com Search API key |
+| `search_url` | `OCG_INTEGRATIONS__YOU_COM__SEARCH_URL` | `https://api.you.com/v1/search` | You.com Search API endpoint |
+| `livecrawl` | `OCG_INTEGRATIONS__YOU_COM__LIVECRAWL` | `true` | Request crawled HTML from You.com for web results |
+| `livecrawl_count` | `OCG_INTEGRATIONS__YOU_COM__LIVECRAWL_COUNT` | `10` | Maximum web results crawled per discovery query (1–10) |
+| `livecrawl_timeout_secs` | `OCG_INTEGRATIONS__YOU_COM__LIVECRAWL_TIMEOUT_SECS` | `10` | Per-result crawl timeout in seconds (1–60) |
+| `schedule_timezone` | `OCG_INTEGRATIONS__YOU_COM__SCHEDULE_TIMEZONE` | `Asia/Baku` | IANA timezone for the daily discovery run |
+| `schedule_hour` | `OCG_INTEGRATIONS__YOU_COM__SCHEDULE_HOUR` | `9` | Hour of the daily discovery run (0–23) |
+
+Livecrawl is billed per crawled result and can add latency. It is used only for
+web results; when no crawled HTML is available, event discovery falls back to
+the source page fetch and then to strict RFC3339 dates from search snippets.
+
 ## Meetings (`meetings`) — optional
 
 | Key | Description |

--- a/ocg-server/Cargo.toml
+++ b/ocg-server/Cargo.toml
@@ -25,6 +25,7 @@ csv = { workspace = true }
 deadpool-postgres = { workspace = true }
 emojis = { workspace = true }
 figment = { workspace = true }
+futures-util = { workspace = true }
 garde = { workspace = true }
 hex = { workspace = true }
 hmac = { workspace = true }
@@ -44,6 +45,7 @@ postgres-openssl = { workspace = true }
 quick-xml = { workspace = true }
 qrcode = { workspace = true }
 reqwest = { workspace = true }
+redis = { workspace = true }
 rkyv = { workspace = true }
 rust-embed = { workspace = true }
 serde = { workspace = true }

--- a/ocg-server/src/config.rs
+++ b/ocg-server/src/config.rs
@@ -133,6 +133,15 @@ pub(crate) struct YouComConfig {
     /// Search endpoint, allowing API-version changes without source changes.
     #[serde(default = "default_you_com_search_url")]
     pub search_url: String,
+    /// Request crawled HTML for web search results.
+    #[serde(default = "default_you_com_livecrawl")]
+    pub livecrawl: bool,
+    /// Maximum web results to crawl for each discovery query.
+    #[serde(default = "default_you_com_livecrawl_count")]
+    pub livecrawl_count: u8,
+    /// Maximum seconds You.com may spend crawling each result.
+    #[serde(default = "default_you_com_livecrawl_timeout_secs")]
+    pub livecrawl_timeout_secs: u8,
     /// IANA timezone used to schedule the daily discovery run.
     #[serde(default = "default_baku_timezone")]
     pub schedule_timezone: String,
@@ -152,6 +161,12 @@ impl YouComConfig {
         self.search_url
             .parse::<reqwest::Url>()
             .map_err(|err| anyhow::anyhow!("invalid integrations.you_com.search_url: {err}"))?;
+        if self.livecrawl_count == 0 || self.livecrawl_count > 10 {
+            bail!("integrations.you_com.livecrawl_count must be between 1 and 10");
+        }
+        if self.livecrawl_timeout_secs == 0 || self.livecrawl_timeout_secs > 60 {
+            bail!("integrations.you_com.livecrawl_timeout_secs must be between 1 and 60");
+        }
         self.schedule_timezone.parse::<chrono_tz::Tz>().map_err(|err| {
             anyhow::anyhow!("invalid integrations.you_com.schedule_timezone: {err}")
         })?;
@@ -161,6 +176,18 @@ impl YouComConfig {
 
 fn default_you_com_search_url() -> String {
     "https://api.you.com/v1/search".into()
+}
+
+const fn default_you_com_livecrawl() -> bool {
+    true
+}
+
+const fn default_you_com_livecrawl_count() -> u8 {
+    10
+}
+
+const fn default_you_com_livecrawl_timeout_secs() -> u8 {
+    10
 }
 
 fn default_baku_timezone() -> String {

--- a/ocg-server/src/config.rs
+++ b/ocg-server/src/config.rs
@@ -45,6 +45,8 @@ pub(crate) struct Config {
     pub recording_publishing: Option<RecordingPublishingConfig>,
     /// External partner integrations.
     pub integrations: Option<IntegrationsConfig>,
+    /// Optional Redis-backed realtime delivery.
+    pub redis: Option<RedisConfig>,
 }
 
 impl Config {
@@ -111,6 +113,15 @@ impl Config {
 pub(crate) struct IntegrationsConfig {
     /// You.com event discovery configuration.
     pub you_com: Option<YouComConfig>,
+}
+
+/// Redis connection configuration for optional realtime delivery.
+///
+/// Set `OCG_REDIS__URL` to enable Redis Pub/Sub-backed WebSocket notifications.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub(crate) struct RedisConfig {
+    /// Redis connection URL.
+    pub url: String,
 }
 
 impl IntegrationsConfig {

--- a/ocg-server/src/db/dashboard/group.rs
+++ b/ocg-server/src/db/dashboard/group.rs
@@ -252,6 +252,12 @@ pub(crate) trait DBDashboardGroup {
 
     /// Adds a source URL to group event discovery.
     async fn add_group_event_integration_source(&self, group_id: Uuid, url: &str) -> Result<Uuid>;
+    /// Adds source URLs to group event discovery.
+    async fn add_group_event_integration_sources(
+        &self,
+        group_id: Uuid,
+        urls: &[String],
+    ) -> Result<usize>;
 
     /// Removes a source URL and every event discovered from it.
     async fn delete_group_event_integration_source(
@@ -1158,6 +1164,29 @@ where
             &[&group_id, &url],
         )
         .await
+    }
+
+    async fn add_group_event_integration_sources(
+        &self,
+        group_id: Uuid,
+        urls: &[String],
+    ) -> Result<usize> {
+        if urls.is_empty() {
+            return Ok(0);
+        }
+        let added: i64 = self
+            .fetch_scalar_one(
+                "with inserted as (
+                    insert into group_event_integration_source (group_id, url)
+                    select $1, unnest($2::text[])
+                    on conflict (group_id, url) do update set enabled = true, updated_at = now()
+                    where not group_event_integration_source.enabled
+                    returning 1
+                 ) select count(*) from inserted",
+                &[&group_id, &urls],
+            )
+            .await?;
+        Ok(added as usize)
     }
 
     /// [`DBDashboardGroup::delete_group_event_integration_source`]

--- a/ocg-server/src/db/jobs.rs
+++ b/ocg-server/src/db/jobs.rs
@@ -61,6 +61,8 @@ pub(crate) trait DBJobs {
     async fn update_job_discovery(&self, user_id: Uuid, enabled: bool) -> Result<()>;
     /// Add a source URL owned by the current user.
     async fn add_job_discovery_source(&self, user_id: Uuid, url: &str) -> Result<Uuid>;
+    /// Add source URLs owned by the current user.
+    async fn add_job_discovery_sources(&self, user_id: Uuid, urls: &[String]) -> Result<usize>;
     /// Delete a source URL and every job discovered from it.
     async fn delete_job_discovery_source(&self, user_id: Uuid, source_id: Uuid) -> Result<()>;
     /// Publishes a pending discovered job.
@@ -213,6 +215,25 @@ where
             &[&user_id, &url],
         )
         .await
+    }
+
+    async fn add_job_discovery_sources(&self, user_id: Uuid, urls: &[String]) -> Result<usize> {
+        if urls.is_empty() {
+            return Ok(0);
+        }
+        let added: i64 = self
+            .fetch_scalar_one(
+                "with inserted as (
+                    insert into jobs_discovery_source (user_id, url)
+                    select $1, unnest($2::text[])
+                    on conflict (user_id, url) do update set enabled = true, updated_at = now()
+                    where not jobs_discovery_source.enabled
+                    returning 1
+                 ) select count(*) from inserted",
+                &[&user_id, &urls],
+            )
+            .await?;
+        Ok(added as usize)
     }
 
     async fn delete_job_discovery_source(&self, user_id: Uuid, source_id: Uuid) -> Result<()> {

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -634,6 +634,11 @@ mock! {
             group_id: Uuid,
             url: &str,
         ) -> Result<Uuid>;
+        async fn add_group_event_integration_sources(
+            &self,
+            group_id: Uuid,
+            urls: &[String],
+        ) -> Result<usize>;
         async fn delete_group_event_integration_source(
             &self,
             actor_user_id: Uuid,
@@ -1243,6 +1248,11 @@ mock! {
         ) -> Result<crate::types::jobs::JobDiscoveryDashboard>;
         async fn update_job_discovery(&self, user_id: Uuid, enabled: bool) -> Result<()>;
         async fn add_job_discovery_source(&self, user_id: Uuid, url: &str) -> Result<Uuid>;
+        async fn add_job_discovery_sources(
+            &self,
+            user_id: Uuid,
+            urls: &[String],
+        ) -> Result<usize>;
         async fn delete_job_discovery_source(
             &self,
             user_id: Uuid,

--- a/ocg-server/src/handlers.rs
+++ b/ocg-server/src/handlers.rs
@@ -32,6 +32,8 @@ pub(crate) mod images;
 pub(crate) mod meetings;
 /// Payments handlers.
 pub(crate) mod payments;
+/// Realtime WebSocket handlers.
+pub(crate) mod realtime;
 /// Global site handlers.
 pub(crate) mod site;
 /// Shared tests helpers for handlers modules.

--- a/ocg-server/src/handlers/dashboard/group/integrations.rs
+++ b/ocg-server/src/handlers/dashboard/group/integrations.rs
@@ -6,6 +6,7 @@ use axum::{
     http::StatusCode,
     response::{Html, IntoResponse},
 };
+use axum_messages::Messages;
 use garde::Validate;
 use serde::Deserialize;
 use tracing::instrument;
@@ -17,11 +18,13 @@ use crate::{
         error::HandlerError,
         extractors::{CurrentUser, SelectedAllianceId, SelectedGroupId, ValidatedForm},
     },
-    integrations::you_com::validate_source_url,
+    integrations::you_com::{parse_source_urls, validate_source_url},
     services::event_discovery::ManualEventDiscovery,
     templates::dashboard::group::integrations::Page,
     types::permissions::GroupPermission,
 };
+
+const MAX_DISCOVERY_SOURCE_IMPORT: usize = 1_000;
 
 /// Displays source URLs, settings, and the latest ingestion result.
 #[instrument(skip_all, err)]
@@ -96,6 +99,38 @@ pub(crate) async fn add_source(
     validate_source_url(input.url.trim()).map_err(HandlerError::from)?;
     db.add_group_event_integration_source(group_id, input.url.trim())
         .await?;
+    Ok(Html(
+        prepare_page(&db, alliance_id, group_id, user.user_id)
+            .await?
+            .render()?,
+    ))
+}
+
+/// Adds multiple validated source URLs to the selected group.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_sources(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    SelectedGroupId(group_id): SelectedGroupId,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<SourceBatchInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let parsed = parse_source_urls(&input.urls, MAX_DISCOVERY_SOURCE_IMPORT);
+    let submitted_count = parsed.urls.len();
+    let urls: Vec<String> = parsed
+        .urls
+        .into_iter()
+        .filter(|url| validate_source_url(url).is_ok())
+        .collect();
+    let invalid_count = submitted_count - urls.len();
+    let added = db.add_group_event_integration_sources(group_id, &urls).await?;
+    let duplicate_count = parsed.duplicate_count + urls.len().saturating_sub(added);
+    messages.success(format!(
+        "Imported {added} source URL(s); skipped {duplicate_count} duplicate(s), \
+         {invalid_count} invalid URL(s), and {} above the 1,000 URL limit.",
+        parsed.over_limit_count
+    ));
     Ok(Html(
         prepare_page(&db, alliance_id, group_id, user.user_id)
             .await?
@@ -191,6 +226,12 @@ pub(crate) struct SettingsInput {
 pub(crate) struct SourceInput {
     #[garde(skip)]
     url: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(crate) struct SourceBatchInput {
+    #[garde(skip)]
+    urls: String,
 }
 
 fn validate_settings(input: &SettingsInput) -> Result<(), HandlerError> {

--- a/ocg-server/src/handlers/dashboard/jobs.rs
+++ b/ocg-server/src/handlers/dashboard/jobs.rs
@@ -19,7 +19,7 @@ use crate::{
         error::HandlerError,
         extractors::{CurrentUser, ValidatedForm},
     },
-    integrations::you_com::validate_source_url,
+    integrations::you_com::{parse_source_urls, validate_source_url},
     router::serde_qs_config,
     services::job_discovery::ManualJobDiscovery,
     services::notifications::{DynNotificationsManager, NewNotification, NotificationKind},
@@ -45,6 +45,7 @@ mod tests;
 const DASHBOARD_JOBS_URL: &str = "/dashboard/jobs";
 const DASHBOARD_MOCK_INTERVIEWS_URL: &str = "/dashboard/jobs/mock-interviews";
 const DASHBOARD_DISCOVERY_URL: &str = "/dashboard/jobs/discovery";
+const MAX_DISCOVERY_SOURCE_IMPORT: usize = 1_000;
 
 #[derive(Debug, Deserialize, Validate)]
 pub(crate) struct DiscoverySettingsInput {
@@ -57,6 +58,12 @@ pub(crate) struct DiscoverySettingsInput {
 pub(crate) struct DiscoverySourceInput {
     #[garde(skip)]
     url: String,
+}
+
+#[derive(Debug, Deserialize, Validate)]
+pub(crate) struct DiscoverySourceBatchInput {
+    #[garde(skip)]
+    urls: String,
 }
 
 /// Render the jobs dashboard.
@@ -188,6 +195,35 @@ pub(crate) async fn add_discovery_source(
     validate_source_url(input.url.trim()).map_err(HandlerError::from)?;
     db.add_job_discovery_source(user.user_id, input.url.trim()).await?;
     messages.success("Discovery source added.");
+    Ok((
+        StatusCode::SEE_OTHER,
+        [("Location", DASHBOARD_DISCOVERY_URL)],
+    ))
+}
+
+/// Add multiple source URLs, retaining valid entries when an import has invalid rows.
+#[instrument(skip_all, err)]
+pub(crate) async fn add_discovery_sources(
+    messages: Messages,
+    CurrentUser(user): CurrentUser,
+    State(db): State<DynDB>,
+    ValidatedForm(input): ValidatedForm<DiscoverySourceBatchInput>,
+) -> Result<impl IntoResponse, HandlerError> {
+    let parsed = parse_source_urls(&input.urls, MAX_DISCOVERY_SOURCE_IMPORT);
+    let submitted_count = parsed.urls.len();
+    let valid_urls: Vec<String> = parsed
+        .urls
+        .into_iter()
+        .filter(|url| validate_source_url(url).is_ok())
+        .collect();
+    let invalid_count = submitted_count - valid_urls.len();
+    let added = db.add_job_discovery_sources(user.user_id, &valid_urls).await?;
+    let duplicate_count = parsed.duplicate_count + valid_urls.len().saturating_sub(added);
+    messages.success(format!(
+        "Imported {added} source URL(s); skipped {duplicate_count} duplicate(s), \
+         {invalid_count} invalid URL(s), and {} above the 1,000 URL limit.",
+        parsed.over_limit_count
+    ));
     Ok((
         StatusCode::SEE_OTHER,
         [("Location", DASHBOARD_DISCOVERY_URL)],

--- a/ocg-server/src/handlers/realtime.rs
+++ b/ocg-server/src/handlers/realtime.rs
@@ -1,0 +1,71 @@
+//! WebSocket endpoints for Redis-backed discovery completion notifications.
+
+use axum::{
+    Extension,
+    extract::ws::{Message, WebSocket, WebSocketUpgrade},
+    http::StatusCode,
+    response::Response,
+};
+use futures_util::StreamExt;
+use tower_sessions::Session;
+
+use crate::{
+    auth::AuthSession,
+    handlers::auth::SELECTED_GROUP_ID_KEY,
+    services::realtime::{DiscoveryRealtime, group_channel, user_channel},
+};
+
+/// Upgrades an authenticated user's discovery notifications stream.
+pub(crate) async fn user_discovery(
+    websocket: WebSocketUpgrade,
+    auth_session: AuthSession,
+    Extension(realtime): Extension<DiscoveryRealtime>,
+) -> Result<Response, StatusCode> {
+    let user_id = auth_session
+        .user
+        .as_ref()
+        .map(|user| user.user_id)
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    upgrade(websocket, realtime, user_channel(user_id)).await
+}
+
+/// Upgrades the selected group's discovery notifications stream.
+///
+/// Group read authorization is applied by the route middleware before this handler.
+pub(crate) async fn group_discovery(
+    websocket: WebSocketUpgrade,
+    session: Session,
+    Extension(realtime): Extension<DiscoveryRealtime>,
+) -> Result<Response, StatusCode> {
+    let group_id = session
+        .get(SELECTED_GROUP_ID_KEY)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::FORBIDDEN)?;
+    upgrade(websocket, realtime, group_channel(group_id)).await
+}
+
+async fn upgrade(
+    websocket: WebSocketUpgrade,
+    realtime: DiscoveryRealtime,
+    channel: String,
+) -> Result<Response, StatusCode> {
+    let subscription = realtime
+        .subscribe(channel)
+        .await
+        .map_err(|_| StatusCode::SERVICE_UNAVAILABLE)?;
+
+    Ok(websocket.on_upgrade(move |socket| forward_messages(socket, subscription)))
+}
+
+async fn forward_messages(mut socket: WebSocket, mut subscription: redis::aio::PubSub) {
+    let mut messages = subscription.on_message();
+    while let Some(message) = messages.next().await {
+        let Ok(payload) = message.get_payload::<String>() else {
+            continue;
+        };
+        if socket.send(Message::Text(payload.into())).await.is_err() {
+            break;
+        }
+    }
+}

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -157,6 +157,47 @@ pub(crate) fn validate_source_url(url: &str) -> Result<()> {
     source_search_domain(url).map(|_| ())
 }
 
+/// URLs and omitted entries from a dashboard source import.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SourceUrlImport {
+    pub urls: Vec<String>,
+    pub duplicate_count: usize,
+    pub over_limit_count: usize,
+}
+
+/// Parses newline- or comma-delimited source URLs for dashboard imports.
+pub(crate) fn parse_source_urls(input: &str, limit: usize) -> SourceUrlImport {
+    let mut urls = Vec::new();
+    let mut seen = HashSet::new();
+    let mut duplicate_count = 0;
+    let mut over_limit_count = 0;
+    for raw_url in input.split(['\n', ',']) {
+        let url = raw_url.trim();
+        if url.is_empty() {
+            continue;
+        }
+        let url = if url.contains("://") {
+            url.to_owned()
+        } else {
+            format!("https://{url}")
+        };
+        if !seen.insert(url.to_ascii_lowercase()) {
+            duplicate_count += 1;
+            continue;
+        }
+        if urls.len() == limit {
+            over_limit_count += 1;
+            continue;
+        }
+        urls.push(url);
+    }
+    SourceUrlImport {
+        urls,
+        duplicate_count,
+        over_limit_count,
+    }
+}
+
 /// Returns the hostname suitable for a You.com `site:` search operator.
 ///
 /// Dashboard sources are full URLs, while `site:` accepts only a domain.
@@ -215,6 +256,35 @@ mod tests {
                 .unwrap(),
             "careers.example.com"
         );
+    }
+
+    #[test]
+    fn parses_and_normalizes_batch_source_urls() {
+        assert_eq!(
+            parse_source_urls(
+                "careers.example.com\nhttps://jobs.example.com, careers.example.com",
+                10
+            ),
+            SourceUrlImport {
+                urls: vec![
+                    "https://careers.example.com".into(),
+                    "https://jobs.example.com".into()
+                ],
+                duplicate_count: 1,
+                over_limit_count: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn tracks_urls_excluded_by_the_import_limit() {
+        let input = (0..1_001)
+            .map(|index| format!("source-{index}.example"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let import = parse_source_urls(&input, 1_000);
+        assert_eq!(import.urls.len(), 1_000);
+        assert_eq!(import.over_limit_count, 1);
     }
 
     #[test]

--- a/ocg-server/src/integrations/you_com.rs
+++ b/ocg-server/src/integrations/you_com.rs
@@ -39,6 +39,9 @@ impl DiscoveredEvent {
 pub(crate) struct YouComClient {
     api_key: String,
     http: Client,
+    livecrawl: bool,
+    livecrawl_count: u8,
+    livecrawl_timeout_secs: u8,
     search_url: String,
 }
 
@@ -48,6 +51,9 @@ impl YouComClient {
         Ok(Self {
             api_key: cfg.api_key.clone(),
             http,
+            livecrawl: cfg.livecrawl,
+            livecrawl_count: cfg.livecrawl_count,
+            livecrawl_timeout_secs: cfg.livecrawl_timeout_secs,
             search_url: cfg.search_url.clone(),
         })
     }
@@ -56,7 +62,18 @@ impl YouComClient {
     pub(crate) async fn search(&self, query: &str) -> Result<Vec<SearchResult>> {
         let mut search_url =
             reqwest::Url::parse(&self.search_url).context("invalid You.com search URL")?;
-        search_url.query_pairs_mut().append_pair("query", query);
+        {
+            let mut query_pairs = search_url.query_pairs_mut();
+            query_pairs
+                .append_pair("query", query)
+                .append_pair("count", &self.livecrawl_count.to_string());
+            if self.livecrawl {
+                query_pairs
+                    .append_pair("livecrawl", "web")
+                    .append_pair("livecrawl_formats", "html")
+                    .append_pair("crawl_timeout", &self.livecrawl_timeout_secs.to_string());
+            }
+        }
         let response = self
             .http
             .get(search_url)
@@ -83,6 +100,15 @@ pub(crate) struct SearchResult {
     pub description: Option<String>,
     #[serde(default)]
     pub snippets: Vec<String>,
+    #[serde(default)]
+    pub contents: Option<SearchResultContents>,
+}
+
+/// Content returned for a result when You.com livecrawl is enabled.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SearchResultContents {
+    #[serde(default)]
+    pub html: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -157,6 +183,7 @@ mod tests {
             url: url.into(),
             description: description.map(str::to_owned),
             snippets: vec![],
+            contents: None,
         }
     }
 
@@ -208,7 +235,11 @@ mod tests {
         let payload: SearchResponse = serde_json::from_str(
             r#"{
                 "results": {
-                    "web": [{"title": "Baku meetup", "url": "https://example.test/web"}],
+                    "web": [{
+                        "title": "Baku meetup",
+                        "url": "https://example.test/web",
+                        "contents": {"html": "<script type=\"application/ld+json\">{}</script>"}
+                    }],
                     "news": [{"title": "Baku news", "url": "https://example.test/news"}]
                 }
             }"#,
@@ -217,5 +248,12 @@ mod tests {
 
         assert_eq!(payload.results.web.len(), 1);
         assert_eq!(payload.results.news.len(), 1);
+        assert_eq!(
+            payload.results.web[0]
+                .contents
+                .as_ref()
+                .and_then(|contents| contents.html.as_deref()),
+            Some(r#"<script type="application/ld+json">{}</script>"#)
+        );
     }
 }

--- a/ocg-server/src/main.rs
+++ b/ocg-server/src/main.rs
@@ -10,6 +10,8 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use activity_tracker::ActivityTrackerDB;
 use anyhow::{Context, Result};
+use axum::{Extension, Router, middleware, routing::get};
+use axum_login::login_required;
 use clap::Parser;
 use deadpool_postgres::Runtime;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
@@ -34,8 +36,10 @@ use crate::{
         payments::{
             DynPaymentsManager, DynPaymentsProvider, PgPaymentsManager, build_payments_provider,
         },
+        realtime::{DiscoveryRealtime, configure as configure_discovery_realtime},
         recording_publishing::RecordingPublishingManager,
     },
+    types::permissions::GroupPermission,
 };
 
 /// Activity tracking.
@@ -106,12 +110,24 @@ async fn main() -> Result<()> {
     let background_tasks = BackgroundTasks::new();
     let db = setup_db(&cfg)?;
     let image_storage = setup_image_storage(&cfg, db.clone());
+    let discovery_realtime = DiscoveryRealtime::from_config(cfg.redis.as_ref());
+    configure_discovery_realtime(discovery_realtime.clone());
 
     // Configure background services that depend on the database
     start_meetings_workers(&cfg, db.clone(), &background_tasks);
     start_recording_publishing_workers(&cfg, &db, &background_tasks);
-    start_event_discovery_worker(&cfg, db.clone(), &background_tasks);
-    start_job_discovery_worker(&cfg, db.clone(), &background_tasks);
+    start_event_discovery_worker(
+        &cfg,
+        db.clone(),
+        discovery_realtime.clone(),
+        &background_tasks,
+    );
+    start_job_discovery_worker(
+        &cfg,
+        db.clone(),
+        discovery_realtime.clone(),
+        &background_tasks,
+    );
     let activity_tracker = setup_activity_tracker(db.clone(), &background_tasks);
     let notifications_manager = setup_notifications_manager(&cfg, db.clone(), &background_tasks)?;
     let payments_manager = setup_payments_manager(
@@ -133,6 +149,7 @@ async fn main() -> Result<()> {
         cfg.payments.clone(),
         payments_manager,
         notifications_manager,
+        discovery_realtime,
         &cfg.server,
     )
     .await?;
@@ -191,7 +208,12 @@ fn setup_image_storage(cfg: &Config, db: Arc<PgDB>) -> DynImageStorage {
 }
 
 /// Starts You.com discovery when its integration is configured and enabled.
-fn start_event_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &BackgroundTasks) {
+fn start_event_discovery_worker(
+    cfg: &Config,
+    db: Arc<PgDB>,
+    realtime: Option<DiscoveryRealtime>,
+    background_tasks: &BackgroundTasks,
+) {
     if let Some(you_com_cfg) = cfg
         .integrations
         .as_ref()
@@ -200,6 +222,7 @@ fn start_event_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &
         services::event_discovery::start(
             you_com_cfg,
             db,
+            realtime,
             &background_tasks.task_tracker,
             &background_tasks.cancellation_token,
         );
@@ -207,7 +230,12 @@ fn start_event_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &
 }
 
 /// Starts global job discovery with the same configured You.com account.
-fn start_job_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &BackgroundTasks) {
+fn start_job_discovery_worker(
+    cfg: &Config,
+    db: Arc<PgDB>,
+    realtime: Option<DiscoveryRealtime>,
+    background_tasks: &BackgroundTasks,
+) {
     if let Some(you_com_cfg) = cfg
         .integrations
         .as_ref()
@@ -216,6 +244,7 @@ fn start_job_discovery_worker(cfg: &Config, db: Arc<PgDB>, background_tasks: &Ba
         services::job_discovery::start(
             you_com_cfg,
             db,
+            realtime,
             &background_tasks.task_tracker,
             &background_tasks.cancellation_token,
         );
@@ -338,13 +367,14 @@ async fn run_server(
     payments_cfg: Option<PaymentsConfig>,
     payments_manager: DynPaymentsManager,
     notifications_manager: Arc<PgNotificationsManager>,
+    discovery_realtime: Option<DiscoveryRealtime>,
     server_cfg: &HttpServerConfig,
 ) -> Result<()> {
     // Build the router before binding the TCP listener
     let router = router::setup(
         activity_tracker,
         db.clone(),
-        Some(db),
+        Some(db.clone()),
         image_storage,
         you_com_cfg,
         meetings_cfg,
@@ -354,6 +384,7 @@ async fn run_server(
         server_cfg,
     )
     .await?;
+    let router = with_realtime_routes(router, db, server_cfg, discovery_realtime)?;
     let listener = TcpListener::bind(&server_cfg.addr).await?;
 
     // Serve requests until a graceful shutdown signal arrives
@@ -371,6 +402,48 @@ async fn run_server(
     info!("server stopped");
 
     Ok(())
+}
+
+/// Adds optional, separately authenticated WebSocket endpoints for discovery updates.
+fn with_realtime_routes(
+    router: Router,
+    db: Arc<PgDB>,
+    server_cfg: &HttpServerConfig,
+    realtime: Option<DiscoveryRealtime>,
+) -> Result<Router> {
+    let Some(realtime) = realtime else {
+        return Ok(router);
+    };
+    let db: DynDB = db;
+    let auth_layer = auth::setup_layer(server_cfg, db.clone())?;
+    let login_required = login_required!(
+        auth::AuthnBackend,
+        login_url = crate::handlers::auth::LOG_IN_URL,
+        redirect_field = "next_url"
+    );
+
+    let user_realtime_router = Router::new()
+        .route(
+            "/ws/discovery/user",
+            get(crate::handlers::realtime::user_discovery),
+        )
+        .route_layer(login_required.clone())
+        .layer(Extension(realtime.clone()))
+        .layer(auth_layer.clone());
+    let group_realtime_router = Router::new()
+        .route(
+            "/ws/discovery/group",
+            get(crate::handlers::realtime::group_discovery),
+        )
+        .route_layer(middleware::from_fn_with_state(
+            (db, GroupPermission::Read),
+            crate::handlers::auth::user_has_selected_group_permission,
+        ))
+        .route_layer(login_required)
+        .layer(Extension(realtime))
+        .layer(auth_layer);
+
+    Ok(user_realtime_router.merge(group_realtime_router).merge(router))
 }
 
 /// Returns a future that completes when the program receives a shutdown signal.

--- a/ocg-server/src/router.rs
+++ b/ocg-server/src/router.rs
@@ -308,6 +308,10 @@ pub(crate) async fn setup(
             post(crate::handlers::dashboard::jobs::add_discovery_source),
         )
         .route(
+            "/dashboard/jobs/discovery/sources/import",
+            post(crate::handlers::dashboard::jobs::add_discovery_sources),
+        )
+        .route(
             "/dashboard/jobs/discovery/sources/{source_id}",
             delete(crate::handlers::dashboard::jobs::delete_discovery_source),
         )

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -366,6 +366,10 @@ pub(super) fn setup_group_dashboard_router(state: &State) -> Router<State> {
             post(dashboard::group::integrations::add_source),
         )
         .route(
+            "/integrations/sources/import",
+            post(dashboard::group::integrations::add_sources),
+        )
+        .route(
             "/integrations/sources/{source_id}",
             delete(dashboard::group::integrations::delete_source),
         )

--- a/ocg-server/src/services.rs
+++ b/ocg-server/src/services.rs
@@ -16,5 +16,7 @@ pub(crate) mod notifications;
 /// Payments service module.
 pub(crate) mod payments;
 
+/// Redis Pub/Sub-backed realtime delivery.
+pub(crate) mod realtime;
 /// Recording publishing service module.
 pub(crate) mod recording_publishing;

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -15,12 +15,14 @@ use crate::{
     config::YouComConfig,
     db::{PgDB, PgExecutor, dashboard::group::DBDashboardGroup},
     integrations::{
-        event_page::{EventPageClient, validate_candidate_url},
+        event_page::{EventPageClient, extract_event_json_ld, validate_candidate_url},
         you_com::{
             DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_city_results,
         },
     },
 };
+
+const MAX_LIVECRAWL_HTML_BYTES: usize = 1_000_000;
 
 /// Executes authorized, on-demand discovery runs from the dashboard.
 #[derive(Clone)]
@@ -195,12 +197,15 @@ async fn ingest_sources(
                 info!(%err, candidate_url = %result.url, source_url = %source.url, "skipped unsafe event discovery candidate");
                 continue;
             }
-            let event = match event_pages.fetch(&result.url, &source.url).await {
-                Ok(event) => event.or_else(|| parse_discovered_event(&result, &result.url)),
-                Err(err) => {
-                    info!(%err, candidate_url = %result.url, "could not enrich event discovery candidate");
-                    parse_discovered_event(&result, &result.url)
-                }
+            let event = match event_from_livecrawl(&result) {
+                Some(event) => Some(event),
+                None => match event_pages.fetch(&result.url, &source.url).await {
+                    Ok(event) => event.or_else(|| parse_discovered_event(&result, &result.url)),
+                    Err(err) => {
+                        info!(%err, candidate_url = %result.url, "could not enrich event discovery candidate");
+                        parse_discovered_event(&result, &result.url)
+                    }
+                },
             };
             if let Some(event) = event {
                 events.push(event);
@@ -305,6 +310,17 @@ async fn ingest_sources(
     }
     result?;
     Ok(())
+}
+
+/// Extract an event from bounded HTML returned by You.com livecrawl.
+fn event_from_livecrawl(result: &SearchResult) -> Option<DiscoveredEvent> {
+    result
+        .contents
+        .as_ref()?
+        .html
+        .as_deref()
+        .filter(|html| html.len() <= MAX_LIVECRAWL_HTML_BYTES)
+        .and_then(|html| extract_event_json_ld(html, &result.url))
 }
 
 /// Extract only events with an explicit RFC3339 date from the search response.
@@ -423,6 +439,7 @@ mod tests {
             url: "https://example.test/event".into(),
             description: Some("Join us next Thursday in Baku".into()),
             snippets: vec![],
+            contents: None,
         };
         assert!(parse_discovered_event(&result, "https://example.test").is_none());
     }
@@ -434,8 +451,46 @@ mod tests {
             url: "https://example.test/event".into(),
             description: Some("Starts 2099-07-21T12:00:00Z in Baku".into()),
             snippets: vec![],
+            contents: None,
         };
         let event = parse_discovered_event(&result, "https://example.test").unwrap();
         assert_eq!(event.title, "Baku Rust meetup");
+    }
+
+    #[test]
+    fn prefers_event_json_ld_from_livecrawl_content() {
+        let result = SearchResult {
+            title: "Search result title".into(),
+            url: "https://example.test/event".into(),
+            description: None,
+            snippets: vec![],
+            contents: Some(crate::integrations::you_com::SearchResultContents {
+                html: Some(
+                    r#"<script type="application/ld+json">
+                        {"@type":"Event","name":"Baku Rust meetup","startDate":"2099-07-21T12:00:00Z"}
+                    </script>"#
+                        .into(),
+                ),
+            }),
+        };
+
+        let event = event_from_livecrawl(&result).unwrap();
+        assert_eq!(event.title, "Baku Rust meetup");
+        assert_eq!(event.source_url, "https://example.test/event");
+    }
+
+    #[test]
+    fn rejects_oversized_livecrawl_content() {
+        let result = SearchResult {
+            title: "Search result title".into(),
+            url: "https://example.test/event".into(),
+            description: None,
+            snippets: vec![],
+            contents: Some(crate::integrations::you_com::SearchResultContents {
+                html: Some("x".repeat(MAX_LIVECRAWL_HTML_BYTES + 1)),
+            }),
+        };
+
+        assert!(event_from_livecrawl(&result).is_none());
     }
 }

--- a/ocg-server/src/services/event_discovery.rs
+++ b/ocg-server/src/services/event_discovery.rs
@@ -20,6 +20,7 @@ use crate::{
             DiscoveredEvent, SearchResult, YouComClient, source_search_domain, unique_city_results,
         },
     },
+    services::realtime::{DiscoveryCompletion, DiscoveryRealtime, DiscoveryStatus, configured},
 };
 
 const MAX_LIVECRAWL_HTML_BYTES: usize = 1_000_000;
@@ -41,8 +42,9 @@ impl ManualEventDiscovery {
     pub(crate) fn spawn_group_run(&self, group_id: Uuid) {
         let cfg = self.cfg.clone();
         let db = self.db.clone();
+        let realtime = configured();
         tokio::spawn(async move {
-            if let Err(err) = run_group(cfg, db, group_id).await {
+            if let Err(err) = run_group(cfg, db, group_id, realtime).await {
                 error!(%err, %group_id, "manual You.com event discovery failed");
             }
         });
@@ -58,6 +60,7 @@ impl ManualEventDiscovery {
 pub(crate) fn start(
     cfg: YouComConfig,
     db: std::sync::Arc<PgDB>,
+    realtime: Option<DiscoveryRealtime>,
     task_tracker: &TaskTracker,
     cancellation_token: &CancellationToken,
 ) {
@@ -90,7 +93,7 @@ pub(crate) fn start(
                     () = cancellation_token.cancelled() => break,
                 }
 
-                if let Err(err) = ingest_configured_sources(&db, &client).await {
+                if let Err(err) = ingest_configured_sources(&db, &client, realtime.clone()).await {
                     error!(%err, "You.com Baku event discovery failed");
                 }
             }
@@ -103,6 +106,7 @@ pub(crate) async fn run_group(
     cfg: YouComConfig,
     db: std::sync::Arc<PgDB>,
     group_id: Uuid,
+    realtime: Option<DiscoveryRealtime>,
 ) -> anyhow::Result<()> {
     anyhow::ensure!(cfg.enabled, "You.com event discovery is disabled");
     let integration_enabled: bool = db
@@ -119,7 +123,7 @@ pub(crate) async fn run_group(
         "event discovery is not enabled for this group"
     );
     let client = YouComClient::new(&cfg)?;
-    ingest_sources(&db, &client, &[group_id]).await
+    ingest_sources(&db, &client, &[group_id], realtime).await
 }
 
 #[derive(Debug, Deserialize)]
@@ -131,7 +135,11 @@ struct Source {
     url: String,
 }
 
-async fn ingest_configured_sources(db: &PgDB, client: &YouComClient) -> anyhow::Result<()> {
+async fn ingest_configured_sources(
+    db: &PgDB,
+    client: &YouComClient,
+    realtime: Option<DiscoveryRealtime>,
+) -> anyhow::Result<()> {
     let run_group_ids: Vec<Uuid> = db
         .fetch_scalar_one(
             "select coalesce(array_agg(group_id), '{}'::uuid[])
@@ -139,7 +147,7 @@ async fn ingest_configured_sources(db: &PgDB, client: &YouComClient) -> anyhow::
             &[],
         )
         .await?;
-    ingest_sources(db, client, &run_group_ids).await
+    ingest_sources(db, client, &run_group_ids, realtime).await
 }
 
 /// Ingests sources and records runs for the supplied enabled groups.
@@ -147,6 +155,7 @@ async fn ingest_sources(
     db: &PgDB,
     client: &YouComClient,
     run_group_ids: &[Uuid],
+    realtime: Option<DiscoveryRealtime>,
 ) -> anyhow::Result<()> {
     for group_id in run_group_ids {
         db.execute(
@@ -307,6 +316,20 @@ async fn ingest_sources(
                 .await?
             }
         };
+        if let Some(realtime) = &realtime {
+            let (status, discovered_count, created_count) = match &result {
+                Ok(()) => (DiscoveryStatus::Succeeded, discovered_count, created_count),
+                Err(_) => (DiscoveryStatus::Failed, 0, 0),
+            };
+            realtime
+                .publish(DiscoveryCompletion::Group {
+                    group_id: *group_id,
+                    status,
+                    discovered_count,
+                    created_count,
+                })
+                .await;
+        }
     }
     result?;
     Ok(())

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -19,6 +19,7 @@ use crate::{
         job_page::JobPageClient,
         you_com::{SearchResult, YouComClient, source_search_domain},
     },
+    services::realtime::{DiscoveryCompletion, DiscoveryRealtime, DiscoveryStatus, configured},
     types::jobs::JobInput,
 };
 
@@ -39,8 +40,9 @@ impl ManualJobDiscovery {
     pub(crate) fn spawn_user_run(&self, user_id: Uuid) {
         let cfg = self.cfg.clone();
         let db = self.db.clone();
+        let realtime = configured();
         tokio::spawn(async move {
-            if let Err(err) = run_user(cfg, db, user_id).await {
+            if let Err(err) = run_user(cfg, db, user_id, realtime).await {
                 error!(%err, %user_id, "manual You.com job discovery failed");
             }
         });
@@ -51,6 +53,7 @@ impl ManualJobDiscovery {
 pub(crate) fn start(
     cfg: YouComConfig,
     db: Arc<PgDB>,
+    realtime: Option<DiscoveryRealtime>,
     tasks: &TaskTracker,
     cancel: &CancellationToken,
 ) {
@@ -73,7 +76,7 @@ pub(crate) fn start(
                     () = sleep(delay_until_next_run(timezone, cfg.schedule_hour)) => {},
                     () = cancel.cancelled() => break,
                 }
-                if let Err(err) = ingest_enabled(&db, &client).await {
+                if let Err(err) = ingest_enabled(&db, &client, realtime.clone()).await {
                     error!(%err, "scheduled You.com job discovery failed");
                 }
             }
@@ -81,25 +84,39 @@ pub(crate) fn start(
     });
 }
 
-pub(crate) async fn run_user(cfg: YouComConfig, db: Arc<PgDB>, user_id: Uuid) -> Result<()> {
+pub(crate) async fn run_user(
+    cfg: YouComConfig,
+    db: Arc<PgDB>,
+    user_id: Uuid,
+    realtime: Option<DiscoveryRealtime>,
+) -> Result<()> {
     anyhow::ensure!(cfg.enabled, "You.com job discovery is disabled");
     let enabled: bool = db.fetch_scalar_one(
         "select exists(select 1 from jobs_discovery_integration where user_id = $1 and enabled)",
         &[&user_id],
     ).await?;
     anyhow::ensure!(enabled, "job discovery is not enabled");
-    ingest_users(&db, &YouComClient::new(&cfg)?, &[user_id]).await
+    ingest_users(&db, &YouComClient::new(&cfg)?, &[user_id], realtime).await
 }
 
-async fn ingest_enabled(db: &PgDB, client: &YouComClient) -> Result<()> {
+async fn ingest_enabled(
+    db: &PgDB,
+    client: &YouComClient,
+    realtime: Option<DiscoveryRealtime>,
+) -> Result<()> {
     let users: Vec<Uuid> = db.fetch_scalar_one(
         "select coalesce(array_agg(user_id), '{}'::uuid[]) from jobs_discovery_integration where enabled",
         &[],
     ).await?;
-    ingest_users(db, client, &users).await
+    ingest_users(db, client, &users, realtime).await
 }
 
-async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Result<()> {
+async fn ingest_users(
+    db: &PgDB,
+    client: &YouComClient,
+    users: &[Uuid],
+    realtime: Option<DiscoveryRealtime>,
+) -> Result<()> {
     for user_id in users {
         db.execute(
             "insert into jobs_discovery_run (user_id, status) values ($1, 'running')",
@@ -211,6 +228,16 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
                  where user_id = $1 and status = 'running' order by started_at desc limit 1)",
                 &[user_id, &discovered, &created],
             ).await?;
+            if let Some(realtime) = &realtime {
+                realtime
+                    .publish(DiscoveryCompletion::User {
+                        user_id: *user_id,
+                        status: DiscoveryStatus::Succeeded,
+                        discovered_count: discovered,
+                        created_count: created,
+                    })
+                    .await;
+            }
             info!(%user_id, discovered, created, "published discovered jobs");
         }
         Result::<()>::Ok(())
@@ -223,6 +250,16 @@ async fn ingest_users(db: &PgDB, client: &YouComClient, users: &[Uuid]) -> Resul
                  where user_id = $1 and status = 'running' order by started_at desc limit 1)",
                 &[user_id, &err.to_string()],
             ).await?;
+            if let Some(realtime) = &realtime {
+                realtime
+                    .publish(DiscoveryCompletion::User {
+                        user_id: *user_id,
+                        status: DiscoveryStatus::Failed,
+                        discovered_count: 0,
+                        created_count: 0,
+                    })
+                    .await;
+            }
         }
     }
     outcome

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -323,6 +323,7 @@ mod tests {
                 url: "https://x.test".into(),
                 description: None,
                 snippets: vec![],
+                contents: None,
             })
             .is_none()
         );
@@ -334,6 +335,7 @@ mod tests {
             url: "https://x.test/jobs/1".into(),
             description: Some("Build reliable systems.".into()),
             snippets: vec![],
+            contents: None,
         })
         .unwrap();
         assert_eq!(job.company_name, "Acme");
@@ -346,6 +348,7 @@ mod tests {
             url: "https://x.test/jobs/1".into(),
             description: None,
             snippets: vec!["Build reliable systems.".into()],
+            contents: None,
         })
         .unwrap();
         assert_eq!(job.summary, "Build reliable systems.");
@@ -358,6 +361,7 @@ mod tests {
             url: "https://careers.bcg.com/search-results".into(),
             description: Some("Have questions about careers at BCG?".into()),
             snippets: vec![],
+            contents: None,
         });
         assert!(job.is_none());
     }

--- a/ocg-server/src/services/realtime.rs
+++ b/ocg-server/src/services/realtime.rs
@@ -1,0 +1,127 @@
+//! Redis Pub/Sub transport for discovery completion notifications.
+
+use std::sync::OnceLock;
+
+use redis::AsyncCommands;
+use serde::Serialize;
+use tracing::warn;
+use uuid::Uuid;
+
+use crate::config::RedisConfig;
+
+static DISCOVERY_REALTIME: OnceLock<DiscoveryRealtime> = OnceLock::new();
+
+/// Optional realtime delivery backed by Redis Pub/Sub.
+#[derive(Clone)]
+pub(crate) struct DiscoveryRealtime {
+    client: redis::Client,
+}
+
+impl DiscoveryRealtime {
+    /// Builds a realtime transport when Redis is configured.
+    pub(crate) fn from_config(config: Option<&RedisConfig>) -> Option<Self> {
+        let config = config?;
+        match redis::Client::open(config.url.as_str()) {
+            Ok(client) => Some(Self { client }),
+            Err(error) => {
+                warn!(%error, "Redis realtime delivery is disabled due to an invalid Redis URL");
+                None
+            }
+        }
+    }
+
+    /// Publishes a completion notification without affecting discovery outcomes.
+    pub(crate) async fn publish(&self, notification: DiscoveryCompletion) {
+        let channel = notification.channel();
+        let payload = match serde_json::to_string(&notification) {
+            Ok(payload) => payload,
+            Err(error) => {
+                warn!(%error, "could not serialize discovery completion notification");
+                return;
+            }
+        };
+
+        let result = async {
+            let mut connection = self.client.get_multiplexed_async_connection().await?;
+            let _: () = connection.publish(channel, payload).await?;
+            redis::RedisResult::Ok(())
+        }
+        .await;
+
+        if let Err(error) = result {
+            warn!(%error, "could not publish discovery completion notification");
+        }
+    }
+
+    /// Opens a Redis Pub/Sub subscription for a websocket client.
+    pub(crate) async fn subscribe(
+        &self,
+        channel: String,
+    ) -> redis::RedisResult<redis::aio::PubSub> {
+        let mut pubsub = self.client.get_async_pubsub().await?;
+        pubsub.subscribe(channel).await?;
+        Ok(pubsub)
+    }
+}
+
+/// Installs the process-wide optional realtime transport for request-spawned jobs.
+pub(crate) fn configure(realtime: Option<DiscoveryRealtime>) {
+    if let Some(realtime) = realtime {
+        let _ = DISCOVERY_REALTIME.set(realtime);
+    }
+}
+
+/// Returns the configured realtime transport, when Redis delivery is enabled.
+pub(crate) fn configured() -> Option<DiscoveryRealtime> {
+    DISCOVERY_REALTIME.get().cloned()
+}
+
+/// A discovery run completion payload sent to the owning dashboard scope.
+#[derive(Debug, Serialize)]
+#[serde(tag = "scope", rename_all = "snake_case")]
+pub(crate) enum DiscoveryCompletion {
+    /// Completion for one user's jobs discovery run.
+    User {
+        user_id: Uuid,
+        status: DiscoveryStatus,
+        discovered_count: i32,
+        created_count: i32,
+    },
+    /// Completion for one selected group's event discovery run.
+    Group {
+        group_id: Uuid,
+        status: DiscoveryStatus,
+        discovered_count: i32,
+        created_count: i32,
+    },
+}
+
+impl DiscoveryCompletion {
+    /// Returns the private Redis channel for this notification's scope.
+    pub(crate) fn channel(&self) -> String {
+        match self {
+            Self::User { user_id, .. } => user_channel(*user_id),
+            Self::Group { group_id, .. } => group_channel(*group_id),
+        }
+    }
+}
+
+/// The terminal state of a discovery run.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DiscoveryStatus {
+    /// The run completed successfully.
+    Succeeded,
+    /// The run completed with an error.
+    Failed,
+}
+
+/// Returns the Redis channel for one user's discovery notifications.
+pub(crate) fn user_channel(user_id: Uuid) -> String {
+    format!("ocg:discovery:user:{user_id}")
+}
+
+/// Returns the Redis channel for one group's discovery notifications.
+pub(crate) fn group_channel(group_id: Uuid) -> String {
+    format!("ocg:discovery:group:{group_id}")
+}

--- a/ocg-server/static/js/common/app-init.js
+++ b/ocg-server/static/js/common/app-init.js
@@ -31,3 +31,64 @@ window.addEventListener("pageshow", (event) => {
     resetRestoredModalState(document);
   }
 });
+
+function websocketUrl(path) {
+  const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${scheme}//${window.location.host}${path}`;
+}
+
+function refreshDiscoveryDashboard(scope) {
+  if (scope === "user" && window.location.pathname === "/dashboard/jobs/discovery") {
+    window.location.reload();
+    return;
+  }
+
+  if (
+    scope === "group" &&
+    document.querySelector('form[hx-put="/dashboard/group/integrations"]')
+  ) {
+    window.htmx.ajax("GET", "/dashboard/group/integrations", {
+      target: "#dashboard-content",
+      swap: "innerHTML",
+    });
+  }
+}
+
+function subscribeToDiscoveryUpdates(path, expectedScope) {
+  let retried = false;
+
+  function connect() {
+    const socket = new WebSocket(websocketUrl(path));
+    let opened = false;
+
+    socket.addEventListener("open", () => {
+      opened = true;
+    });
+    socket.addEventListener("message", (event) => {
+      try {
+        const notification = JSON.parse(event.data);
+        if (notification.scope === expectedScope) {
+          refreshDiscoveryDashboard(expectedScope);
+        }
+      } catch {
+        // Ignore malformed messages; polling remains available as a fallback.
+      }
+    });
+    socket.addEventListener("close", () => {
+      // A failed initial handshake means realtime is not enabled. Do not retry it.
+      if (opened && !retried) {
+        retried = true;
+        window.setTimeout(connect, 3_000);
+      }
+    });
+  }
+
+  connect();
+}
+
+if (window.location.pathname === "/dashboard/jobs/discovery") {
+  subscribeToDiscoveryUpdates("/ws/discovery/user", "user");
+}
+if (window.location.pathname.startsWith("/dashboard/group")) {
+  subscribeToDiscoveryUpdates("/ws/discovery/group", "group");
+}

--- a/ocg-server/templates/dashboard/group/integrations.html
+++ b/ocg-server/templates/dashboard/group/integrations.html
@@ -21,6 +21,11 @@
       <input class="input-primary flex-1" type="url" name="url" placeholder="https://events.example.com" required {% if !integration.can_manage_events %}disabled{% endif %}>
       <button class="button-primary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Add source</button>
     </form>
+    <form class="mt-3 space-y-2" hx-post="/dashboard/group/integrations/sources/import" hx-target="#dashboard-content">
+      <label class="text-sm text-stone-600" for="event-discovery-source-import">Import up to 1,000 URLs (one per line or comma-separated)</label>
+      <textarea class="input-primary w-full" id="event-discovery-source-import" name="urls" rows="5" placeholder="events.example.com&#10;https://calendar.example.com" {% if !integration.can_manage_events %}disabled{% endif %}></textarea>
+      <button class="button-secondary" type="submit" {% if !integration.can_manage_events %}disabled{% endif %}>Import sources</button>
+    </form>
     <ul class="mt-4 space-y-2">
     {% for source in integration.sources %}
       <li class="flex items-center justify-between gap-3 border rounded p-3">

--- a/ocg-server/templates/dashboard/jobs/discovery.html
+++ b/ocg-server/templates/dashboard/jobs/discovery.html
@@ -27,6 +27,11 @@
         <input class="input-primary flex-1" type="url" name="url" placeholder="https://careers.example.com" required>
         <button class="button-primary">Add source</button>
       </form>
+      <form class="mt-3 space-y-2" action="/dashboard/jobs/discovery/sources/import" method="post">
+        <label class="text-sm text-stone-600" for="job-discovery-source-import">Import up to 1,000 URLs (one per line or comma-separated)</label>
+        <textarea class="input-primary w-full" id="job-discovery-source-import" name="urls" rows="5" placeholder="careers.example.com&#10;https://jobs.example.com"></textarea>
+        <button class="button-secondary">Import sources</button>
+      </form>
       <ul class="mt-4 space-y-2">{% for source in discovery.sources %}
         <li class="flex items-center justify-between gap-3 border rounded p-3">
           <a class="truncate underline" href="{{ source.url }}" target="_blank" rel="noopener noreferrer">{{ source.url }}</a>


### PR DESCRIPTION
## Summary
- add reproducible 1,000-source enterprise careers and event catalogs with provenance
- allow importing up to 1,000 sources and report skipped invalid, duplicate, and excess entries
- deliver Redis-backed WebSocket completion notifications while retaining HTMX polling fallback

## Test plan
- [x] `cargo fmt --check`
- [x] targeted You.com import parser tests
- [x] targeted job and event discovery tests
- [x] `cargo check -p ocg-server`
- [x] `python3 database/data/discovery/build_catalogs.py --validate`
- [x] `git diff --check`

Made with [Cursor](https://cursor.com)