### PR TITLE
fix: three front-end fixes for the event page and landscape tiles

### DIFF
--- a/ocg-server/static/css/styles.src.css
+++ b/ocg-server/static/css/styles.src.css
@@ -478,6 +478,10 @@ button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-
 /* Landscape logo marquee */
 .marquee-row {
   overflow: hidden;
+  /* The tiles lift on hover, so leave clipping room above and below and pull it
+     back with a matching negative margin to keep the row spacing unchanged. */
+  padding-block: 0.375rem;
+  margin-block: -0.375rem;
   -webkit-mask-image: linear-gradient(to right,
       transparent,
       black 8%,

--- a/ocg-server/templates/event/page.html
+++ b/ocg-server/templates/event/page.html
@@ -237,7 +237,7 @@
         <div class="py-4">
           <div class="grid md:grid-cols-2 gap-5 sm:gap-8 md:gap-5 lg:gap-8">
             {# Event date -#}
-            <div class="border border-stone-200 rounded-lg h-full bg-white">
+            <div class="border border-stone-200 rounded-lg h-full min-w-0 bg-white">
               <div class="p-4 h-full flex flex-col">
                 {% let registration_window_message = event.registration_window_message() -%}
                 <div class="flex items-center justify-between mb-4 min-h-[25px]">
@@ -327,7 +327,7 @@
           </div>
           {# End event date -#}
           {# Location -#}
-          <div class="border border-stone-200 rounded-lg p-4 bg-white h-full flex flex-col">
+          <div class="border border-stone-200 rounded-lg p-4 bg-white h-full min-w-0 flex flex-col">
             <div class="flex items-center justify-between mb-4 min-h-[25px]">
               <div class="text-base/3 uppercase font-semibold text-stone-400">Location</div>
             </div>

--- a/ocg-server/templates/macros/landscape.html
+++ b/ocg-server/templates/macros/landscape.html
@@ -21,16 +21,14 @@
        href="{{ url }}"
        target="_blank"
        rel="noopener noreferrer"
-       title="{{ entry.name }}"
        hx-boost="false">{% call logo_media(entry) %}{% endcall %}</a>
   {% else if let Some(url) = &entry.github_url -%}
     <a class="{{ tile_class }}"
        href="{{ url }}"
        target="_blank"
        rel="noopener noreferrer"
-       title="{{ entry.name }}"
        hx-boost="false">{% call logo_media(entry) %}{% endcall %}</a>
   {% else -%}
-    <div class="{{ tile_class }}" title="{{ entry.name }}">{% call logo_media(entry) %}{% endcall %}</div>
+    <div class="{{ tile_class }}">{% call logo_media(entry) %}{% endcall %}</div>
   {% endif -%}
 {%- endmacro %}


### PR DESCRIPTION
Three small front-end fixes, each in its own commit.

## 1. Event date and location cards overflow on mobile

On the public event page the **Event date** and **Location** cards spill outside the rounded page card on narrow viewports, and the document ends up horizontally scrollable (`scrollWidth` 430px on a 390px viewport).

The grid in `ocg-server/templates/event/page.html` uses auto-sized tracks, so the track minimum falls back to the item's min-content. The `whitespace-nowrap` date line and the registration-window message (`Registration is open until …`) push that min-content to ~411px, and the single-column mobile track grows with it. `min-w-0` on the `.truncate` span does not help, because it is the track minimum that needs capping, not the span.

Fix: `min-w-0` on both grid items, so the track minimum is 0 and the cards follow the container width. The registration message then truncates as intended.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/abdullaabdullazade/goup.vc/pr-assets/before.png" width="380"> | <img src="https://raw.githubusercontent.com/abdullaabdullazade/goup.vc/pr-assets/after.png" width="380"> |

Measured in headless Chrome at 390x800 (mobile emulation) on the live page:

- before: `document.documentElement.scrollWidth` = 430
- after: `document.documentElement.scrollWidth` = 390

Desktop (`md:` and up) is unchanged, since those tracks were already explicit.

## 2. Duplicate tooltip on the landscape logo tiles

The tiles carried `title="{{ entry.name }}"`, but the name is already rendered under the logo. Hovering a tile popped a native tooltip repeating the same text over the neighbouring tiles. Removed the attribute.

Hovering the `Paymes` tile, whose name is already printed under the logo:

<img src="https://raw.githubusercontent.com/abdullaabdullazade/goup.vc/pr-assets/tooltip-before.png" width="300">

After the change no tooltip is shown. Native tooltips are drawn by the browser outside the page, so this one had to be captured from the desktop rather than with a page screenshot.

## 3. Logo tiles clipped when they lift on hover

`.marquee-row` is `overflow: hidden` and is exactly as tall as its tiles, so the `hover:-translate-y-0.5` lift was cut off at the top edge. Added `padding-block: 0.375rem` with a matching negative `margin-block`, which gives the lift room to render without changing the spacing between rows.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/abdullaabdullazade/goup.vc/pr-assets/marquee-before.png" width="300"> | <img src="https://raw.githubusercontent.com/abdullaabdullazade/goup.vc/pr-assets/marquee-after.png" width="300"> |
