### PR TITLE
Improve job discovery and landscape navigation

### DIFF
--- a/database/migrations/functions/001_load_functions.sql
+++ b/database/migrations/functions/001_load_functions.sql
@@ -68,6 +68,7 @@
 {{ template "landscape/add_landscape_entry.sql" }}
 {{ template "landscape/delete_landscape_entry.sql" }}
 {{ template "landscape/list_alliance_landscape_entries.sql" }}
+{{ template "landscape/list_alliance_landscape_entries_for_export.sql" }}
 {{ template "landscape/search_landscape_entries.sql" }}
 {{ template "landscape/update_landscape_entry.sql" }}
 {{ template "landscape/update_landscape_entry_published.sql" }}

--- a/database/migrations/functions/landscape/list_alliance_landscape_entries_for_export.sql
+++ b/database/migrations/functions/landscape/list_alliance_landscape_entries_for_export.sql
@@ -1,0 +1,46 @@
+create or replace function list_alliance_landscape_entries_for_export(
+    p_alliance_id uuid,
+    p_filters jsonb
+) returns jsonb language plpgsql stable as $$
+declare
+    v_query text := nullif(trim(p_filters->>'query'), '');
+    v_entries jsonb;
+begin
+    with matches as (
+        select le.*
+        from landscape_entry le
+        left join landscape_accelerator_profile lap on lap.landscape_entry_id = le.landscape_entry_id
+        where le.alliance_id = p_alliance_id
+        and (
+            v_query is null
+            or le.name ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.summary ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.description ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or le.category ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.application_url ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.curriculum_url ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.cohort_status ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or lap.weekly_agenda::text ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            or exists (
+                select 1 from unnest(le.tags) tag
+                where tag ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+            or exists (
+                select 1 from unnest(lap.tracks) track
+                where track ilike '%' || escape_ilike_pattern(v_query) || '%' escape '\'
+            )
+        )
+    )
+    select coalesce(
+        jsonb_agg(landscape_entry_json(matches) order by matches.created_at desc, matches.landscape_entry_id desc),
+        '[]'::jsonb
+    )
+    into v_entries
+    from matches;
+
+    return jsonb_build_object(
+        'entries', v_entries,
+        'total', jsonb_array_length(v_entries)
+    );
+end;
+$$;

--- a/database/migrations/functions/landscape/search_landscape_entries.sql
+++ b/database/migrations/functions/landscape/search_landscape_entries.sql
@@ -20,6 +20,10 @@ begin
         and (v_kind is null or le.kind = v_kind)
         and (
             v_category is null
+            or (
+                v_category = 'Uncategorized'
+                and nullif(trim(le.category), '') is null
+            )
             or le.category ilike '%' || escape_ilike_pattern(v_category) || '%' escape '\'
         )
         and (

--- a/ocg-server/src/db/landscape.rs
+++ b/ocg-server/src/db/landscape.rs
@@ -28,6 +28,13 @@ pub(crate) trait DBLandscape {
         filters: &DashboardLandscapeFilters,
     ) -> Result<LandscapeOutput>;
 
+    /// Lists all matching entries for an authorized dashboard CSV export.
+    async fn list_alliance_landscape_entries_for_export(
+        &self,
+        alliance_id: Uuid,
+        filters: &DashboardLandscapeFilters,
+    ) -> Result<LandscapeOutput>;
+
     /// Add a landscape entry to an alliance.
     async fn add_landscape_entry(
         &self,
@@ -88,6 +95,19 @@ where
     ) -> Result<LandscapeOutput> {
         self.fetch_json_one(
             "select list_alliance_landscape_entries($1::uuid, $2::jsonb)",
+            &[&alliance_id, &Json(filters)],
+        )
+        .await
+    }
+
+    #[instrument(skip(self, filters), err)]
+    async fn list_alliance_landscape_entries_for_export(
+        &self,
+        alliance_id: Uuid,
+        filters: &DashboardLandscapeFilters,
+    ) -> Result<LandscapeOutput> {
+        self.fetch_json_one(
+            "select list_alliance_landscape_entries_for_export($1::uuid, $2::jsonb)",
             &[&alliance_id, &Json(filters)],
         )
         .await

--- a/ocg-server/src/db/mock.rs
+++ b/ocg-server/src/db/mock.rs
@@ -1346,6 +1346,11 @@ mock! {
             alliance_id: Uuid,
             filters: &crate::types::landscape::DashboardLandscapeFilters,
         ) -> Result<crate::types::landscape::LandscapeOutput>;
+        async fn list_alliance_landscape_entries_for_export(
+            &self,
+            alliance_id: Uuid,
+            filters: &crate::types::landscape::DashboardLandscapeFilters,
+        ) -> Result<crate::types::landscape::LandscapeOutput>;
         async fn add_landscape_entry(
             &self,
             actor_user_id: Uuid,

--- a/ocg-server/src/handlers/dashboard/alliance/landscape.rs
+++ b/ocg-server/src/handlers/dashboard/alliance/landscape.rs
@@ -4,7 +4,10 @@ use anyhow::Result;
 use askama::Template;
 use axum::{
     extract::{Path, RawQuery, State},
-    http::{HeaderName, StatusCode},
+    http::{
+        HeaderName, StatusCode,
+        header::{CONTENT_DISPOSITION, CONTENT_TYPE},
+    },
     response::{Html, IntoResponse},
 };
 use garde::Validate;
@@ -20,7 +23,7 @@ use crate::{
     router::serde_qs_config,
     templates::dashboard::alliance::landscape,
     types::{
-        landscape::{DashboardLandscapeFilters, LandscapeEntryInput},
+        landscape::{DashboardLandscapeFilters, LandscapeEntry, LandscapeEntryInput},
         pagination::{self, NavigationLinks},
         permissions::AlliancePermission,
     },
@@ -49,6 +52,41 @@ pub(crate) async fn list_page(
     let headers = [(HeaderName::from_static("hx-push-url"), url)];
 
     Ok((headers, Html(template.render()?)))
+}
+
+/// Downloads all matching landscape entries as an administrator-only CSV.
+#[instrument(skip_all, err)]
+pub(crate) async fn download_csv(
+    SelectedAllianceId(alliance_id): SelectedAllianceId,
+    State(db): State<DynDB>,
+    RawQuery(raw_query): RawQuery,
+) -> Result<impl IntoResponse, HandlerError> {
+    let mut filters: DashboardLandscapeFilters =
+        if raw_query.as_deref().unwrap_or_default().is_empty() {
+            DashboardLandscapeFilters::default()
+        } else {
+            serde_qs_config().deserialize_str(raw_query.as_deref().unwrap_or_default())?
+        };
+    filters.limit = None;
+    filters.offset = None;
+    filters.validate()?;
+
+    let (alliance, output) = tokio::try_join!(
+        db.get_alliance_full(alliance_id),
+        db.list_alliance_landscape_entries_for_export(alliance_id, &filters)
+    )?;
+    let csv = build_landscape_csv(&output.entries)?;
+    let file_name = format!("alliance-{}-landscape.csv", alliance.name);
+    Ok((
+        [
+            (CONTENT_TYPE, "text/csv; charset=utf-8".to_string()),
+            (
+                CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{file_name}\""),
+            ),
+        ],
+        csv,
+    ))
 }
 
 /// Adds a new landscape entry.
@@ -166,4 +204,64 @@ pub(crate) async fn prepare_list_page(
             navigation_links,
         },
     ))
+}
+
+fn build_landscape_csv(entries: &[LandscapeEntry]) -> Result<Vec<u8>, HandlerError> {
+    let mut writer = csv::WriterBuilder::new()
+        .terminator(csv::Terminator::Any(b'\n'))
+        .from_writer(vec![]);
+    writer
+        .write_record([
+            "Name",
+            "Slug",
+            "Kind",
+            "Published",
+            "Category",
+            "Summary",
+            "Description",
+            "Website URL",
+            "GitHub URL",
+            "Tags",
+            "Affiliations",
+            "Created At",
+            "Updated At",
+        ])
+        .map_err(anyhow::Error::from)?;
+    for entry in entries {
+        let row = vec![
+            entry.name.clone(),
+            entry.slug.clone(),
+            entry.kind.clone(),
+            if entry.published {
+                "Yes".to_string()
+            } else {
+                "No".to_string()
+            },
+            entry.category.clone().unwrap_or_default(),
+            entry.summary.clone(),
+            entry.description.clone().unwrap_or_default(),
+            entry.website_url.clone().unwrap_or_default(),
+            entry.github_url.clone().unwrap_or_default(),
+            entry.tags.join(", "),
+            entry
+                .affiliations
+                .iter()
+                .map(|affiliation| {
+                    format!(
+                        "{} ({})",
+                        affiliation.display_name(),
+                        affiliation.role_label()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; "),
+            entry.created_at.format("%Y-%m-%d").to_string(),
+            entry
+                .updated_at
+                .map(|updated_at| updated_at.format("%Y-%m-%d").to_string())
+                .unwrap_or_default(),
+        ];
+        writer.write_record(row).map_err(anyhow::Error::from)?;
+    }
+    writer.into_inner().map_err(|error| anyhow::Error::from(error).into())
 }

--- a/ocg-server/src/router/dashboard.rs
+++ b/ocg-server/src/router/dashboard.rs
@@ -121,6 +121,10 @@ pub(super) fn setup_alliance_dashboard_router(state: &State) -> Router<State> {
 
     // Alliance landscape management endpoints
     let landscape_management = Router::new()
+        .route(
+            "/landscape.csv",
+            get(dashboard::alliance::landscape::download_csv),
+        )
         .route("/landscape/add", post(dashboard::alliance::landscape::add))
         .route(
             "/landscape/{entry_id}/delete",

--- a/ocg-server/src/services/job_discovery.rs
+++ b/ocg-server/src/services/job_discovery.rs
@@ -8,7 +8,7 @@ use garde::Validate;
 use tokio::time::sleep;
 use tokio_postgres::types::Json;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -140,12 +140,21 @@ async fn ingest_users(
             for source_url in sources {
                 let mut seen = HashSet::new();
                 let search_domain = source_search_domain(&source_url)?;
-                let mut candidates: Vec<(String, JobInput)> = job_pages
-                    .discover_greenhouse_jobs(&source_url)
-                    .await?
-                    .into_iter()
-                    .map(|input| (input.apply_url.clone(), input))
-                    .collect();
+                let mut candidates: Vec<(String, JobInput)> =
+                    match job_pages.discover_greenhouse_jobs(&source_url).await {
+                        Ok(jobs) => jobs
+                            .into_iter()
+                            .map(|input| (input.apply_url.clone(), input))
+                            .collect(),
+                        Err(err) => {
+                            warn!(
+                                %err,
+                                source_url = %source_url,
+                                "skipped embedded Greenhouse discovery after source page fetch failed"
+                            );
+                            Vec::new()
+                        }
+                    };
                 for result in client
                     .search(&format!("jobs hiring careers site:{search_domain}"))
                     .await?

--- a/ocg-server/src/templates/filters.rs
+++ b/ocg-server/src/templates/filters.rs
@@ -15,6 +15,7 @@
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use num_format::{Locale, ToFormattedString};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use tracing::error;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -101,6 +102,18 @@ pub(crate) fn md_to_html(s: &str, _: &dyn askama::Values) -> askama::Result<Stri
 #[askama::filter_fn]
 pub(crate) fn num_fmt(n: &i64, _: &dyn askama::Values) -> askama::Result<String> {
     Ok(n.to_formatted_string(&Locale::en))
+}
+
+/// Builds a public landscape URL filtered by category.
+#[askama::filter_fn]
+pub(crate) fn landscape_category_url<S: AsRef<str>>(
+    category: S,
+    _: &dyn askama::Values,
+) -> askama::Result<String> {
+    Ok(format!(
+        "/landscape?category={}",
+        utf8_percent_encode(category.as_ref(), NON_ALPHANUMERIC)
+    ))
 }
 
 /// Returns up to two uppercase initials extracted from a name, used as a

--- a/ocg-server/templates/dashboard/alliance/landscape.html
+++ b/ocg-server/templates/dashboard/alliance/landscape.html
@@ -187,12 +187,19 @@
   <button class="btn-primary" type="submit">Search</button>
 </form>
 
-<div class="mb-5 flex items-center justify-between gap-3">
+<div class="mb-5 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
   <div class="text-sm text-stone-600">
     {{ pagination::range_display(offset = filters.offset.unwrap_or(0) , count = entries.len(), total = total, label = "entry") }}
   </div>
-  <a class="text-sm font-semibold text-primary-700 hover:text-primary-900"
-     href="/landscape">Public landscape</a>
+  <div class="flex flex-wrap gap-3">
+    {% if can_manage_landscape -%}
+      <a href="/dashboard/alliance/landscape.csv"
+         class="btn-secondary-anchor"
+         download>Download CSV</a>
+    {% endif -%}
+    <a class="text-sm font-semibold text-primary-700 hover:text-primary-900"
+       href="/landscape">Public landscape</a>
+  </div>
 </div>
 
 {% if entries.is_empty() -%}

--- a/ocg-server/templates/dashboard/jobs/discovery.html
+++ b/ocg-server/templates/dashboard/jobs/discovery.html
@@ -64,7 +64,10 @@
     </section>
     <section class="mt-8 border-t pt-6">
       <form action="/dashboard/jobs/discovery/run" method="post"><button class="button-secondary" {% if !discovery.enabled %}disabled{% endif %}>Run discovery now</button></form>
-      {% if let Some(run) = discovery.latest_run %}<p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} candidates discovered · {{ run.created_count }} job drafts created</p>{% endif %}
+      {% if let Some(run) = discovery.latest_run %}
+        <p class="mt-3">Latest run: {{ run.status }} · {{ run.discovered_count }} candidates discovered · {{ run.created_count }} job drafts created</p>
+        {% if let Some(error) = run.error_message %}<p class="mt-2 text-red-700">{{ error }}</p>{% endif %}
+      {% endif %}
     </section>
   {% endif %}
 </div>

--- a/ocg-server/templates/site/stats/page.html
+++ b/ocg-server/templates/site/stats/page.html
@@ -543,10 +543,11 @@
             {% if stats.landscape_overview.by_category.len() > 0 -%}
               <div class="mt-6 grid gap-x-12 sm:grid-cols-2 lg:grid-cols-3">
                 {% for (label, count) in stats.landscape_overview.by_category -%}
-                  <div class="flex items-baseline justify-between gap-4 border-0 border-b border-solid border-stone-200 py-3">
+                  <a href="{{ label|landscape_category_url }}"
+                     class="flex items-baseline justify-between gap-4 border-0 border-b border-solid border-stone-200 py-3 transition hover:border-stone-400 hover:text-stone-950">
                     <span class="min-w-0 truncate text-sm text-stone-700">{{ label }}</span>
                     <span class="font-amethysta text-base font-bold tabular-nums text-stone-950">{{ count|num_fmt }}</span>
-                  </div>
+                  </a>
                 {% endfor -%}
               </div>
             {% endif -%}

--- a/tests/unit/dashboard/discovery-templates.test.js
+++ b/tests/unit/dashboard/discovery-templates.test.js
@@ -23,6 +23,7 @@ describe("discovery dashboard templates", () => {
     );
     expect(template).to.include("candidates discovered");
     expect(template).to.include("job drafts created");
+    expect(template).to.include("run.error_message");
   });
 
   it("keeps group candidates visible when no event draft exists", async () => {


### PR DESCRIPTION
## Summary
- continue You.com job discovery when a source page blocks the optional Greenhouse check, and show failed-run errors in the dashboard
- add a permission-protected CSV export for all alliance landscape entries
- link stats category counts to their filtered public landscape results, including Uncategorized entries

## Test plan
- [x] `cargo check --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/ocg-server/Cargo.toml`
- [x] `cargo test --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/ocg-server/Cargo.toml services::job_discovery::tests`
- [x] `cargo fmt --check --manifest-path /Users/sako/ydc/github/hackathons/goup.vc/ocg-server/Cargo.toml`
- [x] `git diff --check`
- [ ] Database pgTAP test (blocked locally: `tern` is not installed)

Made with [Cursor](https://cursor.com)