### PR TITLE
Add bulk startup landscape creation MCP tool

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -163,6 +163,9 @@ through the standard `tools/list` method.
 - `goup_service_status`: inspect systemd logs and local HTTP status.
 - `goup_create_event`: create an unpublished draft event through `add_event`.
 - `goup_update_event`: update an existing event through `update_event`.
+- `goup_create_startup`: add a startup to the landscape through `add_landscape_entry`; published by default.
+- `goup_create_github_project`: add a GitHub project to the landscape through `add_landscape_entry`; requires `github_url`.
+- `goup_create_startups_bulk`: add many startups to the landscape in one call, sharing `actor_user_id`, `alliance_id`, and a default `published`; each entry is created independently so one failure does not abort the rest, and the result reports per-entry status.
 - `goup_search`: search public events, groups, jobs, ecosystem entries, and wiki sources in one call.
 - `goup_search_groups`: list or search groups.
 - `goup_search_events`: list or search events.

--- a/mcp/server.mjs
+++ b/mcp/server.mjs
@@ -258,6 +258,8 @@ async function runAction(action, args) {
       return createLandscapeEntry(args, "startup");
     case "create_github_project":
       return createLandscapeEntry(args, "github_project");
+    case "create_startups_bulk":
+      return createLandscapeEntriesBulk(args, "startup");
     case "search_wiki":
       return searchWiki(args);
     case "submit_talk":
@@ -439,6 +441,62 @@ from created${resultJoin};
 `;
 
   return (await runPsql(sql)).trim();
+}
+
+async function createLandscapeEntriesBulk(args, kind) {
+  if (!ENABLE_MUTATIONS) {
+    throw new Error("Mutating MCP tools are disabled. Set MCP_ENABLE_MUTATIONS=true to allow landscape entry creation.");
+  }
+
+  const actorUserId = requireUuid(args.actor_user_id, "actor_user_id");
+  const allianceId = requireUuid(args.alliance_id, "alliance_id");
+
+  if (!Array.isArray(args.entries) || args.entries.length === 0) {
+    throw new Error("entries must be a non-empty array of landscape entries");
+  }
+
+  const sharedPublished = args.published;
+  const results = [];
+  let created = 0;
+  let failed = 0;
+
+  for (let index = 0; index < args.entries.length; index += 1) {
+    const raw = args.entries[index] || {};
+    const entryArgs = {
+      ...raw,
+      actor_user_id: raw.actor_user_id || actorUserId,
+      alliance_id: raw.alliance_id || allianceId,
+      published: raw.published !== undefined ? raw.published : sharedPublished,
+    };
+
+    try {
+      const output = await createLandscapeEntry(entryArgs, kind);
+      let parsed;
+      try {
+        parsed = JSON.parse(output);
+      } catch {
+        parsed = { message: output };
+      }
+      results.push({ index, name: raw.name || null, status: "ok", ...parsed });
+      created += 1;
+    } catch (error) {
+      results.push({
+        index,
+        name: raw.name || null,
+        status: "error",
+        error: String(error && error.message ? error.message : error),
+      });
+      failed += 1;
+    }
+  }
+
+  return JSON.stringify({
+    kind,
+    total: args.entries.length,
+    created,
+    failed,
+    results,
+  });
 }
 
 async function searchWiki(args) {

--- a/mcp/tools.json
+++ b/mcp/tools.json
@@ -679,6 +679,103 @@
     "action": "create_github_project"
   },
   {
+    "name": "goup_create_startups_bulk",
+    "title": "GOUP Bulk Create Startup Landscape Entries",
+    "description": "Add many startups to the GOUP landscape in one call through the database add_landscape_entry function. Each entry is created independently, so one failure does not abort the rest. Requires MCP_ENABLE_MUTATIONS=true and database access through DATABASE_URL or TERN_CONF.",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "actor_user_id": {
+          "type": "string",
+          "description": "User ID recorded as the creator for every entry. Can be overridden per entry."
+        },
+        "alliance_id": {
+          "type": "string",
+          "description": "Alliance ID where the entries will be created. Can be overridden per entry."
+        },
+        "published": {
+          "type": "boolean",
+          "description": "Default publish state applied to every entry unless the entry sets its own. Defaults to true."
+        },
+        "entries": {
+          "type": "array",
+          "description": "Startups to create. Each item accepts the same fields as goup_create_startup.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Startup name."
+              },
+              "summary": {
+                "type": "string",
+                "description": "Short summary for cards and search results."
+              },
+              "description": {
+                "type": "string",
+                "description": "Optional full description."
+              },
+              "website_url": {
+                "type": "string",
+                "description": "Optional startup website URL."
+              },
+              "github_url": {
+                "type": "string",
+                "description": "Optional GitHub URL."
+              },
+              "logo_url": {
+                "type": "string",
+                "description": "Optional logo image URL."
+              },
+              "category": {
+                "type": "string",
+                "description": "Optional category label, for example AI, DevTools, Fintech, or Infrastructure."
+              },
+              "tags": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "description": "Optional tags as an array or comma-separated string."
+              },
+              "published": {
+                "type": "boolean",
+                "description": "Optional per-entry publish state that overrides the shared default."
+              },
+              "actor_user_id": {
+                "type": "string",
+                "description": "Optional per-entry creator that overrides the shared actor_user_id."
+              },
+              "alliance_id": {
+                "type": "string",
+                "description": "Optional per-entry alliance that overrides the shared alliance_id."
+              }
+            },
+            "required": [
+              "name",
+              "summary"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "actor_user_id",
+        "alliance_id",
+        "entries"
+      ],
+      "additionalProperties": false
+    },
+    "action": "create_startups_bulk"
+  },
+  {
     "name": "goup_search_wiki",
     "title": "GOUP Search Wiki",
     "description": "List or search GOUP wiki sections and feed sources.",


### PR DESCRIPTION
## Why

The MCP server already exposes `goup_create_startup` for adding a single landscape entry, but seeding a batch (for example importing a curated set of local startups) means one MCP round trip per entry. This adds a bulk variant.

## What

New tool **`goup_create_startups_bulk`**:

- Accepts an `entries` array plus a shared `actor_user_id`, `alliance_id`, and default `published` (defaults to `true`, matching `goup_create_startup`).
- Each entry accepts the same fields as `goup_create_startup` (`name`, `summary`, `description`, `website_url`, `github_url`, `logo_url`, `category`, `tags`) and may override `published`, `actor_user_id`, or `alliance_id` per entry.
- Reuses the existing `createLandscapeEntry` path, so behavior and the `add_landscape_entry` DB call stay identical.
- Entries are created independently: one failing entry does not abort the rest. The result reports `total`, `created`, `failed`, and a per-entry `results` list with the new `landscape_entry_id` or the error.
- Gated behind `MCP_ENABLE_MUTATIONS=true`, same as the other create tools.

Also refreshes the MCP README tool list, which was missing `goup_create_startup` and `goup_create_github_project`.

## Changes
- `mcp/server.mjs`: `create_startups_bulk` dispatch case + `createLandscapeEntriesBulk` function.
- `mcp/tools.json`: `goup_create_startups_bulk` tool schema.
- `mcp/README.md`: document the landscape create tools including the new bulk one.

## Verification
- `node --check mcp/server.mjs` passes.
- `mcp/tools.json` parses as valid JSON (18 tools).
- No behavior change to existing tools; the bulk path delegates to the existing single-create function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)